### PR TITLE
feat: add GitHub webhook deployments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ curl localhost:3000/api/deployments/{id}
 - `src/lib/docker.ts` - docker build/run/stop
 - `src/lib/deployer.ts` - deploy orchestration
 - `src/app/api/` - REST API routes
+- `src/proxy.ts` - auth middleware; add public endpoints here (e.g. `/api/github/webhook`)
 - `schema/` - SQL migrations
 - `test/fixtures/` - test apps with Dockerfiles
 

--- a/examples/node-hello/Dockerfile
+++ b/examples/node-hello/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY index.js ./
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/examples/node-hello/index.js
+++ b/examples/node-hello/index.js
@@ -1,0 +1,12 @@
+const http = require("node:http");
+
+const PORT = process.env.PORT || 8080;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("Hello from Frost!");
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/examples/node-hello/package.json
+++ b/examples/node-hello/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "node-hello",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/schema/012-auto-deploy.sql
+++ b/schema/012-auto-deploy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE services ADD COLUMN auto_deploy INTEGER DEFAULT 1;

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -427,6 +427,78 @@ api -X DELETE "$BASE_URL/api/projects/$PROJECT6_ID" > /dev/null
 echo "Deleted project"
 
 echo ""
+echo "=== Test 27: Webhook triggers deployment (full e2e) ==="
+TEST_WEBHOOK_SECRET="e2e-test-webhook-secret-$(date +%s)"
+echo "Setting up test GitHub App credentials..."
+remote "sqlite3 /opt/frost/data/frost.db \"
+INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_id', 'test-app-id');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_slug', 'test-app');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_name', 'Test App');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_private_key', 'test-private-key');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_webhook_secret', '$TEST_WEBHOOK_SECRET');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_client_id', 'test-client-id');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_client_secret', 'test-client-secret');
+\""
+echo "Inserted test GitHub App credentials"
+
+PROJECT7=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-webhook-deploy"}')
+PROJECT7_ID=$(echo "$PROJECT7" | jq -r '.id')
+echo "Created project: $PROJECT7_ID"
+
+SERVICE7=$(api -X POST "$BASE_URL/api/projects/$PROJECT7_ID/services" \
+  -d '{"name":"webhook-deploy-test","repoUrl":"https://github.com/elitan/frost.git","dockerfilePath":"examples/node-hello/Dockerfile"}')
+SERVICE7_ID=$(echo "$SERVICE7" | jq -r '.id')
+echo "Created service: $SERVICE7_ID"
+
+COMMIT_SHA="e2etest$(date +%s)"
+WEBHOOK_PAYLOAD=$(cat <<PAYLOAD
+{"ref":"refs/heads/main","after":"$COMMIT_SHA","repository":{"default_branch":"main","clone_url":"https://github.com/elitan/frost.git","html_url":"https://github.com/elitan/frost"},"head_commit":{"message":"e2e test commit"}}
+PAYLOAD
+)
+WEBHOOK_SIGNATURE="sha256=$(echo -n "$WEBHOOK_PAYLOAD" | openssl dgst -sha256 -hmac "$TEST_WEBHOOK_SECRET" | awk '{print $2}')"
+
+echo "Sending webhook..."
+WEBHOOK_RESULT=$(curl -sS -X POST "$BASE_URL/api/github/webhook" \
+  -H "Content-Type: application/json" \
+  -H "X-Hub-Signature-256: $WEBHOOK_SIGNATURE" \
+  -H "X-GitHub-Event: push" \
+  -d "$WEBHOOK_PAYLOAD")
+echo "Webhook response: $WEBHOOK_RESULT"
+
+TRIGGERED=$(echo "$WEBHOOK_RESULT" | jq -r '.deployments[0] // empty')
+if [ -z "$TRIGGERED" ]; then
+  echo "FAIL: Webhook did not trigger deployment"
+  echo "Response: $WEBHOOK_RESULT"
+  exit 1
+fi
+echo "Webhook triggered deployment: $TRIGGERED"
+
+echo ""
+echo "=== Test 28: Wait for webhook-triggered deployment ==="
+wait_for_deployment "$TRIGGERED" 60
+
+echo ""
+echo "=== Test 29: Verify webhook-deployed service responds ==="
+HOST_PORT7=$(api "$BASE_URL/api/deployments/$TRIGGERED" | jq -r '.hostPort')
+echo "Service running on port: $HOST_PORT7"
+
+RESPONSE7=$(curl -sf "http://$SERVER_IP:$HOST_PORT7" 2>&1 || true)
+if echo "$RESPONSE7" | grep -q "Hello from Frost"; then
+  echo "Webhook-deployed service responds correctly!"
+else
+  echo "FAIL: Service response unexpected: $RESPONSE7"
+  exit 1
+fi
+
+echo ""
+echo "=== Test 30: Cleanup webhook deploy test ==="
+api -X DELETE "$BASE_URL/api/projects/$PROJECT7_ID" > /dev/null
+remote "sqlite3 /opt/frost/data/frost.db \"
+DELETE FROM settings WHERE key LIKE 'github_app_%';
+\""
+echo "Deleted project and cleaned up test GitHub App credentials"
+
+echo ""
 echo "========================================="
 echo "All E2E tests passed!"
 echo "========================================="

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -448,7 +448,7 @@ PROJECT7_ID=$(echo "$PROJECT7" | jq -r '.id')
 echo "Created project: $PROJECT7_ID"
 
 SERVICE7=$(api -X POST "$BASE_URL/api/projects/$PROJECT7_ID/services" \
-  -d '{"name":"webhook-deploy-test","repoUrl":"https://github.com/elitan/frost.git","dockerfilePath":"examples/node-hello/Dockerfile"}')
+  -d '{"name":"webhook-deploy-test","repoUrl":"https://github.com/elitan/frost.git","dockerfilePath":"test/fixtures/simple-node/Dockerfile"}')
 SERVICE7_ID=$(echo "$SERVICE7" | jq -r '.id')
 echo "Created service: $SERVICE7_ID"
 
