### PR TITLE
Update documentation to use lowercase 'iop' consistently

### DIFF
--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -1,40 +1,40 @@
 ---
 title: Commands
-description: Complete reference for all Lightform CLI commands
+description: Complete reference for all iop CLI commands
 ---
 
 # Commands
 
-Complete reference for all available Lightform CLI commands.
+Complete reference for all available iop CLI commands.
 
-## `lightform init`
+## `iop init`
 
-Initialize a new Lightform project with configuration files.
+Initialize a new iop project with configuration files.
 
 ### Usage
 
 ```bash
-lightform init
+iop init
 ```
 
 ### What it does
 
-- Creates `lightform.yml` with basic configuration template
-- Creates `.lightform/secrets` file for sensitive environment variables
-- Prompts you to add `.lightform/secrets` to `.gitignore`
+- Creates `iop.yml` with basic configuration template
+- Creates `.iop/secrets` file for sensitive environment variables
+- Prompts you to add `.iop/secrets` to `.gitignore`
 
 ### Example Output
 
 ```bash
-❯ lightform init
-✓ Created lightform.yml
-✓ Created .lightform/secrets
-! Add .lightform/secrets to your .gitignore file
+❯ iop init
+✓ Created iop.yml
+✓ Created .iop/secrets
+! Add .iop/secrets to your .gitignore file
 ```
 
 ### Generated Files
 
-**`lightform.yml`**:
+**`iop.yml`**:
 
 ```yaml
 name: my-project
@@ -56,7 +56,7 @@ apps:
       app_port: 3000
 ```
 
-**`.lightform/secrets`**:
+**`.iop/secrets`**:
 
 ```bash
 # Add your secrets here
@@ -66,24 +66,24 @@ apps:
 
 ---
 
-## `lightform setup`
+## `iop setup`
 
 Prepare servers for deployment by installing Docker and setting up infrastructure.
 
 ### Usage
 
 ```bash
-lightform setup [service...]               # Set up servers for specific services
-lightform setup                           # Set up all servers
-lightform setup --verbose                 # Show detailed output
+iop setup [service...]               # Set up servers for specific services
+iop setup                           # Set up all servers
+iop setup --verbose                 # Show detailed output
 ```
 
 ### Examples
 
 ```bash
-lightform setup                           # Set up all servers
-lightform setup web api                   # Set up only servers for web and api
-lightform setup --verbose                 # Detailed logging
+iop setup                           # Set up all servers
+iop setup web api                   # Set up only servers for web and api
+iop setup --verbose                 # Detailed logging
 ```
 
 ### What it does
@@ -98,20 +98,20 @@ lightform setup --verbose                 # Detailed logging
 ### Example Output
 
 ```bash
-❯ lightform setup
+❯ iop setup
 Setting up servers for deployment...
 
 [✓] server1.com
     ├─ [✓] SSH connection verified
     ├─ [✓] Docker installed and running
-    ├─ [✓] Lightform network created
+    ├─ [✓] iop network created
     ├─ [✓] Reverse proxy configured
     └─ [✓] SSL automation enabled
 
 [✓] server2.com
     ├─ [✓] SSH connection verified
     ├─ [✓] Docker installed and running
-    ├─ [✓] Lightform network created
+    ├─ [✓] iop network created
     ├─ [✓] Reverse proxy configured
     └─ [✓] SSL automation enabled
 
@@ -120,36 +120,36 @@ Setting up servers for deployment...
 
 ---
 
-## `lightform deploy`
+## `iop deploy`
 
 Deploy applications or services with zero downtime.
 
 ### Usage
 
 ```bash
-lightform deploy [app...]                 # Deploy specific apps
-lightform deploy                          # Deploy all apps
-lightform deploy --services               # Deploy services instead of apps
-lightform deploy --force                  # Skip git status checks
-lightform deploy --verbose                # Show detailed output
-lightform deploy -c config.yml            # Use specific config file
+iop deploy [app...]                 # Deploy specific apps
+iop deploy                          # Deploy all apps
+iop deploy --services               # Deploy services instead of apps
+iop deploy --force                  # Skip git status checks
+iop deploy --verbose                # Show detailed output
+iop deploy -c config.yml            # Use specific config file
 ```
 
 ### Examples
 
 ```bash
-lightform deploy                          # Deploy all apps
-lightform deploy web                      # Deploy only the web app
-lightform deploy web api                  # Deploy web and api apps
-lightform deploy --services               # Deploy all services
-lightform deploy backend --force          # Force deploy (skip git checks)
-lightform deploy --verbose                # Detailed logging
-lightform deploy -c lightform.staging.yml      # Use staging configuration
+iop deploy                          # Deploy all apps
+iop deploy web                      # Deploy only the web app
+iop deploy web api                  # Deploy web and api apps
+iop deploy --services               # Deploy all services
+iop deploy backend --force          # Force deploy (skip git checks)
+iop deploy --verbose                # Detailed logging
+iop deploy -c iop.staging.yml      # Use staging configuration
 ```
 
 ### Deployment Process
 
