### PR TITLE
feat: add one-click rollback

### DIFF
--- a/.github/workflows/e2e-vps.yml
+++ b/.github/workflows/e2e-vps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  SNAPSHOT_ID: 347726926
+  SNAPSHOT_ID: 348108379
   SSH_KEY_NAME: frost-e2e-ci
 
 jobs:

--- a/.github/workflows/e2e-vps.yml
+++ b/.github/workflows/e2e-vps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  SNAPSHOT_ID: 348108379
+  SNAPSHOT_ID: 348130680
   SSH_KEY_NAME: frost-e2e-ci
 
 jobs:

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-is": "^19.2.3",
         "recharts": "^3.6.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-is": "^19.2.3",
     "recharts": "^3.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"

--- a/schema/015-deployment-snapshot.sql
+++ b/schema/015-deployment-snapshot.sql
@@ -1,0 +1,8 @@
+ALTER TABLE deployments ADD COLUMN image_name TEXT;
+ALTER TABLE deployments ADD COLUMN env_vars_snapshot TEXT;
+ALTER TABLE deployments ADD COLUMN container_port INTEGER;
+ALTER TABLE deployments ADD COLUMN health_check_path TEXT;
+ALTER TABLE deployments ADD COLUMN health_check_timeout INTEGER;
+ALTER TABLE deployments ADD COLUMN volumes TEXT;
+ALTER TABLE deployments ADD COLUMN rollback_eligible INTEGER DEFAULT 0;
+ALTER TABLE deployments ADD COLUMN rollback_source_id TEXT;

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -147,7 +147,7 @@ echo "# Test Group 2: Multi-service networking"
 echo "########################################"
 
 echo ""
-echo "=== Test 7: Create project with two services ==="
+echo "=== Test 7: Create project with two services (auto-deploys) ==="
 PROJECT2=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-multiservice"}')
 PROJECT2_ID=$(echo "$PROJECT2" | jq -r '.id')
 echo "Created project: $PROJECT2_ID"
