### PR TITLE
feat: replace sslip.io with custom x.myluma.cloud domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ apps:
 [✓] Zero-downtime deployment of web (3.5s)
 [✓] Deployment completed successfully in 9.8s
 
-https://a1b2c3d4-web-luma-192-168-1-100.sslip.io
+https://a1b2c3d4-web-luma-192-168-1-100.x.myluma.cloud
 ```
 
 ## Why Luma?

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1077,10 +1077,10 @@ async function configureProxyForApp(
   // Determine hosts to configure
   let hosts: string[];
   if (shouldUseSslip(appEntry.proxy.hosts)) {
-    // Generate sslip.io domain if no hosts configured
+    // Generate x.myluma.cloud domain if no hosts configured
     const sslipDomain = generateAppSslipDomain(projectName, appEntry.name, serverHostname);
     hosts = [sslipDomain];
-    logger.verboseLog(`Generated sslip.io domain: ${sslipDomain}`);
+    logger.verboseLog(`Generated x.myluma.cloud domain: ${sslipDomain}`);
   } else {
     hosts = appEntry.proxy.hosts!;
   }
@@ -1583,7 +1583,7 @@ export async function deployCommand(rawEntryNamesAndFlags: string[]) {
       for (const entry of targetEntries) {
         const appEntry = entry as AppEntry;
         if (appEntry.proxy) {
-          // Use configured hosts or generate sslip.io domain
+          // Use configured hosts or generate x.myluma.cloud domain
           let hosts: string[];
           if (shouldUseSslip(appEntry.proxy.hosts)) {
             const sslipDomain = generateAppSslipDomain(projectName, appEntry.name, appEntry.server);

--- a/src/utils/sslip.ts
+++ b/src/utils/sslip.ts
@@ -17,7 +17,7 @@ function sanitizeHostForDns(host: string): string {
 }
 
 /**
- * Generates a deterministic hash for sslip.io domain
+ * Generates a deterministic hash for x.myluma.cloud domain
  */
 function generateDeterministicHash(projectName: string, appName: string, serverHost: string): string {
   const input = `${projectName}:${appName}:${serverHost}`;
@@ -25,7 +25,7 @@ function generateDeterministicHash(projectName: string, appName: string, serverH
 }
 
 /**
- * Generates a deterministic sslip.io domain for an app
+ * Generates a deterministic x.myluma.cloud domain for an app
  */
 export function generateAppSslipDomain(
   projectName: string,
@@ -35,13 +35,13 @@ export function generateAppSslipDomain(
   const hash = generateDeterministicHash(projectName, appName, serverHost);
   const sanitizedHost = sanitizeHostForDns(serverHost);
   
-  return `${hash}-${appName}-luma-${sanitizedHost}.sslip.io`;
+  return `${hash}-${appName}-luma-${sanitizedHost}.x.myluma.cloud`;
 }
 
 /**
- * Checks if sslip.io should be used for domain generation
+ * Checks if x.myluma.cloud should be used for domain generation
  */
 export function shouldUseSslip(hosts?: string[]): boolean {
-  // Use sslip.io if no custom hosts are specified
+  // Use x.myluma.cloud if no custom hosts are specified
   return !hosts || hosts.length === 0;
 }


### PR DESCRIPTION
## Summary

- Replace all sslip.io references with x.myluma.cloud custom domain
- Maintain deterministic hash-based subdomain generation  
- Update documentation and examples to reflect new domain
- All tests pass and functionality verified with basic example

## Changes Made

- **src/utils/sslip.ts**: Updated domain generation logic and comments
- **src/commands/deploy.ts**: Updated deployment logging messages  
- **README.md**: Updated example output domain
- Preserved existing x.myluma.cloud references in test files and examples

## Test Results

✅ Domain generation tested and working:
- Basic example generates: `2c309682-web-luma-157-180-47-213.x.myluma.cloud`
- NextJS example uses explicit hosts correctly
- All unit tests pass (23 pass, 5 skip, 0 fail)
- Build completes successfully

## Test plan

- [x] Verify domain generation works with basic example
- [x] Confirm explicit hosts still work (nextjs example)  
- [x] Run all tests to ensure no regressions
- [x] Test actual deployment with local development version
- [x] Verify build process completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)