-1. **Configuration validation** - Verify lightform.yml syntax
+1. **Configuration validation** - Verify iop.yml syntax
 2. **Git status check** - Ensure working directory is clean (unless `--force`)
 3. **Infrastructure verification** - Check servers are ready
 4. **Image building** - Build Docker images locally
@@ -162,7 +162,7 @@ lightform deploy -c lightform.staging.yml      # Use staging configuration
 ### Example Output
 
 ```bash
-❯ lightform deploy
+❯ iop deploy
 Using Git SHA for release ID: a1b2c3d
 Starting deployment with release a1b2c3d
 
@@ -198,31 +198,31 @@ Your apps are live at:
 
 ---
 
-## `lightform status`
+## `iop status`
 
 Check the status of your deployments.
 
 ### Usage
 
 ```bash
-lightform status [app...]                 # Status of specific apps
-lightform status                          # Status of all apps
-lightform status --verbose                # Show detailed status
+iop status [app...]                 # Status of specific apps
+iop status                          # Status of all apps
+iop status --verbose                # Show detailed status
 ```
 
 ### Examples
 
 ```bash
-lightform status                          # All apps status
-lightform status web                      # Status of web app only
-lightform status web api                  # Status of web and api apps
-lightform status --verbose                # Detailed status information
+iop status                          # All apps status
+iop status web                      # Status of web app only
+iop status web api                  # Status of web and api apps
+iop status --verbose                # Detailed status information
 ```
 
 ### Example Output
 
 ```bash
-❯ lightform status
+❯ iop status
 📱 App: web
    Status: ✅ RUNNING (green active)
    Replicas: 2/2 running
@@ -285,19 +285,19 @@ Show detailed output including:
 - Error diagnostics
 
 ```bash
-lightform deploy --verbose
-lightform setup --verbose
-lightform status --verbose
+iop deploy --verbose
+iop setup --verbose
+iop status --verbose
 ```
 
 ### `--config` / `-c`
 
-Use a specific configuration file instead of `lightform.yml`:
+Use a specific configuration file instead of `iop.yml`:
 
 ```bash
-lightform deploy -c lightform.staging.yml
-lightform deploy -c lightform.production.yml
-lightform setup -c environments/prod.yml
+iop deploy -c iop.staging.yml
+iop deploy -c iop.production.yml
+iop setup -c environments/prod.yml
 ```
 
 This enables multi-environment deployments with different configurations.
@@ -311,56 +311,56 @@ Common command sequences for different workflows:
 ### First Deployment
 
 ```bash
-lightform init                            # Initialize project
-# Edit lightform.yml and .lightform/secrets
-lightform setup                           # Prepare servers
-lightform deploy                          # Deploy apps
-lightform status                          # Verify deployment
+iop init                            # Initialize project
+# Edit iop.yml and .iop/secrets
+iop setup                           # Prepare servers
+iop deploy                          # Deploy apps
+iop status                          # Verify deployment
 ```
 
 ### Regular Deployments
 
 ```bash
-lightform deploy                          # Deploy latest changes
-lightform status                          # Check status
+iop deploy                          # Deploy latest changes
+iop status                          # Check status
 ```
 
 ### Multi-Environment Workflow
 
 ```bash
 # Deploy to staging
-lightform deploy -c lightform.staging.yml
+iop deploy -c iop.staging.yml
 
 # Deploy to production
-lightform deploy -c lightform.production.yml
+iop deploy -c iop.production.yml
 
 # Check production status
-lightform status -c lightform.production.yml
+iop status -c iop.production.yml
 ```
 
 ### Service Management
 
 ```bash
-lightform deploy --services               # Deploy/update services
-lightform status --verbose                # Check all services
+iop deploy --services               # Deploy/update services
+iop status --verbose                # Check all services
 ```
 
 ---
 
 ## Exit Codes
 
-Lightform commands return standard exit codes:
+iop commands return standard exit codes:
 
 - **0** - Success
 - **1** - General error (configuration, network, etc.)
 - **2** - Command line usage error
 - **130** - Interrupted by user (Ctrl+C)
 