@@ -485,7 +485,7 @@ HOST_PORT7=$(api "$BASE_URL/api/deployments/$TRIGGERED" | jq -r '.hostPort')
 echo "Service running on port: $HOST_PORT7"
 
 RESPONSE7=$(curl -sf "http://$SERVER_IP:$HOST_PORT7" 2>&1 || true)
-if echo "$RESPONSE7" | grep -q "Hello from Frost"; then
+if echo "$RESPONSE7" | grep -q "Hello from simple-node"; then
   echo "Webhook-deployed service responds correctly!"
 else
   echo "FAIL: Service response unexpected: $RESPONSE7"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -379,6 +379,54 @@ api -X DELETE "$BASE_URL/api/projects/$PROJECT5_ID" > /dev/null
 echo "Deleted project"
 
 echo ""
+echo "########################################"
+echo "# Test Group 6: GitHub Webhook"
+echo "########################################"
+
+echo ""
+echo "=== Test 23: Webhook endpoint is public ==="
+WEBHOOK_RESPONSE=$(curl -sS -X POST "$BASE_URL/api/github/webhook" 2>&1)
+if echo "$WEBHOOK_RESPONSE" | grep -q '"error":"unauthorized"'; then
+  echo "FAIL: Webhook endpoint blocked by auth middleware"
+  exit 1
+fi
+echo "Webhook endpoint is public (returned: $(echo "$WEBHOOK_RESPONSE" | jq -r '.error // .message'))"
+
+echo ""
+echo "=== Test 24: Repo service has autoDeploy enabled by default ==="
+PROJECT6=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-webhook"}')
+PROJECT6_ID=$(echo "$PROJECT6" | jq -r '.id')
+echo "Created project: $PROJECT6_ID"
+
+SERVICE6=$(api -X POST "$BASE_URL/api/projects/$PROJECT6_ID/services" \
+  -d '{"name":"webhook-test","repoUrl":"https://github.com/test/repo.git"}')
+SERVICE6_ID=$(echo "$SERVICE6" | jq -r '.id')
+AUTO_DEPLOY=$(echo "$SERVICE6" | jq -r '.autoDeploy')
+
+if [ "$AUTO_DEPLOY" != "1" ]; then
+  echo "FAIL: autoDeploy should be 1 for repo services, got: $AUTO_DEPLOY"
+  exit 1
+fi
+echo "autoDeploy is enabled by default for repo services"
+
+echo ""
+echo "=== Test 25: autoDeploy toggle works ==="
+api -X PATCH "$BASE_URL/api/services/$SERVICE6_ID" -d '{"autoDeployEnabled":false}' > /dev/null
+SERVICE6_UPDATED=$(api "$BASE_URL/api/services/$SERVICE6_ID")
+AUTO_DEPLOY_OFF=$(echo "$SERVICE6_UPDATED" | jq -r '.autoDeploy')
+
+if [ "$AUTO_DEPLOY_OFF" != "0" ]; then
+  echo "FAIL: autoDeploy should be 0 after disabling, got: $AUTO_DEPLOY_OFF"
+  exit 1
+fi
+echo "autoDeploy toggle works"
+
+echo ""
+echo "=== Test 26: Cleanup webhook test project ==="
+api -X DELETE "$BASE_URL/api/projects/$PROJECT6_ID" > /dev/null
+echo "Deleted project"
+
+echo ""
 echo "========================================="
 echo "All E2E tests passed!"
 echo "========================================="

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -429,6 +429,8 @@ echo "Deleted project"
 echo ""
 echo "=== Test 27: Webhook triggers deployment (full e2e) ==="
 TEST_WEBHOOK_SECRET="e2e-test-webhook-secret-$(date +%s)"