@@ -157,21 +157,22 @@ BACKEND=$(api -X POST "$BASE_URL/api/projects/$PROJECT2_ID/services" \
 BACKEND_ID=$(echo "$BACKEND" | jq -r '.id')
 echo "Created backend service: $BACKEND_ID"
 
+sleep 1
+
 FRONTEND=$(api -X POST "$BASE_URL/api/projects/$PROJECT2_ID/services" \
   -d '{"name":"frontend","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
 FRONTEND_ID=$(echo "$FRONTEND" | jq -r '.id')
 echo "Created frontend service: $FRONTEND_ID"
 
 echo ""
-echo "=== Test 8: Deploy both services (sequentially to avoid port collision) ==="
-DEPLOY_BACKEND=$(api -X POST "$BASE_URL/api/services/$BACKEND_ID/deploy")
-DEPLOY_BACKEND_ID=$(echo "$DEPLOY_BACKEND" | jq -r '.deployment_id')
-echo "Started backend deployment: $DEPLOY_BACKEND_ID"
+echo "=== Test 8: Wait for auto-deployments ==="
+sleep 2
+DEPLOY_BACKEND_ID=$(api "$BASE_URL/api/services/$BACKEND_ID/deployments" | jq -r '.[0].id')
+echo "Backend deployment: $DEPLOY_BACKEND_ID"
 wait_for_deployment "$DEPLOY_BACKEND_ID"
 
-DEPLOY_FRONTEND=$(api -X POST "$BASE_URL/api/services/$FRONTEND_ID/deploy")
-DEPLOY_FRONTEND_ID=$(echo "$DEPLOY_FRONTEND" | jq -r '.deployment_id')
-echo "Started frontend deployment: $DEPLOY_FRONTEND_ID"
+DEPLOY_FRONTEND_ID=$(api "$BASE_URL/api/services/$FRONTEND_ID/deployments" | jq -r '.[0].id')
+echo "Frontend deployment: $DEPLOY_FRONTEND_ID"
 wait_for_deployment "$DEPLOY_FRONTEND_ID"
 
 echo ""
@@ -209,9 +210,9 @@ SERVICE3_ID=$(echo "$SERVICE3" | jq -r '.id')
 echo "Created service with env vars: $SERVICE3_ID"
 
 echo ""
-echo "=== Test 12: Deploy and verify env vars ==="
-DEPLOY3=$(api -X POST "$BASE_URL/api/services/$SERVICE3_ID/deploy")
-DEPLOY3_ID=$(echo "$DEPLOY3" | jq -r '.deployment_id')
+echo "=== Test 12: Wait for auto-deployment and verify env vars ==="
+sleep 2
+DEPLOY3_ID=$(api "$BASE_URL/api/services/$SERVICE3_ID/deployments" | jq -r '.[0].id')
 wait_for_deployment "$DEPLOY3_ID"
 
 CONTAINER_NAME="frost-${PROJECT3_ID}-envcheck"
@@ -249,7 +250,7 @@ echo "# Test Group 4: Service update + redeploy"
 echo "########################################"
 
 echo ""
-echo "=== Test 14: Create service, deploy, update, redeploy ==="
+echo "=== Test 14: Create service and wait for auto-deployment ==="
 PROJECT4=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-update"}')
 PROJECT4_ID=$(echo "$PROJECT4" | jq -r '.id')
 echo "Created project: $PROJECT4_ID"
@@ -259,8 +260,8 @@ SERVICE4=$(api -X POST "$BASE_URL/api/projects/$PROJECT4_ID/services" \
 SERVICE4_ID=$(echo "$SERVICE4" | jq -r '.id')
 echo "Created service: $SERVICE4_ID"
 
-DEPLOY4=$(api -X POST "$BASE_URL/api/services/$SERVICE4_ID/deploy")
-DEPLOY4_ID=$(echo "$DEPLOY4" | jq -r '.deployment_id')
+sleep 2
+DEPLOY4_ID=$(api "$BASE_URL/api/services/$SERVICE4_ID/deployments" | jq -r '.[0].id')
 wait_for_deployment "$DEPLOY4_ID"
 
 HOST_PORT4=$(api "$BASE_URL/api/deployments/$DEPLOY4_ID" | jq -r '.hostPort')
@@ -334,15 +335,14 @@ SERVICE5=$(api -X POST "$BASE_URL/api/projects/$PROJECT5_ID/services" \
 SERVICE5_ID=$(echo "$SERVICE5" | jq -r '.id')
 echo "Created service: $SERVICE5_ID"
 
-echo "Calling deploy API for service $SERVICE5_ID..."
-DEPLOY5=$(api -X POST "$BASE_URL/api/services/$SERVICE5_ID/deploy")
-echo "Deploy response: $DEPLOY5"
-DEPLOY5_ID=$(echo "$DEPLOY5" | jq -r '.deployment_id')
+sleep 2
+DEPLOY5_ID=$(api "$BASE_URL/api/services/$SERVICE5_ID/deployments" | jq -r '.[0].id')
 if [ "$DEPLOY5_ID" = "null" ] || [ -z "$DEPLOY5_ID" ]; then
-  echo "Deploy failed - deployment_id is null or empty"
-  exit 1
+  echo "No auto-deployment found - triggering manual deploy"
+  DEPLOY5=$(api -X POST "$BASE_URL/api/services/$SERVICE5_ID/deploy")
+  DEPLOY5_ID=$(echo "$DEPLOY5" | jq -r '.deployment_id')
 fi
-echo "Started deployment: $DEPLOY5_ID"
+echo "Using deployment: $DEPLOY5_ID"
 wait_for_deployment "$DEPLOY5_ID"
 
 DOMAINS=$(api "$BASE_URL/api/services/$SERVICE5_ID/domains")
@@ -580,10 +580,10 @@ fi
 echo "SSL certificate generated for postgres service"
 
 echo ""
-echo "=== Test 34: Deploy database service ==="
-DEPLOY8=$(api -X POST "$BASE_URL/api/services/$SERVICE8_ID/deploy")
-DEPLOY8_ID=$(echo "$DEPLOY8" | jq -r '.deployment_id')
-echo "Started deployment: $DEPLOY8_ID"
+echo "=== Test 34: Wait for database auto-deployment ==="
+sleep 3
+DEPLOY8_ID=$(api "$BASE_URL/api/services/$SERVICE8_ID/deployments" | jq -r '.[0].id')
+echo "Using deployment: $DEPLOY8_ID"
 wait_for_deployment "$DEPLOY8_ID" 45
 
 echo ""
@@ -651,7 +651,7 @@ echo "# Test Group 8: Rollback"
 echo "########################################"
 
 echo ""
-echo "=== Test 39: Create service and deploy twice ==="
+echo "=== Test 39: Create service (auto-deploys) and deploy again ==="
 PROJECT9=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-rollback"}')
 PROJECT9_ID=$(echo "$PROJECT9" | jq -r '.id')
 echo "Created project: $PROJECT9_ID"
@@ -661,14 +661,14 @@ SERVICE9=$(api -X POST "$BASE_URL/api/projects/$PROJECT9_ID/services" \
 SERVICE9_ID=$(echo "$SERVICE9" | jq -r '.id')
 echo "Created service: $SERVICE9_ID"
 
-DEPLOY9A=$(api -X POST "$BASE_URL/api/services/$SERVICE9_ID/deploy")
-DEPLOY9A_ID=$(echo "$DEPLOY9A" | jq -r '.deployment_id')
-echo "Started first deployment: $DEPLOY9A_ID"
+sleep 2
+DEPLOY9A_ID=$(api "$BASE_URL/api/services/$SERVICE9_ID/deployments" | jq -r '.[0].id')
+echo "First deployment (auto): $DEPLOY9A_ID"
 wait_for_deployment "$DEPLOY9A_ID"
 
 DEPLOY9B=$(api -X POST "$BASE_URL/api/services/$SERVICE9_ID/deploy")
 DEPLOY9B_ID=$(echo "$DEPLOY9B" | jq -r '.deployment_id')
-echo "Started second deployment: $DEPLOY9B_ID"
+echo "Second deployment (manual): $DEPLOY9B_ID"
 wait_for_deployment "$DEPLOY9B_ID"
 
 echo ""
@@ -737,9 +737,9 @@ SERVICE9_DB=$(api -X POST "$BASE_URL/api/projects/$PROJECT9_ID/services" \
 SERVICE9_DB_ID=$(echo "$SERVICE9_DB" | jq -r '.id')
 echo "Created database service: $SERVICE9_DB_ID"
 
-DEPLOY9_DB=$(api -X POST "$BASE_URL/api/services/$SERVICE9_DB_ID/deploy")
-DEPLOY9_DB_ID=$(echo "$DEPLOY9_DB" | jq -r '.deployment_id')
-echo "Started database deployment: $DEPLOY9_DB_ID"
+sleep 3
+DEPLOY9_DB_ID=$(api "$BASE_URL/api/services/$SERVICE9_DB_ID/deployments" | jq -r '.[0].id')
+echo "Using database deployment: $DEPLOY9_DB_ID"
 wait_for_deployment "$DEPLOY9_DB_ID" 45
 
 ROLLBACK_DB_RESULT=$(curl -sS -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" \

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -641,6 +641,121 @@ api -X DELETE "$BASE_URL/api/projects/$PROJECT8_ID" > /dev/null
 echo "Deleted project"
 
 echo ""
+echo "########################################"
+echo "# Test Group 8: Rollback"
+echo "########################################"
+
+echo ""
+echo "=== Test 39: Create service and deploy twice ==="
+PROJECT9=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-rollback"}')
+PROJECT9_ID=$(echo "$PROJECT9" | jq -r '.id')
+echo "Created project: $PROJECT9_ID"
+
+SERVICE9=$(api -X POST "$BASE_URL/api/projects/$PROJECT9_ID/services" \
+  -d '{"name":"rollback-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
+SERVICE9_ID=$(echo "$SERVICE9" | jq -r '.id')
+echo "Created service: $SERVICE9_ID"
+
+DEPLOY9A=$(api -X POST "$BASE_URL/api/services/$SERVICE9_ID/deploy")
+DEPLOY9A_ID=$(echo "$DEPLOY9A" | jq -r '.deployment_id')
+echo "Started first deployment: $DEPLOY9A_ID"
+wait_for_deployment "$DEPLOY9A_ID"
+
+DEPLOY9B=$(api -X POST "$BASE_URL/api/services/$SERVICE9_ID/deploy")
+DEPLOY9B_ID=$(echo "$DEPLOY9B" | jq -r '.deployment_id')
+echo "Started second deployment: $DEPLOY9B_ID"
+wait_for_deployment "$DEPLOY9B_ID"
+
+echo ""
+echo "=== Test 40: Verify deployment has snapshot data ==="
+DEPLOY9B_DATA=$(api "$BASE_URL/api/deployments/$DEPLOY9B_ID")
+IMAGE_NAME=$(echo "$DEPLOY9B_DATA" | jq -r '.imageName')
+ROLLBACK_ELIGIBLE=$(echo "$DEPLOY9B_DATA" | jq -r '.rollbackEligible')
+
+if [ "$IMAGE_NAME" = "null" ] || [ -z "$IMAGE_NAME" ]; then
+  echo "FAIL: Deployment should have imageName snapshot"
+  exit 1
+fi
+echo "Deployment has imageName: $IMAGE_NAME"
+
+if [ "$ROLLBACK_ELIGIBLE" != "1" ]; then
+  echo "FAIL: Deployment should be rollback-eligible (got: $ROLLBACK_ELIGIBLE)"
+  exit 1
+fi
+echo "Deployment is rollback-eligible"
+
+echo ""
+echo "=== Test 41: Rollback to first deployment ==="
+DEPLOY9A_UPDATED=$(api "$BASE_URL/api/deployments/$DEPLOY9A_ID")
+DEPLOY9A_IMAGE=$(echo "$DEPLOY9A_UPDATED" | jq -r '.imageName')
+DEPLOY9A_ELIGIBLE=$(echo "$DEPLOY9A_UPDATED" | jq -r '.rollbackEligible')
+echo "First deployment image: $DEPLOY9A_IMAGE, eligible: $DEPLOY9A_ELIGIBLE"
+
+ROLLBACK_RESULT=$(api -X POST "$BASE_URL/api/deployments/$DEPLOY9A_ID/rollback")
+ROLLBACK_DEPLOY_ID=$(echo "$ROLLBACK_RESULT" | jq -r '.deployment_id')
+
+if [ "$ROLLBACK_DEPLOY_ID" = "null" ] || [ -z "$ROLLBACK_DEPLOY_ID" ]; then
+  echo "FAIL: Rollback did not return new deployment_id"
+  echo "Response: $ROLLBACK_RESULT"
+  exit 1
+fi
+echo "Rollback created new deployment: $ROLLBACK_DEPLOY_ID"
+
+echo ""
+echo "=== Test 42: Wait for rollback deployment ==="
+wait_for_deployment "$ROLLBACK_DEPLOY_ID"
+
+ROLLBACK_DEPLOY=$(api "$BASE_URL/api/deployments/$ROLLBACK_DEPLOY_ID")
+ROLLBACK_SOURCE=$(echo "$ROLLBACK_DEPLOY" | jq -r '.rollbackSourceId')
+if [ "$ROLLBACK_SOURCE" != "$DEPLOY9A_ID" ]; then
+  echo "FAIL: Rollback deployment should have rollbackSourceId=$DEPLOY9A_ID (got: $ROLLBACK_SOURCE)"
+  exit 1
+fi
+echo "Rollback deployment correctly references source deployment"
+
+echo ""
+echo "=== Test 43: Verify rollback service responds ==="
+HOST_PORT9=$(api "$BASE_URL/api/deployments/$ROLLBACK_DEPLOY_ID" | jq -r '.hostPort')
+echo "Service running on port: $HOST_PORT9"
+
+if curl -sf "http://$SERVER_IP:$HOST_PORT9" > /dev/null; then
+  echo "Rollback service is responding!"
+else
+  echo "FAIL: Rollback service failed to respond"
+  exit 1
+fi
+
+echo ""
+echo "=== Test 44: Verify rollback blocked for database services ==="
+SERVICE9_DB=$(api -X POST "$BASE_URL/api/projects/$PROJECT9_ID/services" \
+  -d '{"name":"db-rollback-test","deployType":"database","templateId":"postgres-17"}')
+SERVICE9_DB_ID=$(echo "$SERVICE9_DB" | jq -r '.id')
+echo "Created database service: $SERVICE9_DB_ID"
+
+DEPLOY9_DB=$(api -X POST "$BASE_URL/api/services/$SERVICE9_DB_ID/deploy")
+DEPLOY9_DB_ID=$(echo "$DEPLOY9_DB" | jq -r '.deployment_id')
+echo "Started database deployment: $DEPLOY9_DB_ID"
+wait_for_deployment "$DEPLOY9_DB_ID" 45
+
+ROLLBACK_DB_RESULT=$(curl -sS -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" \
+  -X POST "$BASE_URL/api/deployments/$DEPLOY9_DB_ID/rollback" -w "\n%{http_code}")
+ROLLBACK_DB_STATUS=$(echo "$ROLLBACK_DB_RESULT" | tail -1)
+ROLLBACK_DB_BODY=$(echo "$ROLLBACK_DB_RESULT" | head -n -1)
+
+if [ "$ROLLBACK_DB_STATUS" = "400" ]; then
+  echo "Rollback correctly blocked for database service (400)"
+else
+  echo "FAIL: Rollback should return 400 for database services (got: $ROLLBACK_DB_STATUS)"
+  echo "Body: $ROLLBACK_DB_BODY"
+  exit 1
+fi
+
+echo ""
+echo "=== Test 45: Cleanup rollback test project ==="
+api -X DELETE "$BASE_URL/api/projects/$PROJECT9_ID" > /dev/null
+echo "Deleted project"
+
+echo ""
 echo "========================================="
 echo "All E2E tests passed!"
 echo "========================================="

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -84,8 +84,8 @@ echo "Created service: $SERVICE_ID"
 
 echo ""
 echo "=== Test 3: Get auto-deployment ==="
-sleep 1
-DEPLOYMENT_ID=$(api "$BASE_URL/api/services/$SERVICE_ID" | jq -r '.deployments[0].id // empty')
+sleep 2
+DEPLOYMENT_ID=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments" | jq -r '.[0].id // empty')
 
 if [ -z "$DEPLOYMENT_ID" ]; then
   echo "No auto-deployment found, triggering manual deploy..."

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -69,7 +69,7 @@ fi
 echo "Created project: $PROJECT_ID"
 
 echo ""
-echo "=== Test 2: Create service ==="
+echo "=== Test 2: Create service (auto-deploys) ==="
 SERVICE=$(api -X POST "$BASE_URL/api/projects/$PROJECT_ID/services" \
   -d '{"name":"test-nginx","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
 SERVICE_ID=$(echo "$SERVICE" | jq -r '.id')
@@ -83,17 +83,22 @@ fi
 echo "Created service: $SERVICE_ID"
 
 echo ""
-echo "=== Test 3: Deploy service ==="
-DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
-DEPLOYMENT_ID=$(echo "$DEPLOY" | jq -r '.deployment_id')
+echo "=== Test 3: Get auto-deployment ==="
+sleep 1
+DEPLOYMENT_ID=$(api "$BASE_URL/api/services/$SERVICE_ID" | jq -r '.deployments[0].id // empty')
+
+if [ -z "$DEPLOYMENT_ID" ]; then
+  echo "No auto-deployment found, triggering manual deploy..."
+  DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+  DEPLOYMENT_ID=$(echo "$DEPLOY" | jq -r '.deployment_id')
+fi
 
 if [ "$DEPLOYMENT_ID" = "null" ] || [ -z "$DEPLOYMENT_ID" ]; then
-  echo "Failed to deploy:"
-  echo "$DEPLOY" | jq
+  echo "Failed to get deployment"
   exit 1
 fi
 
-echo "Started deployment: $DEPLOYMENT_ID"
+echo "Using deployment: $DEPLOYMENT_ID"
 
 echo ""
 echo "=== Test 4: Wait for deployment ==="

--- a/src/app/api/deployments/[id]/rollback/route.ts
+++ b/src/app/api/deployments/[id]/rollback/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { rollbackDeployment } from "@/lib/deployer";
+import { imageExists } from "@/lib/docker";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const deployment = await db
+    .selectFrom("deployments")
+    .selectAll()
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  if (!deployment) {
+    return NextResponse.json(
+      { error: "Deployment not found" },
+      { status: 404 },
+    );
+  }
+
+  if (!deployment.imageName) {
+    return NextResponse.json(
+      { error: "Deployment has no image snapshot" },
+      { status: 400 },
+    );
+  }
+
+  const service = await db
+    .selectFrom("services")
+    .select("volumes")
+    .where("id", "=", deployment.serviceId)
+    .executeTakeFirst();
+
+  if (service?.volumes && service.volumes !== "[]") {
+    return NextResponse.json(
+      { error: "Cannot rollback services with volumes" },
+      { status: 400 },
+    );
+  }
+
+  const exists = await imageExists(deployment.imageName);
+  if (!exists) {
+    return NextResponse.json(
+      { error: "Image no longer available" },
+      { status: 410 },
+    );
+  }
+
+  try {
+    const newDeploymentId = await rollbackDeployment(id);
+    return NextResponse.json(
+      { deployment_id: newDeploymentId },
+      { status: 202 },
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Rollback failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
@@ -1,3 +1,4 @@
+import { RotateCcw } from "lucide-react";
 import { StatusDot } from "@/components/status-dot";
 import { cn } from "@/lib/utils";
 
@@ -8,6 +9,10 @@ interface DeploymentRowProps {
   createdAt: number;
   selected: boolean;
   onClick: () => void;
+  canRollback?: boolean;
+  isRunning?: boolean;
+  onRollback?: () => void;
+  isRollingBack?: boolean;
 }
 
 export function DeploymentRow({
@@ -16,16 +21,25 @@ export function DeploymentRow({
   createdAt,
   selected,
   onClick,
+  canRollback,
+  isRunning,
+  onRollback,
+  isRollingBack,
 }: DeploymentRowProps) {
   const date = new Date(createdAt);
   const timeAgo = getTimeAgo(date);
+
+  function handleRollback(e: React.MouseEvent) {
+    e.stopPropagation();
+    onRollback?.();
+  }
 
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
-        "w-full px-4 py-3 text-left transition-colors hover:bg-neutral-800/50",
+        "group w-full px-4 py-3 text-left transition-colors hover:bg-neutral-800/50",
         selected && "bg-neutral-800",
       )}
     >
@@ -36,7 +50,22 @@ export function DeploymentRow({
             {commitSha}
           </span>
         </div>
-        <span className="text-xs text-neutral-500">{timeAgo}</span>
+        <div className="flex items-center gap-2">
+          {canRollback && !isRunning && (
+            <button
+              type="button"
+              onClick={handleRollback}
+              disabled={isRollingBack}
+              title="Rollback to this deployment"
+              className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-200 transition-all disabled:opacity-50"
+            >
+              <RotateCcw
+                className={cn("h-3.5 w-3.5", isRollingBack && "animate-spin")}
+              />
+            </button>
+          )}
+          <span className="text-xs text-neutral-500">{timeAgo}</span>
+        </div>
       </div>
     </button>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -49,6 +49,14 @@ export interface Deployment {
   finishedAt: number | null;
   buildLog: string | null;
   errorMessage: string | null;
+  imageName: string | null;
+  envVarsSnapshot: string | null;
+  containerPort: number | null;
+  healthCheckPath: string | null;
+  healthCheckTimeout: number | null;
+  volumes: string | null;
+  rollbackEligible: number | null;
+  rollbackSourceId: string | null;
 }
 
 export interface EnvVar {
@@ -280,6 +288,11 @@ export const api = {
     listByService: (serviceId: string): Promise<Deployment[]> =>
       fetch(`/api/services/${serviceId}/deployments`).then((r) =>
         handleResponse<Deployment[]>(r),
+      ),
+
+    rollback: (id: string): Promise<{ deployment_id: string }> =>
+      fetch(`/api/deployments/${id}/rollback`, { method: "POST" }).then((r) =>
+        handleResponse<{ deployment_id: string }>(r),
       ),
   },
 

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -39,6 +39,14 @@ export interface Deployment {
   errorMessage: string | null;
   createdAt: number;
   finishedAt: number | null;
+  imageName: string | null;
+  envVarsSnapshot: string | null;
+  containerPort: number | null;
+  healthCheckPath: string | null;
+  healthCheckTimeout: number | null;
+  volumes: string | null;
+  rollbackEligible: Generated<number | null>;
+  rollbackSourceId: string | null;
 }
 
 export interface Domain {

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -11,6 +11,7 @@ import {
   createNetwork,
   type FileMount,
   getAvailablePort,
+  imageExists,
   pullImage,
   runContainer,
   stopContainer,
@@ -321,6 +322,12 @@ async function runServiceDeployment(
       }
     }
 
+    await db
+      .updateTable("deployments")
+      .set({ imageName })
+      .where("id", "=", deploymentId)
+      .execute();
+
     await updateDeployment(deploymentId, { status: "deploying" });
     await appendLog(deploymentId, `\nStarting container...\n`);
     await updateCommitStatusIfGitHub(
@@ -384,6 +391,18 @@ async function runServiceDeployment(
       ];
       await appendLog(deploymentId, "SSL enabled for postgres\n");
     }
+
+    await db
+      .updateTable("deployments")
+      .set({
+        envVarsSnapshot: JSON.stringify(envVarsList),
+        containerPort: service.containerPort,
+        healthCheckPath: service.healthCheckPath,
+        healthCheckTimeout: service.healthCheckTimeout,
+        volumes: service.volumes,
+      })
+      .where("id", "=", deploymentId)
+      .execute();
 
     const hostPort = await getAvailablePort();
     const runResult = await runContainer({
@@ -458,6 +477,8 @@ async function runServiceDeployment(
       );
     }
 
+    await updateRollbackEligible(service.id);
+
     const previousDeployments = await db
       .selectFrom("deployments")
       .select(["id", "containerId"])
@@ -491,5 +512,268 @@ async function runServiceDeployment(
       "Deployment failed",
       deploymentId,
     );
+  }
+}
+
+const ROLLBACK_ELIGIBLE_COUNT = 5;
+
+async function updateRollbackEligible(serviceId: string): Promise<void> {
+  const service = await db
+    .selectFrom("services")
+    .select("volumes")
+    .where("id", "=", serviceId)
+    .executeTakeFirst();
+
+  const hasVolumes = service?.volumes && service.volumes !== "[]";
+  if (hasVolumes) {
+    return;
+  }
+
+  const successfulDeployments = await db
+    .selectFrom("deployments")
+    .select("id")
+    .where("serviceId", "=", serviceId)
+    .where("status", "=", "running")
+    .where("imageName", "is not", null)
+    .orderBy("createdAt", "desc")
+    .execute();
+
+  const eligibleIds = successfulDeployments
+    .slice(0, ROLLBACK_ELIGIBLE_COUNT)
+    .map((d) => d.id);
+  const ineligibleIds = successfulDeployments
+    .slice(ROLLBACK_ELIGIBLE_COUNT)
+    .map((d) => d.id);
+
+  if (eligibleIds.length > 0) {
+    await db
+      .updateTable("deployments")
+      .set({ rollbackEligible: 1 })
+      .where("id", "in", eligibleIds)
+      .execute();
+  }
+
+  if (ineligibleIds.length > 0) {
+    await db
+      .updateTable("deployments")
+      .set({ rollbackEligible: 0 })
+      .where("id", "in", ineligibleIds)
+      .execute();
+  }
+}
+
+export async function rollbackDeployment(
+  deploymentId: string,
+): Promise<string> {
+  const sourceDeployment = await db
+    .selectFrom("deployments")
+    .selectAll()
+    .where("id", "=", deploymentId)
+    .executeTakeFirst();
+
+  if (!sourceDeployment) {
+    throw new Error("Deployment not found");
+  }
+
+  if (!sourceDeployment.imageName) {
+    throw new Error("Deployment has no image snapshot");
+  }
+
+  const service = await db
+    .selectFrom("services")
+    .selectAll()
+    .where("id", "=", sourceDeployment.serviceId)
+    .executeTakeFirst();
+
+  if (!service) {
+    throw new Error("Service not found");
+  }
+
+  if (service.volumes && service.volumes !== "[]") {
+    throw new Error("Cannot rollback services with volumes");
+  }
+
+  const project = await db
+    .selectFrom("projects")
+    .selectAll()
+    .where("id", "=", sourceDeployment.projectId)
+    .executeTakeFirst();
+
+  if (!project) {
+    throw new Error("Project not found");
+  }
+
+  const exists = await imageExists(sourceDeployment.imageName);
+  if (!exists) {
+    throw new Error("Image no longer available");
+  }
+
+  const newDeploymentId = nanoid();
+  const now = Date.now();
+
+  await db
+    .insertInto("deployments")
+    .values({
+      id: newDeploymentId,
+      projectId: sourceDeployment.projectId,
+      serviceId: sourceDeployment.serviceId,
+      commitSha: sourceDeployment.commitSha,
+      commitMessage: `Rollback to ${sourceDeployment.commitSha}`,
+      status: "pending",
+      createdAt: now,
+      imageName: sourceDeployment.imageName,
+      envVarsSnapshot: sourceDeployment.envVarsSnapshot,
+      containerPort: sourceDeployment.containerPort,
+      healthCheckPath: sourceDeployment.healthCheckPath,
+      healthCheckTimeout: sourceDeployment.healthCheckTimeout,
+      volumes: sourceDeployment.volumes,
+      rollbackSourceId: sourceDeployment.id,
+    })
+    .execute();
+
+  runRollbackDeployment(
+    newDeploymentId,
+    sourceDeployment,
+    service,
+    project,
+  ).catch((err) => {
+    console.error("Rollback deployment failed:", err);
+  });
+
+  return newDeploymentId;
+}
+
+async function runRollbackDeployment(
+  deploymentId: string,
+  sourceDeployment: {
+    imageName: string | null;
+    envVarsSnapshot: string | null;
+    containerPort: number | null;
+    healthCheckPath: string | null;
+    healthCheckTimeout: number | null;
+  },
+  service: Selectable<Service>,
+  project: Selectable<Project>,
+) {
+  const containerName = `frost-${project.id}-${service.name}`.toLowerCase();
+  const networkName = `frost-net-${project.id}`.toLowerCase();
+
+  const baseLabels = {
+    "frost.managed": "true",
+    "frost.project.id": project.id,
+    "frost.service.id": service.id,
+    "frost.service.name": service.name,
+  };
+
+  const envVarsList: EnvVar[] = sourceDeployment.envVarsSnapshot
+    ? JSON.parse(sourceDeployment.envVarsSnapshot)
+    : [];
+  const envVars: Record<string, string> = {};
+  for (const e of envVarsList) {
+    envVars[e.key] = e.value;
+  }
+
+  try {
+    await updateDeployment(deploymentId, { status: "deploying" });
+    await appendLog(
+      deploymentId,
+      `Rolling back to image ${sourceDeployment.imageName}...\n`,
+    );
+
+    await createNetwork(networkName, baseLabels);
+
+    const hostPort = await getAvailablePort();
+    const runResult = await runContainer({
+      imageName: sourceDeployment.imageName!,
+      hostPort,
+      containerPort: sourceDeployment.containerPort ?? undefined,
+      name: containerName,
+      envVars,
+      network: networkName,
+      hostname: service.name,
+      labels: {
+        ...baseLabels,
+        "frost.deployment.id": deploymentId,
+      },
+    });
+
+    if (!runResult.success) {
+      throw new Error(runResult.error || "Failed to start container");
+    }
+
+    await appendLog(
+      deploymentId,
+      `Container started: ${runResult.containerId.substring(0, 12)}\n`,
+    );
+
+    const healthCheckType = sourceDeployment.healthCheckPath
+      ? `HTTP ${sourceDeployment.healthCheckPath}`
+      : "TCP";
+    await appendLog(
+      deploymentId,
+      `Health check (${healthCheckType}) on port ${hostPort}...\n`,
+    );
+
+    const isHealthy = await waitForHealthy({
+      containerId: runResult.containerId,
+      port: hostPort,
+      path: sourceDeployment.healthCheckPath,
+      timeoutSeconds: sourceDeployment.healthCheckTimeout ?? 60,
+    });
+
+    if (!isHealthy) {
+      throw new Error("Container failed health check");
+    }
+
+    await updateDeployment(deploymentId, {
+      status: "running",
+      containerId: runResult.containerId,
+      hostPort: hostPort,
+      finishedAt: Date.now(),
+    });
+
+    await appendLog(
+      deploymentId,
+      `\nRollback successful! App available at http://localhost:${hostPort}\n`,
+    );
+
+    try {
+      await syncCaddyConfig();
+      await appendLog(deploymentId, "Caddy config synced\n");
+    } catch (err: any) {
+      await appendLog(
+        deploymentId,
+        `Warning: Failed to sync Caddy config: ${err.message}\n`,
+      );
+    }
+
+    await updateRollbackEligible(service.id);
+
+    const previousDeployments = await db
+      .selectFrom("deployments")
+      .select(["id", "containerId"])
+      .where("serviceId", "=", service.id)
+      .where("id", "!=", deploymentId)
+      .where("status", "=", "running")
+      .execute();
+
+    for (const prev of previousDeployments) {
+      if (prev.containerId) {
+        await stopContainer(prev.containerId);
+      }
+      await db
+        .updateTable("deployments")
+        .set({ status: "failed", finishedAt: Date.now() })
+        .where("id", "=", prev.id)
+        .execute();
+    }
+  } catch (err: any) {
+    const errorMessage = err.message || "Unknown error";
+    await updateDeployment(deploymentId, {
+      status: "failed",
+      errorMessage: errorMessage,
+      finishedAt: Date.now(),
+    });
+    await appendLog(deploymentId, `\nError: ${errorMessage}\n`);
   }
 }

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -233,7 +233,7 @@ async function runServiceDeployment(
         throw new Error("Repo URL, branch, and Dockerfile path are required");
       }
 
-      const repoPath = join(REPOS_PATH, service.id);
+      const repoPath = join(REPOS_PATH, deploymentId);
 
       await updateDeployment(deploymentId, { status: "cloning" });
       await appendLog(deploymentId, `Cloning ${service.repoUrl}...\n`);

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -213,8 +213,7 @@ export async function runContainer(
 
 export async function stopContainer(name: string): Promise<void> {
   try {
-    await execAsync(`docker stop ${name}`);
-    await execAsync(`docker rm ${name}`);
+    await execAsync(`docker rm -f ${name}`);
   } catch {
     // Container might not exist
   }

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -171,7 +171,13 @@ export async function runContainer(
     command,
   } = options;
   try {
+    console.log(`[DEBUG] runContainer: stopping existing container "${name}"`);
     await stopContainer(name);
+    console.log(`[DEBUG] runContainer: stopContainer completed for "${name}"`);
+
+    const checkExisting = await execAsync(`docker ps -a --filter "name=^${name}$" --format "{{.ID}} {{.Status}}"`).catch(() => ({ stdout: "" }));
+    console.log(`[DEBUG] runContainer: existing containers after stop: "${checkExisting.stdout.trim() || 'none'}"`);
+
 
     const allEnvVars = { PORT: String(containerPort), ...envVars };
     const envFlags = Object.entries(allEnvVars)
@@ -194,15 +200,17 @@ export async function runContainer(
       : "";
     const commandPart = command ? command.join(" ") : "";
     const logOpts = "--log-opt max-size=10m --log-opt max-file=3";
-    const { stdout } = await execAsync(
-      `docker run -d --restart on-failure:5 ${logOpts} --name ${name} -p ${hostPort}:${containerPort} ${networkFlag} ${hostnameFlag} ${labelFlags} ${volumeFlags} ${fileMountFlags} ${envFlags} ${imageName} ${commandPart}`.replace(
-        /\s+/g,
-        " ",
-      ),
+    const dockerCmd = `docker run -d --restart on-failure:5 ${logOpts} --name ${name} -p ${hostPort}:${containerPort} ${networkFlag} ${hostnameFlag} ${labelFlags} ${volumeFlags} ${fileMountFlags} ${envFlags} ${imageName} ${commandPart}`.replace(
+      /\s+/g,
+      " ",
     );
+    console.log(`[DEBUG] runContainer: executing docker run for "${name}"`);
+    const { stdout } = await execAsync(dockerCmd);
     const containerId = stdout.trim();
+    console.log(`[DEBUG] runContainer: container created successfully, id="${containerId}"`);
     return { success: true, containerId };
   } catch (err: any) {
+    console.log(`[DEBUG] runContainer: docker run failed for "${name}", error: "${err.stderr || err.message}"`);
     return {
       success: false,
       containerId: "",
@@ -212,10 +220,12 @@ export async function runContainer(
 }
 
 export async function stopContainer(name: string): Promise<void> {
+  console.log(`[DEBUG] stopContainer: attempting to remove "${name}"`);
   try {
-    await execAsync(`docker rm -f ${name}`);
-  } catch {
-    // Container might not exist
+    const result = await execAsync(`docker rm -f ${name}`);
+    console.log(`[DEBUG] stopContainer: successfully removed "${name}", output: "${result.stdout.trim()}"`);
+  } catch (err: any) {
+    console.log(`[DEBUG] stopContainer: failed to remove "${name}", error: "${err.stderr || err.message}"`);
   }
 }
 

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -171,13 +171,7 @@ export async function runContainer(
     command,
   } = options;
   try {
-    console.log(`[DEBUG] runContainer: stopping existing container "${name}"`);
     await stopContainer(name);
-    console.log(`[DEBUG] runContainer: stopContainer completed for "${name}"`);
-
-    const checkExisting = await execAsync(`docker ps -a --filter "name=^${name}$" --format "{{.ID}} {{.Status}}"`).catch(() => ({ stdout: "" }));
-    console.log(`[DEBUG] runContainer: existing containers after stop: "${checkExisting.stdout.trim() || 'none'}"`);
-
 
     const allEnvVars = { PORT: String(containerPort), ...envVars };
     const envFlags = Object.entries(allEnvVars)
@@ -200,17 +194,15 @@ export async function runContainer(
       : "";
     const commandPart = command ? command.join(" ") : "";
     const logOpts = "--log-opt max-size=10m --log-opt max-file=3";
-    const dockerCmd = `docker run -d --restart on-failure:5 ${logOpts} --name ${name} -p ${hostPort}:${containerPort} ${networkFlag} ${hostnameFlag} ${labelFlags} ${volumeFlags} ${fileMountFlags} ${envFlags} ${imageName} ${commandPart}`.replace(
-      /\s+/g,
-      " ",
+    const { stdout } = await execAsync(
+      `docker run -d --restart on-failure:5 ${logOpts} --name ${name} -p ${hostPort}:${containerPort} ${networkFlag} ${hostnameFlag} ${labelFlags} ${volumeFlags} ${fileMountFlags} ${envFlags} ${imageName} ${commandPart}`.replace(
+        /\s+/g,
+        " ",
+      ),
     );
-    console.log(`[DEBUG] runContainer: executing docker run for "${name}"`);
-    const { stdout } = await execAsync(dockerCmd);
     const containerId = stdout.trim();
-    console.log(`[DEBUG] runContainer: container created successfully, id="${containerId}"`);
     return { success: true, containerId };
   } catch (err: any) {
-    console.log(`[DEBUG] runContainer: docker run failed for "${name}", error: "${err.stderr || err.message}"`);
     return {
       success: false,
       containerId: "",
@@ -220,12 +212,10 @@ export async function runContainer(
 }
 
 export async function stopContainer(name: string): Promise<void> {
-  console.log(`[DEBUG] stopContainer: attempting to remove "${name}"`);
   try {
-    const result = await execAsync(`docker rm -f ${name}`);
-    console.log(`[DEBUG] stopContainer: successfully removed "${name}", output: "${result.stdout.trim()}"`);
-  } catch (err: any) {
-    console.log(`[DEBUG] stopContainer: failed to remove "${name}", error: "${err.stderr || err.message}"`);
+    await execAsync(`docker rm -f ${name}`);
+  } catch {
+    // Container might not exist
   }
 }
 

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -439,6 +439,15 @@ export async function removeImage(image: string): Promise<boolean> {
   }
 }
 
+export async function imageExists(imageName: string): Promise<boolean> {
+  try {
+    await execAsync(`docker image inspect ${imageName}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function getRunningImageNames(): Promise<Set<string>> {
   try {
     const { stdout } = await execAsync(`docker ps --format '{{.Image}}'`);

--- a/test/fixtures/env-test/Dockerfile
+++ b/test/fixtures/env-test/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+COPY build.js ./
+COPY index.js ./
+
+# Copy .env if it exists (for build-time vars)
+COPY .en[v] ./
+
+# Run build script to capture .env vars
+RUN npm run build
+
+EXPOSE 8080
+
+CMD ["npm", "start"]

--- a/test/fixtures/env-test/build.js
+++ b/test/fixtures/env-test/build.js
@@ -1,0 +1,22 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const buildTimeEnv = {};
+
+const envPath = path.join(__dirname, ".env");
+if (fs.existsSync(envPath)) {
+  const content = fs.readFileSync(envPath, "utf-8");
+  for (const line of content.split("\n")) {
+    const [key, ...rest] = line.split("=");
+    if (key && rest.length > 0) {
+      buildTimeEnv[key.trim()] = rest.join("=").trim();
+    }
+  }
+}
+
+fs.writeFileSync(
+  path.join(__dirname, "build-env.json"),
+  JSON.stringify(buildTimeEnv, null, 2),
+);
+
+console.log("Build-time env vars captured:", Object.keys(buildTimeEnv));

--- a/test/fixtures/env-test/index.js
+++ b/test/fixtures/env-test/index.js
@@ -1,0 +1,33 @@
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+
+let buildTimeEnv = {};
+try {
+  buildTimeEnv = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "build-env.json"), "utf-8"),
+  );
+} catch (_e) {
+  console.log("No build-env.json found");
+}
+
+const server = http.createServer((req, res) => {
+  const runtimeEnv = {
+    BUILD_VAR: process.env.BUILD_VAR,
+    RUNTIME_VAR: process.env.RUNTIME_VAR,
+    SHARED_VAR: process.env.SHARED_VAR,
+  };
+
+  const response = {
+    buildTime: buildTimeEnv,
+    runtime: runtimeEnv,
+  };
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(response, null, 2));
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/test/fixtures/env-test/package.json
+++ b/test/fixtures/env-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "env-test",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "node build.js",
+    "start": "node index.js"
+  }
+}


### PR DESCRIPTION
## Summary
- Instant rollback to previous deployments with full state restoration
- Stores env vars, containerPort, health check config per deployment snapshot
- Rollback button on deployment history (hover to reveal, non-database services only)
- Rollback uses existing Docker image (no rebuild, instant switch)
- Keeps last 5 deployments rollback-eligible per service
- Cleanup respects rollback-eligible images

## Bug fixes
- Fixed race condition when concurrent deployments clone to same directory (caused git refs corruption)
- Each deployment now clones to unique path using deployment ID

## Test plan
- [x] Deploy a service twice, verify snapshot data populated
- [x] Verify rollback button appears on old deployments (hover)
- [x] Click rollback, verify new deployment created with old image
- [x] Verify rollback disabled for database services
- [x] Run e2e tests on test VPS

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)