-This makes Lightform suitable for use in CI/CD pipelines:
+This makes iop suitable for use in CI/CD pipelines:
 
 ```bash
 #!/bin/bash
-lightform deploy -c lightform.production.yml
+iop deploy -c iop.production.yml
 if [ $? -eq 0 ]; then
     echo "✅ Deployment successful"
 else

--- a/docs/content/docs/concepts.mdx
+++ b/docs/content/docs/concepts.mdx
@@ -1,15 +1,15 @@
 ---
 title: Core Concepts
-description: Understanding the fundamental concepts of Lightform deployments
+description: Understanding the fundamental concepts of iop deployments
 ---
 
 # Core Concepts
 
-Understanding these core concepts will help you get the most out of Lightform.
+Understanding these core concepts will help you get the most out of iop.
 
 ## Apps vs Services
 
-Lightform distinguishes between two types of deployments:
+iop distinguishes between two types of deployments:
 
 ### Apps
 
@@ -57,12 +57,12 @@ services:
 
 ## Zero-Downtime Deployments
 
-Lightform automatically provides zero-downtime deployments for apps using a blue-green deployment strategy.
+iop automatically provides zero-downtime deployments for apps using a blue-green deployment strategy.
 
 ### How It Works
 
 1. **Current State**: Your app is running (let's say in "blue" state)
-2. **New Deployment**: Lightform deploys the new version alongside the current one ("green" state)
+2. **New Deployment**: iop deploys the new version alongside the current one ("green" state)
 3. **Health Checks**: The new version is health checked to ensure it's working properly
 4. **Traffic Switch**: Traffic is atomically switched from blue to green (sub-millisecond)
 5. **Cleanup**: The old version (blue) is stopped and removed
@@ -77,7 +77,7 @@ Lightform automatically provides zero-downtime deployments for apps using a blue
 ### Example Flow
 
 ```bash
-❯ lightform deploy
+❯ iop deploy
 [✓] Building new version (green)
 [✓] Health checking green version
 [✓] Switching traffic: blue → green
@@ -86,7 +86,7 @@ Lightform automatically provides zero-downtime deployments for apps using a blue
 
 ## Registry-Free Operation
 
-One of Lightform's key features is that it doesn't require a Docker registry for your apps.
+One of iop's key features is that it doesn't require a Docker registry for your apps.
 
 ### Traditional Approach (with Registry)
 
@@ -101,7 +101,7 @@ Problems:
 - Security concerns with registry access
 - Additional infrastructure cost
 
-### Lightform's Approach (Registry-Free)
+### iop's Approach (Registry-Free)
 
 ```
 Developer → Build → Transfer directly to Server → Deploy
@@ -123,7 +123,7 @@ Benefits:
 4. **Load remotely** - Servers load images using `docker load`
 
 ```bash
-# What Lightform does internally:
+# What iop does internally:
 docker build -t my-app:v1.0.0 .
 docker save my-app:v1.0.0 | ssh user@server 'docker load'
 ```
@@ -143,7 +143,7 @@ services:
 
 ## Health Checks
 
-Lightform provides automatic health checking for reliable deployments.
+iop provides automatic health checking for reliable deployments.
 
 ### App Health Checks
 
@@ -201,11 +201,11 @@ services:
 
 ## Automatic SSL and Proxy
 
-Lightform includes a built-in reverse proxy with automatic SSL certificate management.
+iop includes a built-in reverse proxy with automatic SSL certificate management.
 
 ### How It Works
 
-1. **Traefik Proxy** - Lightform deploys Traefik as the reverse proxy
+1. **Traefik Proxy** - iop deploys Traefik as the reverse proxy
 2. **Automatic Discovery** - Apps are automatically discovered and routed
 3. **Let's Encrypt** - SSL certificates are obtained automatically
 4. **HTTP → HTTPS** - All HTTP traffic is redirected to HTTPS
@@ -232,7 +232,7 @@ apps:
 
 ## Multi-Server Deployments
 
-Lightform supports deploying across multiple servers for high availability and load distribution.
+iop supports deploying across multiple servers for high availability and load distribution.
 
 ### Configuration
 
@@ -265,14 +265,14 @@ When deploying to multiple servers:
 
 ## Release Management
 
-Lightform uses Git SHAs for release tracking and identification.
+iop uses Git SHAs for release tracking and identification.
 
 ### Release IDs
 
 Every deployment gets a unique release ID based on your Git commit:
 
 ```bash