+echo "Installing sqlite3 if needed..."
+remote "which sqlite3 || apt-get update && apt-get install -y sqlite3" > /dev/null 2>&1
 echo "Setting up test GitHub App credentials..."
 remote "sqlite3 /opt/frost/data/frost.db \"
 INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_id', 'test-app-id');

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { deployService } from "@/lib/deployer";
+import { getGitHubAppCredentials } from "@/lib/github";
+import {
+  findMatchingServices,
+  hasExistingDeployment,
+  shouldTriggerDeploy,
+  verifyWebhookSignature,
+} from "@/lib/webhook";
+
+interface PushPayload {
+  ref: string;
+  after: string;
+  repository: {
+    default_branch: string;
+    clone_url: string;
+    html_url: string;
+  };
+  head_commit: {
+    message: string;
+  } | null;
+}
+
+export async function POST(request: Request) {
+  const creds = await getGitHubAppCredentials();
+  if (!creds) {
+    return NextResponse.json(
+      { error: "GitHub App not configured" },
+      { status: 503 },
+    );
+  }
+
+  const signature = request.headers.get("X-Hub-Signature-256");
+  if (!signature) {
+    return NextResponse.json({ error: "Missing signature" }, { status: 401 });
+  }
+
+  const event = request.headers.get("X-GitHub-Event");
+  if (!event) {
+    return NextResponse.json({ error: "Missing event type" }, { status: 400 });
+  }
+
+  const rawBody = await request.text();
+
+  if (!verifyWebhookSignature(rawBody, signature, creds.webhookSecret)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  if (event === "ping") {
+    return NextResponse.json({ message: "pong" });
+  }
+
+  if (event !== "push") {
+    return NextResponse.json({ message: `Ignored event: ${event}` });
+  }
+
+  const payload: PushPayload = JSON.parse(rawBody);
+  const { ref, after: commitSha, repository, head_commit } = payload;
+
+  if (!shouldTriggerDeploy(ref, repository.default_branch)) {
+    return NextResponse.json({
+      message: `Ignored push to non-default branch: ${ref}`,
+    });
+  }
+
+  const matchedServices = await findMatchingServices(repository.clone_url);
+
+  if (matchedServices.length === 0) {
+    return NextResponse.json({
+      message: "No matching services found",
+    });
+  }
+
+  const commitMessage = head_commit?.message || null;
+  const deploymentIds: string[] = [];
+
+  for (const service of matchedServices) {
+    if (await hasExistingDeployment(service.id, commitSha)) {
+      console.log(
+        `Skipping deployment for service ${service.id}: existing deployment with same commit`,
+      );
+      continue;
+    }
+
+    try {
+      const deploymentId = await deployService(service.id, {
+        commitSha,
+        commitMessage: commitMessage || undefined,
+      });
+      deploymentIds.push(deploymentId);
+    } catch (err) {
+      console.error(`Failed to deploy service ${service.id}:`, err);
+    }
+  }
+
+  return NextResponse.json({
+    message: `Triggered ${deploymentIds.length} deployment(s)`,
+    deployments: deploymentIds,
+  });
+}

--- a/src/app/api/projects/[id]/services/route.ts
+++ b/src/app/api/projects/[id]/services/route.ts
@@ -120,6 +120,7 @@ export async function POST(
       imageUrl: deployType === "image" ? imageUrl : null,
       envVars: JSON.stringify(envVars),
       containerPort: containerPort ?? null,
+      autoDeploy: deployType === "repo" ? 1 : 0,
       createdAt: now,
     })
     .execute();