-❯ lightform deploy
+❯ iop deploy
 Using Git SHA for release ID: a1b2c3d
 ```
 
@@ -294,21 +294,21 @@ my-app/api:a1b2c3d
 
 ## Environment Management
 
-Lightform supports multiple environments through configuration files.
+iop supports multiple environments through configuration files.
 
 ### Environment-Specific Configs
 
 ```bash
-lightform.staging.yml     # Staging environment
-lightform.production.yml  # Production environment
-lightform.dev.yml         # Development environment
+iop.staging.yml     # Staging environment
+iop.production.yml  # Production environment
+iop.dev.yml         # Development environment
 ```
 
 ### Usage
 
 ```bash
-lightform deploy -c lightform.staging.yml     # Deploy to staging
-lightform deploy -c lightform.production.yml  # Deploy to production
+iop deploy -c iop.staging.yml     # Deploy to staging
+iop deploy -c iop.production.yml  # Deploy to production
 ```
 
 ### Benefits
@@ -319,7 +319,7 @@ lightform deploy -c lightform.production.yml  # Deploy to production
 
 ## Security Model
 
-Lightform's security is based on SSH and existing server security practices.
+iop's security is based on SSH and existing server security practices.
 
 ### SSH-Based Security
 
@@ -331,12 +331,12 @@ Lightform's security is based on SSH and existing server security practices.
 ### Secrets Management
 
 ```bash
-# .lightform/secrets - stored locally, never transmitted
+# .iop/secrets - stored locally, never transmitted
 DATABASE_URL=postgres://...
 API_KEY=secret-key
 ```
 
-- Secrets stored locally in `.lightform/secrets`
+- Secrets stored locally in `.iop/secrets`
 - Transmitted securely over SSH
 - Available as environment variables in containers
 - Never stored in logs or configuration files
@@ -350,12 +350,12 @@ API_KEY=secret-key
 
 ## Networking
 
-Lightform creates isolated Docker networks for secure communication between containers.
+iop creates isolated Docker networks for secure communication between containers.
 
 ### Network Architecture
 
 ```
-Internet → Traefik Proxy → Lightform Network → Your Apps
+Internet → Traefik Proxy → iop Network → Your Apps
                         → Services (Database, Cache)
 ```
 
@@ -366,15 +366,15 @@ Apps and services can communicate using their names:
 ```javascript
 // In your app, connect to database service
 const db = new Client({
-  host: "postgres", // Service name from lightform.yml
+  host: "postgres", // Service name from iop.yml
   port: 5432,
 });
 ```
 
 ### Port Management
 
-- **Automatic port assignment** - Lightform handles internal port mapping
+- **Automatic port assignment** - iop handles internal port mapping
 - **External ports** - Only Traefik proxy exposed (80, 443)
 - **Service ports** - Optional external access for databases, etc.
 
-Understanding these concepts will help you design and deploy robust applications with Lightform. Each concept builds on the others to provide a complete, reliable deployment solution.
+Understanding these concepts will help you design and deploy robust applications with iop. Each concept builds on the others to provide a complete, reliable deployment solution.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -1,11 +1,11 @@
 ---
 title: Configuration Reference
-description: Complete reference for lightform.yml configuration options
+description: Complete reference for iop.yml configuration options
 ---
 
 # Configuration Reference
 
-Complete reference for all configuration options available in `lightform.yml`.
+Complete reference for all configuration options available in `iop.yml`.
 
 ## Basic Structure
 
@@ -32,7 +32,7 @@ services: # Services (pre-built images)
 
 ## Apps Configuration
 
-Apps are your main applications that Lightform builds and deploys with zero-downtime.
+Apps are your main applications that iop builds and deploys with zero-downtime.
 
 ### Basic App Configuration
 
@@ -59,7 +59,7 @@ apps:
       plain: # Plain text variables
         - NODE_ENV=production
         - PORT=3000
-      secret: # Variables from .lightform/secrets
+      secret: # Variables from .iop/secrets
         - DATABASE_URL
         - API_KEY
 
@@ -119,7 +119,7 @@ services:
       plain:
         - POSTGRES_DB=myapp
       secret:
-        - POSTGRES_PASSWORD # From .lightform/secrets
+        - POSTGRES_PASSWORD # From .iop/secrets
 
     ports: # Port mapping
       - "5432:5432"
@@ -182,7 +182,7 @@ docker:
 
 ## Environment Variables
 
-Lightform supports both plain text and secret environment variables.
+iop supports both plain text and secret environment variables.
 
 ### Plain Variables
 
@@ -196,10 +196,10 @@ environment:
 
 ### Secret Variables
 
-Store sensitive values in `.lightform/secrets`:
+Store sensitive values in `.iop/secrets`:
 
 ```bash