--- a/src/app/api/services/[id]/route.ts
+++ b/src/app/api/services/[id]/route.ts
@@ -91,6 +91,9 @@ export async function PATCH(
     }
     updates.healthCheckTimeout = body.healthCheckTimeout;
   }
+  if (body.autoDeployEnabled !== undefined) {
+    updates.autoDeploy = body.autoDeployEnabled ? 1 : 0;
+  }
 
   if (Object.keys(updates).length > 0) {
     await db

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -83,6 +83,7 @@ export interface Service {
   containerPort: Generated<number | null>;
   healthCheckPath: Generated<string | null>;
   healthCheckTimeout: Generated<number | null>;
+  autoDeploy: Generated<number | null>;
 }
 
 export interface Setting {

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeGitHubUrl, parseOwnerRepoFromUrl } from "./github";
+
+describe("normalizeGitHubUrl", () => {
+  test("strips .git suffix", () => {
+    expect(normalizeGitHubUrl("https://github.com/user/repo.git")).toBe(
+      "https://github.com/user/repo",
+    );
+  });
+
+  test("converts SSH to HTTPS format", () => {
+    expect(normalizeGitHubUrl("git@github.com:user/repo.git")).toBe(
+      "https://github.com/user/repo",
+    );
+  });
+
+  test("handles URL without .git", () => {
+    expect(normalizeGitHubUrl("https://github.com/user/repo")).toBe(
+      "https://github.com/user/repo",
+    );
+  });
+
+  test("handles SSH without .git", () => {
+    expect(normalizeGitHubUrl("git@github.com:user/repo")).toBe(
+      "https://github.com/user/repo",
+    );
+  });
+});
+
+describe("parseOwnerRepoFromUrl", () => {
+  test("parses HTTPS URL", () => {
+    const result = parseOwnerRepoFromUrl("https://github.com/elitan/frost");
+    expect(result).toEqual({ owner: "elitan", repo: "frost" });
+  });
+
+  test("parses HTTPS URL with .git", () => {
+    const result = parseOwnerRepoFromUrl("https://github.com/elitan/frost.git");
+    expect(result).toEqual({ owner: "elitan", repo: "frost" });
+  });
+
+  test("parses SSH URL", () => {
+    const result = parseOwnerRepoFromUrl("git@github.com:elitan/frost.git");
+    expect(result).toEqual({ owner: "elitan", repo: "frost" });
+  });
+
+  test("returns null for invalid URL", () => {
+    expect(parseOwnerRepoFromUrl("not-a-github-url")).toBeNull();
+    expect(parseOwnerRepoFromUrl("https://gitlab.com/user/repo")).toBeNull();
+  });
+
+  test("handles repos with hyphens and numbers", () => {
+    const result = parseOwnerRepoFromUrl(
+      "https://github.com/my-org/my-repo-123",
+    );
+    expect(result).toEqual({ owner: "my-org", repo: "my-repo-123" });
+  });
+});

--- a/src/lib/webhook.test.ts
+++ b/src/lib/webhook.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
+import { shouldTriggerDeploy, verifyWebhookSignature } from "./webhook";
+
+describe("verifyWebhookSignature", () => {
+  const secret = "test-secret";
+
+  test("accepts valid signature", () => {
+    const payload = '{"test": true}';
+    const signature = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
+
+    expect(verifyWebhookSignature(payload, signature, secret)).toBe(true);
+  });
+
+  test("rejects invalid signature", () => {
+    const payload = '{"test": true}';
+    const signature = "sha256=invalid";
+
+    expect(verifyWebhookSignature(payload, signature, secret)).toBe(false);
+  });
+
+  test("rejects tampered payload", () => {
+    const originalPayload = '{"test": true}';
+    const tamperedPayload = '{"test": false}';
+    const signature = `sha256=${createHmac("sha256", secret).update(originalPayload).digest("hex")}`;
+
+    expect(verifyWebhookSignature(tamperedPayload, signature, secret)).toBe(
+      false,
+    );
+  });
+
+  test("rejects wrong secret", () => {
+    const payload = '{"test": true}';
+    const signature = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
+
+    expect(verifyWebhookSignature(payload, signature, "wrong-secret")).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldTriggerDeploy", () => {
+  test("returns true for default branch push", () => {
+    expect(shouldTriggerDeploy("refs/heads/main", "main")).toBe(true);
+    expect(shouldTriggerDeploy("refs/heads/master", "master")).toBe(true);
+  });
+
+  test("returns false for non-default branch push", () => {
+    expect(shouldTriggerDeploy("refs/heads/feature", "main")).toBe(false);
+    expect(shouldTriggerDeploy("refs/heads/develop", "main")).toBe(false);
+  });
+
+  test("returns false for tag push", () => {
+    expect(shouldTriggerDeploy("refs/tags/v1.0.0", "main")).toBe(false);
+  });
+
+  test("handles branch names with slashes", () => {
+    expect(
+      shouldTriggerDeploy(
+        "refs/heads/feature/my-feature",
+        "feature/my-feature",
+      ),
+    ).toBe(true);
+    expect(
+      shouldTriggerDeploy("refs/heads/feature/other", "feature/my-feature"),
+    ).toBe(false);
+  });
+});

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -1,0 +1,60 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { db } from "./db";
+import { normalizeGitHubUrl } from "./github";
+
+export function verifyWebhookSignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): boolean {
+  const expected = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
+  if (signature.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+}
+
+export function shouldTriggerDeploy(
+  ref: string,
+  defaultBranch: string,
+): boolean {
+  const expectedRef = `refs/heads/${defaultBranch}`;
+  return ref === expectedRef;
+}
+
+export async function findMatchingServices(webhookRepoUrl: string) {
+  const normalizedWebhookUrl = normalizeGitHubUrl(webhookRepoUrl);
+
+  const services = await db
+    .selectFrom("services")
+    .selectAll()
+    .where("deployType", "=", "repo")
+    .where("autoDeploy", "=", 1)
+    .execute();
+
+  return services.filter((service) => {
+    if (!service.repoUrl) return false;
+    return normalizeGitHubUrl(service.repoUrl) === normalizedWebhookUrl;
+  });
+}
+
+export async function hasExistingDeployment(
+  serviceId: string,
+  commitSha: string,
+): Promise<boolean> {
+  const existing = await db
+    .selectFrom("deployments")
+    .select("id")
+    .where("serviceId", "=", serviceId)
+    .where("commitSha", "=", commitSha.substring(0, 7))
+    .where((eb) =>
+      eb.or([
+        eb("status", "=", "pending"),
+        eb("status", "=", "cloning"),
+        eb("status", "=", "building"),
+        eb("status", "=", "deploying"),
+        eb("status", "=", "running"),
+      ]),
+    )
+    .executeTakeFirst();
+
+  return !!existing;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,7 +44,8 @@ export function proxy(request: NextRequest) {
   if (
     pathname === "/login" ||
     pathname.startsWith("/api/auth/") ||
-    pathname === "/api/health"
+    pathname === "/api/health" ||
+    pathname === "/api/github/webhook"
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary

- Add `/api/github/webhook` endpoint for GitHub push events
- Verify webhook signatures with HMAC-SHA256
- Auto-deploy services on push to default branch
- Update GitHub commit status during deployment lifecycle
- Add `autoDeploy` toggle per service (default: enabled for repo services)

## Changes

- `schema/012-auto-deploy.sql` - Migration for auto_deploy column
- `src/app/api/github/webhook/route.ts` - Webhook endpoint
- `src/lib/webhook.ts` - Extracted helpers for testability
- `src/lib/deployer.ts` - GitHub commit status updates
- `src/lib/github.ts` - URL normalization and commit status API
- `src/proxy.ts` - Added webhook to public endpoints

## Test plan

- [x] Unit tests pass (`bun test`)
- [x] E2e tests pass for webhook feature (tests 23-26)
- [x] Webhook endpoint is public (no auth required)
- [x] autoDeploy defaults to enabled for repo services
- [x] autoDeploy toggle works

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)