-# .lightform/secrets
+# .iop/secrets
 DATABASE_URL=postgres://user:pass@localhost:5432/myapp
 JWT_SECRET=supersecretkey
 API_KEY=secret-api-key
@@ -323,7 +323,7 @@ apps:
         NODE_VERSION: 18
         BUILD_ENV: production
 
-      # Build secrets (from .lightform/secrets)
+      # Build secrets (from .iop/secrets)
       secrets:
         - PRIVATE_NPM_TOKEN
 ```
@@ -358,7 +358,7 @@ services:
 ### Environment-Specific Files
 
 ```yaml
-# lightform.staging.yml
+# iop.staging.yml
 name: myapp-staging
 apps:
   web:
@@ -368,7 +368,7 @@ apps:
       hosts:
         - staging.myapp.com
 
-# lightform.production.yml
+# iop.production.yml
 name: myapp-prod
 apps:
   web:
@@ -384,8 +384,8 @@ apps:
 Deploy with specific configuration:
 
 ```bash
-lightform deploy -c lightform.staging.yml
-lightform deploy -c lightform.production.yml
+iop deploy -c iop.staging.yml
+iop deploy -c iop.production.yml
 ```
 
 ## Complete Example

--- a/docs/content/docs/examples.mdx
+++ b/docs/content/docs/examples.mdx
@@ -1,11 +1,11 @@
 ---
 title: Examples
-description: Real-world examples and configurations for Lightform deployments
+description: Real-world examples and configurations for iop deployments
 ---
 
 # Examples
 
-Real-world examples showing how to deploy different types of applications with Lightform.
+Real-world examples showing how to deploy different types of applications with iop.
 
 ## Basic Web Application
 
@@ -74,7 +74,7 @@ EXPOSE 3000
 CMD ["./main"]
 ```
 
-**lightform.yml**:
+**iop.yml**:
 
 ```yaml
 name: my-go-app
@@ -105,10 +105,10 @@ apps:
 ### Deployment
 
 ```bash
-lightform init                  # Creates configuration files
-# Edit lightform.yml with your settings
-lightform setup                 # Prepare server
-lightform deploy                # Deploy app
+iop init                  # Creates configuration files
+# Edit iop.yml with your settings
+iop setup                 # Prepare server
+iop deploy                # Deploy app
 ```
 
 ---
@@ -187,7 +187,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 CMD ["node", "server.js"]
 ```
 
-**lightform.yml**:
+**iop.yml**:
 
 ```yaml
 name: my-nextjs-app
@@ -229,7 +229,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
 Deploy a complete application with frontend, API, and PostgreSQL database.
 
-**lightform.yml**:
+**iop.yml**:
 
 ```yaml
 name: ecommerce-app
@@ -320,7 +320,7 @@ services:
       retries: 3
 ```
 
-**.lightform/secrets**:
+**.iop/secrets**:
 
 ```bash
 DATABASE_URL=postgres://ecommerce:secure_password@db.mysite.com:5432/ecommerce
@@ -334,13 +334,13 @@ STRIPE_SECRET_KEY=sk_live_...
 
 ```bash
 # Deploy services first (database, cache)
-lightform deploy --services
+iop deploy --services
 
 # Then deploy applications
-lightform deploy
+iop deploy
 
 # Check everything is running
-lightform status
+iop status
 ```
 
 ---
@@ -349,7 +349,7 @@ lightform status
 
 Deploy multiple microservices with load balancing and service discovery.
 
-**lightform.yml**:
+**iop.yml**:
 
 ```yaml
 name: microservices-platform
@@ -458,7 +458,7 @@ services:
 
 Deploy the same application to different environments with environment-specific configurations.
 
-**lightform.staging.yml**:
+**iop.staging.yml**:
 
 ```yaml
 name: myapp-staging
@@ -514,7 +514,7 @@ services:
       - postgres_staging_data:/var/lib/postgresql/data
 ```
 
-**lightform.production.yml**:
+**iop.production.yml**:
 
 ```yaml
 name: myapp-production
@@ -582,16 +582,16 @@ services:
 
 ```bash
 # Deploy to staging
-lightform deploy -c lightform.staging.yml
+iop deploy -c iop.staging.yml
 
 # Test staging environment
 curl https://staging.myapp.com/health
 
 # Deploy to production
-lightform deploy -c lightform.production.yml
+iop deploy -c iop.production.yml
 
 # Monitor production
-lightform status -c lightform.production.yml
+iop status -c iop.production.yml
 ```
 
 ---
@@ -621,8 +621,8 @@ jobs:
         with:
           node-version: "18"
 
-      - name: Install Lightform
-        run: npm install -g lightform
+      - name: Install iop
+        run: npm install -g iop
 
       - name: Setup SSH
         run: |
@@ -633,12 +633,12 @@ jobs:
 
       - name: Create secrets file
         run: |
-          mkdir -p .lightform
-          echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .lightform/secrets
-          echo "API_KEY=${{ secrets.API_KEY }}" >> .lightform/secrets
+          mkdir -p .iop
+          echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .iop/secrets
+          echo "API_KEY=${{ secrets.API_KEY }}" >> .iop/secrets
 
       - name: Deploy to production
-        run: lightform deploy -c lightform.production.yml
+        run: iop deploy -c iop.production.yml
 ```
 
 ### GitLab CI
@@ -653,15 +653,15 @@ deploy:
   stage: deploy
   image: node:18
   before_script:
-    - npm install -g lightform
+    - npm install -g iop
     - mkdir -p ~/.ssh
     - echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
     - chmod 600 ~/.ssh/id_rsa
     - ssh-keyscan -H $SERVER_HOST >> ~/.ssh/known_hosts
-    - mkdir -p .lightform
-    - echo "DATABASE_URL=$DATABASE_URL" >> .lightform/secrets
+    - mkdir -p .iop
+    - echo "DATABASE_URL=$DATABASE_URL" >> .iop/secrets
   script:
-    - lightform deploy -c lightform.production.yml
+    - iop deploy -c iop.production.yml
   only:
     - main
 ```
@@ -682,10 +682,10 @@ ssh:
 2. **Separate environment secrets**:
 
 ```bash
-# .lightform/secrets.staging
+# .iop/secrets.staging
 DATABASE_URL=postgres://...staging...
 
-# .lightform/secrets.production
+# .iop/secrets.production
 DATABASE_URL=postgres://...production...
 ```
 
@@ -747,8 +747,8 @@ app.get("/health", async (req, res) => {
 
 ```bash
 # Check all environments
-lightform status -c lightform.staging.yml
-lightform status -c lightform.production.yml
+iop status -c iop.staging.yml
+iop status -c iop.production.yml
 ```
 
-These examples provide a solid foundation for deploying various types of applications with Lightform. Adapt them to your specific needs and infrastructure requirements.
+These examples provide a solid foundation for deploying various types of applications with iop. Adapt them to your specific needs and infrastructure requirements.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Welcome to Lightform
+title: Welcome to iop
 description: Zero-downtime deployments for your own servers
 ---
 
-# Lightform: Ship Docker Anywhere ⚡
+# iop: Ship Docker Anywhere ⚡
 
-Lightform is a TypeScript CLI tool that provides **zero-downtime deployments** and **automatic HTTPS** on your own servers. Deploy any Docker application with blue-green deployments, automatic SSL certificates, health checks, and multi-server support.
+iop is a TypeScript CLI tool that provides **zero-downtime deployments** and **automatic HTTPS** on your own servers. Deploy any Docker application with blue-green deployments, automatic SSL certificates, health checks, and multi-server support.
 
 ## Key Features
 
@@ -18,7 +18,7 @@ Lightform is a TypeScript CLI tool that provides **zero-downtime deployments** a
 
 ## Quick Start
 
-Get started with Lightform in just a few minutes:
+Get started with iop in just a few minutes:
 
 <Cards>
   <Card title='Installation' href='/installation' />
@@ -27,7 +27,7 @@ Get started with Lightform in just a few minutes:
   <Card title='Examples' href='/examples' />
 </Cards>
 
-## Why Choose Lightform?
+## Why Choose iop?
 
 ### vs Kamal (37signals)
 
@@ -51,14 +51,14 @@ Get started with Lightform in just a few minutes:
 ## Example Deployment
 
 ```bash
-❯ lightform deploy
+❯ iop deploy
 Using Git SHA for release ID: 9d8209a
 Starting deployment with release 9d8209a
 
 [✓] Configuration loaded (0ms)
 [✓] Git status verified (3ms)
 [✓] Infrastructure ready (1.2s)
-[✓] web → elitan/lightform-test-web:9d8209a (3.3s)
+[✓] web → elitan/iop-test-web:9d8209a (3.3s)
 [✓] Building Images (3.3s)
   └─ 157.180.25.101
      ├─ [✓] Loading image (2.5s)
@@ -72,4 +72,4 @@ Your app is live at:
 
 ## Get Started
 
-Ready to deploy? Follow our [Quick Start guide](/docs/quick-start) to deploy your first application with Lightform.
+Ready to deploy? Follow our [Quick Start guide](/docs/quick-start) to deploy your first application with iop.

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -1,62 +1,62 @@
 ---
 title: Installation
-description: Install Lightform CLI tool and set up your environment
+description: Install iop CLI tool and set up your environment
 ---
 
 # Installation
 
-Get Lightform up and running on your system.
+Get iop up and running on your system.
 
 ## Prerequisites
 
 ### Local Machine
 
-- **Bun** or **Node.js 18+** - For running the Lightform CLI
+- **Bun** or **Node.js 18+** - For running the iop CLI
 - **Git** - For version tracking and release IDs
 - **Docker** (optional) - Only needed if you want to test builds locally
 
 ### Target Servers
 
-- **Ubuntu/Debian Linux** - Lightform supports Ubuntu and Debian-based distributions
-- **SSH access with sudo privileges** - Lightform needs to install Docker and configure services
+- **Ubuntu/Debian Linux** - iop supports Ubuntu and Debian-based distributions
+- **SSH access with sudo privileges** - iop needs to install Docker and configure services
 - **Ports 80 and 443 open** - For HTTP/HTTPS traffic
 - **Git** (installed automatically during setup)
 
-## Install Lightform CLI
+## Install iop CLI
 
 ### Using npm (Recommended)
 
 ```bash
-npm install -g @elitan/lightform
+npm install -g @elitan/iop
 ```
 
 ### Using Bun
 
 ```bash
-bun install -g @elitan/lightform
+bun install -g @elitan/iop
 ```
 
 ### Using npx (No Installation)
 
-You can run Lightform without installing it globally:
+You can run iop without installing it globally:
 
 ```bash
-npx @elitan/lightform init
-npx @elitan/lightform deploy
+npx @elitan/iop init
+npx @elitan/iop deploy
 ```
 
 ## Verify Installation
 
-Check that Lightform is installed correctly:
+Check that iop is installed correctly:
 
 ```bash
-lightform --help
+iop --help
 ```
 
 You should see output similar to:
 
 ```
-Lightform CLI - Please provide a command.
+iop CLI - Please provide a command.
 Available commands: init, setup, deploy, status, redeploy, rollback
 
 Flags:
@@ -67,7 +67,7 @@ Flags:
 
 ## Server Setup
 
-Lightform will automatically install and configure Docker on your servers when you run `lightform setup`. However, you may want to prepare your servers in advance:
+iop will automatically install and configure Docker on your servers when you run `iop setup`. However, you may want to prepare your servers in advance:
 
 ### Create a Deployment User (Recommended)
 
@@ -82,10 +82,10 @@ sudo usermod -aG docker,sudo deploy
 ssh-copy-id deploy@your-server.com
 ```
 
-Then configure Lightform to use this user:
+Then configure iop to use this user:
 
 ```yaml
-# lightform.yml
+# iop.yml
 ssh:
   username: deploy
 ```
@@ -105,14 +105,14 @@ sudo usermod -aG docker $USER
 
 Ensure your servers have the required ports open:
 
-- **Port 22** - SSH access for Lightform
+- **Port 22** - SSH access for iop
 - **Port 80** - HTTP traffic (redirected to HTTPS)
 - **Port 443** - HTTPS traffic
-- **Custom ports** - Any ports specified in your `lightform.yml` configuration
+- **Custom ports** - Any ports specified in your `iop.yml` configuration
 
 ## Next Steps
 
-With Lightform installed, you're ready to:
+With iop installed, you're ready to:
 
 1. [Initialize your first project](/quick-start)
 2. [Configure your deployment](/configuration)
@@ -126,7 +126,7 @@ If you get `command not found` after installation:
 
 1. **Check your PATH** - Make sure npm/bun global bin directory is in your PATH
 2. **Restart your terminal** - Close and reopen your terminal
-3. **Use npx** - Run `npx @elitan/lightform` as an alternative
+3. **Use npx** - Run `npx @elitan/iop` as an alternative
 
 ### Permission Issues
 

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -1,29 +1,29 @@
 ---
 title: Quick Start
-description: Deploy your first application with Lightform in minutes
+description: Deploy your first application with iop in minutes
 ---
 
 # Quick Start
 
-Get your first application deployed with Lightform in just a few minutes. This guide will walk you through creating a simple web application and deploying it to your server.
+Get your first application deployed with iop in just a few minutes. This guide will walk you through creating a simple web application and deploying it to your server.
 
 ## Step 1: Initialize Your Project
 
-Navigate to your project directory and initialize Lightform:
+Navigate to your project directory and initialize iop:
 
 ```bash
 cd your-project
-lightform init
+iop init
 ```
 
 This creates two files:
 
-- **`lightform.yml`** - Your deployment configuration
-- **`.lightform/secrets`** - Secure credentials storage (add to `.gitignore`)
+- **`iop.yml`** - Your deployment configuration
+- **`.iop/secrets`** - Secure credentials storage (add to `.gitignore`)
 
 ## Step 2: Configure Your Deployment
 
-Edit the generated `lightform.yml` file:
+Edit the generated `iop.yml` file:
 
 ```yaml
 name: my-app
@@ -48,7 +48,7 @@ apps:
         - NODE_ENV=production
         - PORT=3000
       secret:
-        - DATABASE_URL # Optional: from .lightform/secrets
+        - DATABASE_URL # Optional: from .iop/secrets
 ```
 
 ### Key Configuration Options
@@ -61,15 +61,15 @@ apps:
 
 ## Step 3: Add Secrets (Optional)
 
-If your app needs environment variables with sensitive values, add them to `.lightform/secrets`:
+If your app needs environment variables with sensitive values, add them to `.iop/secrets`:
 
 ```bash
-# .lightform/secrets
+# .iop/secrets
 DATABASE_URL=postgres://user:pass@localhost:5432/myapp
 API_KEY=your-secret-api-key
 ```
 
-**Important**: Add `.lightform/secrets` to your `.gitignore` file!
+**Important**: Add `.iop/secrets` to your `.gitignore` file!
 
 ## Step 4: Prepare Your Dockerfile
 
@@ -115,7 +115,7 @@ app.get("/up", (req, res) => {
 Prepare your server for deployments:
 
 ```bash
-lightform setup
+iop setup
 ```
 
 This will:
@@ -130,13 +130,13 @@ This will:
 Deploy your application:
 
 ```bash
-lightform deploy
+iop deploy
 ```
 
 You'll see output like this:
 
 ```
-❯ lightform deploy
+❯ iop deploy
 Using Git SHA for release ID: a1b2c3d
 Starting deployment with release a1b2c3d
 
@@ -160,7 +160,7 @@ Your app is live at:
 Check the status of your deployment:
 
 ```bash
-lightform status
+iop status
 ```
 
 Output:
@@ -176,7 +176,7 @@ Visit your domain - it should be live with automatic HTTPS!
 
 ## What Happened?
 
-During deployment, Lightform:
+During deployment, iop:
 
 1. **Built your Docker image** locally using your Dockerfile
 2. **Transferred the image** securely to your server via SSH (no registry needed)
@@ -206,10 +206,10 @@ If your Docker build fails:
 
 ### Connection Issues
 
-If Lightform can't connect to your server:
+If iop can't connect to your server:
 
 1. **Verify SSH access** - Test with `ssh user@your-server.com`
-2. **Check SSH configuration** - Ensure the username in `lightform.yml` matches your server
+2. **Check SSH configuration** - Ensure the username in `iop.yml` matches your server
 3. **Firewall settings** - Make sure ports 22, 80, and 443 are open
 
 ### Health Check Failures

--- a/docs/src/app/layout.config.tsx
+++ b/docs/src/app/layout.config.tsx
@@ -19,11 +19,11 @@ export const baseOptions: BaseLayoutProps = {
         >
           <circle cx={12} cy={12} r={12} fill='currentColor' />
         </svg>
-        Lightform
+        iop
       </>
     ),
   },
   // see https://fumadocs.dev/docs/ui/navigation/links
   links: [],
-  githubUrl: "https://github.com/elitan/lightform",
+  githubUrl: "https://github.com/elitan/iop",
 };


### PR DESCRIPTION
## Summary
- Replace all 'Lightform' references with 'iop' in documentation
- Update CLI commands, configuration examples, and descriptions  
- Fix GitHub repository URL references
- Ensure consistent branding throughout documentation site

## Files Updated
- `docs/src/app/layout.config.tsx` - Updated title and GitHub URL
- `docs/content/docs/*.mdx` - Updated all command references and examples

## Test Plan
- [x] Documentation site builds successfully
- [x] All references consistently use lowercase 'iop'
- [x] No broken links or references

🤖 Generated with [Claude Code](https://claude.ai/code)