### PR TITLE
feat: improve health check settings UX

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -775,28 +775,22 @@ echo "# Test Group 9: Health Check Config"
 echo "########################################"
 
 echo ""
-echo "=== Test 46: Create service and configure HTTP health check ==="
+echo "=== Test 46: Create service with HTTP health check ==="
 PROJECT10=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-healthcheck"}')
 PROJECT10_ID=$(echo "$PROJECT10" | jq -r '.id')
 echo "Created project: $PROJECT10_ID"
 
 SERVICE10=$(api -X POST "$BASE_URL/api/projects/$PROJECT10_ID/services" \
-  -d '{"name":"health-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
+  -d '{"name":"health-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"healthCheckPath":"/","healthCheckTimeout":30}')
 SERVICE10_ID=$(echo "$SERVICE10" | jq -r '.id')
+HEALTH_PATH=$(echo "$SERVICE10" | jq -r '.healthCheckPath')
+HEALTH_TIMEOUT=$(echo "$SERVICE10" | jq -r '.healthCheckTimeout')
 
 if [ "$SERVICE10_ID" = "null" ] || [ -z "$SERVICE10_ID" ]; then
   echo "FAIL: Failed to create service"
   echo "$SERVICE10" | jq
   exit 1
 fi
-echo "Created service: $SERVICE10_ID"
-
-api -X PATCH "$BASE_URL/api/services/$SERVICE10_ID" \
-  -d '{"healthCheckPath":"/","healthCheckTimeout":30}' > /dev/null
-
-SERVICE10_UPDATED=$(api "$BASE_URL/api/services/$SERVICE10_ID")
-HEALTH_PATH=$(echo "$SERVICE10_UPDATED" | jq -r '.healthCheckPath')
-HEALTH_TIMEOUT=$(echo "$SERVICE10_UPDATED" | jq -r '.healthCheckTimeout')
 
 if [ "$HEALTH_PATH" != "/" ]; then
   echo "FAIL: healthCheckPath should be '/', got: $HEALTH_PATH"
@@ -806,18 +800,13 @@ if [ "$HEALTH_TIMEOUT" != "30" ]; then
   echo "FAIL: healthCheckTimeout should be 30, got: $HEALTH_TIMEOUT"
   exit 1
 fi
-echo "Configured HTTP health check: path=$HEALTH_PATH, timeout=$HEALTH_TIMEOUT"
+echo "Created service with HTTP health check: path=$HEALTH_PATH, timeout=$HEALTH_TIMEOUT"
 
 echo ""
-echo "=== Test 47: Wait for initial deployment, then redeploy with HTTP health check ==="
+echo "=== Test 47: Wait for deployment and verify HTTP health check in logs ==="
 sleep 2
-DEPLOY10_INIT=$(api "$BASE_URL/api/services/$SERVICE10_ID/deployments" | jq -r '.[0].id')
-echo "Waiting for initial deployment: $DEPLOY10_INIT"
-wait_for_deployment "$DEPLOY10_INIT"
-
-DEPLOY10=$(api -X POST "$BASE_URL/api/services/$SERVICE10_ID/deploy")
-DEPLOY10_ID=$(echo "$DEPLOY10" | jq -r '.deploymentId')
-echo "Triggered deployment with HTTP health check: $DEPLOY10_ID"
+DEPLOY10_ID=$(api "$BASE_URL/api/services/$SERVICE10_ID/deployments" | jq -r '.[0].id')
+echo "Using deployment: $DEPLOY10_ID"
 wait_for_deployment "$DEPLOY10_ID"
 
 BUILD_LOG10=$(api "$BASE_URL/api/deployments/$DEPLOY10_ID" | jq -r '.buildLog')

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -770,6 +770,95 @@ api -X DELETE "$BASE_URL/api/projects/$PROJECT9_ID" > /dev/null
 echo "Deleted project"
 
 echo ""
+echo "########################################"
+echo "# Test Group 9: Health Check Config"
+echo "########################################"
+
+echo ""
+echo "=== Test 46: Create service with HTTP health check ==="
+PROJECT10=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-healthcheck"}')
+PROJECT10_ID=$(echo "$PROJECT10" | jq -r '.id')
+echo "Created project: $PROJECT10_ID"
+
+SERVICE10=$(api -X POST "$BASE_URL/api/projects/$PROJECT10_ID/services" \
+  -d '{"name":"health-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"healthCheckPath":"/","healthCheckTimeout":30}')
+SERVICE10_ID=$(echo "$SERVICE10" | jq -r '.id')
+HEALTH_PATH=$(echo "$SERVICE10" | jq -r '.healthCheckPath')
+HEALTH_TIMEOUT=$(echo "$SERVICE10" | jq -r '.healthCheckTimeout')
+
+if [ "$SERVICE10_ID" = "null" ] || [ -z "$SERVICE10_ID" ]; then
+  echo "FAIL: Failed to create service"
+  echo "$SERVICE10" | jq
+  exit 1
+fi
+
+if [ "$HEALTH_PATH" != "/" ]; then
+  echo "FAIL: healthCheckPath should be '/', got: $HEALTH_PATH"
+  exit 1
+fi
+if [ "$HEALTH_TIMEOUT" != "30" ]; then
+  echo "FAIL: healthCheckTimeout should be 30, got: $HEALTH_TIMEOUT"
+  exit 1
+fi
+echo "Created service with HTTP health check: path=$HEALTH_PATH, timeout=$HEALTH_TIMEOUT"
+
+echo ""
+echo "=== Test 47: Wait for deployment and verify HTTP health check in logs ==="
+sleep 2
+DEPLOY10_ID=$(api "$BASE_URL/api/services/$SERVICE10_ID/deployments" | jq -r '.[0].id')
+echo "Using deployment: $DEPLOY10_ID"
+wait_for_deployment "$DEPLOY10_ID"
+
+BUILD_LOG10=$(api "$BASE_URL/api/deployments/$DEPLOY10_ID" | jq -r '.buildLog')
+if echo "$BUILD_LOG10" | grep -q "Health check (HTTP /)"; then
+  echo "HTTP health check logged correctly"
+else
+  echo "FAIL: Expected 'Health check (HTTP /)' in build log"
+  echo "Build log: $BUILD_LOG10"
+  exit 1
+fi
+
+echo ""
+echo "=== Test 48: Update to TCP health check ==="
+api -X PATCH "$BASE_URL/api/services/$SERVICE10_ID" \
+  -d '{"healthCheckPath":null,"healthCheckTimeout":45}' > /dev/null
+
+SERVICE10_UPDATED=$(api "$BASE_URL/api/services/$SERVICE10_ID")
+HEALTH_PATH_UPDATED=$(echo "$SERVICE10_UPDATED" | jq -r '.healthCheckPath')
+HEALTH_TIMEOUT_UPDATED=$(echo "$SERVICE10_UPDATED" | jq -r '.healthCheckTimeout')
+
+if [ "$HEALTH_PATH_UPDATED" != "null" ]; then
+  echo "FAIL: healthCheckPath should be null, got: $HEALTH_PATH_UPDATED"
+  exit 1
+fi
+if [ "$HEALTH_TIMEOUT_UPDATED" != "45" ]; then
+  echo "FAIL: healthCheckTimeout should be 45, got: $HEALTH_TIMEOUT_UPDATED"
+  exit 1
+fi
+echo "Updated to TCP health check: timeout=$HEALTH_TIMEOUT_UPDATED"
+
+echo ""
+echo "=== Test 49: Redeploy and verify TCP health check in logs ==="
+DEPLOY10B=$(api -X POST "$BASE_URL/api/services/$SERVICE10_ID/deploy")
+DEPLOY10B_ID=$(echo "$DEPLOY10B" | jq -r '.deployment_id')
+echo "New deployment: $DEPLOY10B_ID"
+wait_for_deployment "$DEPLOY10B_ID"
+
+BUILD_LOG10B=$(api "$BASE_URL/api/deployments/$DEPLOY10B_ID" | jq -r '.buildLog')
+if echo "$BUILD_LOG10B" | grep -q "Health check (TCP)"; then
+  echo "TCP health check logged correctly"
+else
+  echo "FAIL: Expected 'Health check (TCP)' in build log"
+  echo "Build log: $BUILD_LOG10B"
+  exit 1
+fi
+
+echo ""
+echo "=== Test 50: Cleanup health check test project ==="
+api -X DELETE "$BASE_URL/api/projects/$PROJECT10_ID" > /dev/null
+echo "Deleted project"
+
+echo ""
 echo "========================================="
 echo "All E2E tests passed!"
 echo "========================================="

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -775,22 +775,28 @@ echo "# Test Group 9: Health Check Config"
 echo "########################################"
 
 echo ""
-echo "=== Test 46: Create service with HTTP health check ==="
+echo "=== Test 46: Create service and configure HTTP health check ==="
 PROJECT10=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-healthcheck"}')
 PROJECT10_ID=$(echo "$PROJECT10" | jq -r '.id')
 echo "Created project: $PROJECT10_ID"
 
 SERVICE10=$(api -X POST "$BASE_URL/api/projects/$PROJECT10_ID/services" \
-  -d '{"name":"health-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"healthCheckPath":"/","healthCheckTimeout":30}')
+  -d '{"name":"health-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
 SERVICE10_ID=$(echo "$SERVICE10" | jq -r '.id')
-HEALTH_PATH=$(echo "$SERVICE10" | jq -r '.healthCheckPath')
-HEALTH_TIMEOUT=$(echo "$SERVICE10" | jq -r '.healthCheckTimeout')
 
 if [ "$SERVICE10_ID" = "null" ] || [ -z "$SERVICE10_ID" ]; then
   echo "FAIL: Failed to create service"
   echo "$SERVICE10" | jq
   exit 1
 fi
+echo "Created service: $SERVICE10_ID"
+
+api -X PATCH "$BASE_URL/api/services/$SERVICE10_ID" \
+  -d '{"healthCheckPath":"/","healthCheckTimeout":30}' > /dev/null
+
+SERVICE10_UPDATED=$(api "$BASE_URL/api/services/$SERVICE10_ID")
+HEALTH_PATH=$(echo "$SERVICE10_UPDATED" | jq -r '.healthCheckPath')
+HEALTH_TIMEOUT=$(echo "$SERVICE10_UPDATED" | jq -r '.healthCheckTimeout')
 
 if [ "$HEALTH_PATH" != "/" ]; then
   echo "FAIL: healthCheckPath should be '/', got: $HEALTH_PATH"
@@ -800,13 +806,18 @@ if [ "$HEALTH_TIMEOUT" != "30" ]; then
   echo "FAIL: healthCheckTimeout should be 30, got: $HEALTH_TIMEOUT"
   exit 1
 fi
-echo "Created service with HTTP health check: path=$HEALTH_PATH, timeout=$HEALTH_TIMEOUT"
+echo "Configured HTTP health check: path=$HEALTH_PATH, timeout=$HEALTH_TIMEOUT"
 
 echo ""
-echo "=== Test 47: Wait for deployment and verify HTTP health check in logs ==="
+echo "=== Test 47: Wait for initial deployment, then redeploy with HTTP health check ==="
 sleep 2
-DEPLOY10_ID=$(api "$BASE_URL/api/services/$SERVICE10_ID/deployments" | jq -r '.[0].id')
-echo "Using deployment: $DEPLOY10_ID"
+DEPLOY10_INIT=$(api "$BASE_URL/api/services/$SERVICE10_ID/deployments" | jq -r '.[0].id')
+echo "Waiting for initial deployment: $DEPLOY10_INIT"
+wait_for_deployment "$DEPLOY10_INIT"
+
+DEPLOY10=$(api -X POST "$BASE_URL/api/services/$SERVICE10_ID/deploy")
+DEPLOY10_ID=$(echo "$DEPLOY10" | jq -r '.deploymentId')
+echo "Triggered deployment with HTTP health check: $DEPLOY10_ID"
 wait_for_deployment "$DEPLOY10_ID"
 
 BUILD_LOG10=$(api "$BASE_URL/api/deployments/$DEPLOY10_ID" | jq -r '.buildLog')

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -90,7 +90,7 @@ DEPLOYMENT_ID=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments" | jq -r '.[
 if [ -z "$DEPLOYMENT_ID" ]; then
   echo "No auto-deployment found, triggering manual deploy..."
   DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
-  DEPLOYMENT_ID=$(echo "$DEPLOY" | jq -r '.deployment_id')
+  DEPLOYMENT_ID=$(echo "$DEPLOY" | jq -r '.deploymentId')
 fi
 
 if [ "$DEPLOYMENT_ID" = "null" ] || [ -z "$DEPLOYMENT_ID" ]; then
@@ -279,7 +279,7 @@ api -X PATCH "$BASE_URL/api/services/$SERVICE4_ID" \
   -d '{"imageUrl":"httpd:alpine","containerPort":80}' > /dev/null
 
 DEPLOY4B=$(api -X POST "$BASE_URL/api/services/$SERVICE4_ID/deploy")
-DEPLOY4B_ID=$(echo "$DEPLOY4B" | jq -r '.deployment_id')
+DEPLOY4B_ID=$(echo "$DEPLOY4B" | jq -r '.deploymentId')
 wait_for_deployment "$DEPLOY4B_ID"
 
 HOST_PORT4B=$(api "$BASE_URL/api/deployments/$DEPLOY4B_ID" | jq -r '.hostPort')
@@ -340,7 +340,7 @@ DEPLOY5_ID=$(api "$BASE_URL/api/services/$SERVICE5_ID/deployments" | jq -r '.[0]
 if [ "$DEPLOY5_ID" = "null" ] || [ -z "$DEPLOY5_ID" ]; then
   echo "No auto-deployment found - triggering manual deploy"
   DEPLOY5=$(api -X POST "$BASE_URL/api/services/$SERVICE5_ID/deploy")
-  DEPLOY5_ID=$(echo "$DEPLOY5" | jq -r '.deployment_id')
+  DEPLOY5_ID=$(echo "$DEPLOY5" | jq -r '.deploymentId')
 fi
 echo "Using deployment: $DEPLOY5_ID"
 wait_for_deployment "$DEPLOY5_ID"
@@ -672,7 +672,7 @@ echo "First deployment (auto): $DEPLOY9A_ID"
 wait_for_deployment "$DEPLOY9A_ID"
 
 DEPLOY9B=$(api -X POST "$BASE_URL/api/services/$SERVICE9_ID/deploy")
-DEPLOY9B_ID=$(echo "$DEPLOY9B" | jq -r '.deployment_id')
+DEPLOY9B_ID=$(echo "$DEPLOY9B" | jq -r '.deploymentId')
 echo "Second deployment (manual): $DEPLOY9B_ID"
 wait_for_deployment "$DEPLOY9B_ID"
 
@@ -702,10 +702,10 @@ DEPLOY9A_ELIGIBLE=$(echo "$DEPLOY9A_UPDATED" | jq -r '.rollbackEligible')
 echo "First deployment image: $DEPLOY9A_IMAGE, eligible: $DEPLOY9A_ELIGIBLE"
 
 ROLLBACK_RESULT=$(api -X POST "$BASE_URL/api/deployments/$DEPLOY9A_ID/rollback")
-ROLLBACK_DEPLOY_ID=$(echo "$ROLLBACK_RESULT" | jq -r '.deployment_id')
+ROLLBACK_DEPLOY_ID=$(echo "$ROLLBACK_RESULT" | jq -r '.deploymentId')
 
 if [ "$ROLLBACK_DEPLOY_ID" = "null" ] || [ -z "$ROLLBACK_DEPLOY_ID" ]; then
-  echo "FAIL: Rollback did not return deployment_id"
+  echo "FAIL: Rollback did not return deploymentId"
   echo "Response: $ROLLBACK_RESULT"
   exit 1
 fi
@@ -840,7 +840,7 @@ echo "Updated to TCP health check: timeout=$HEALTH_TIMEOUT_UPDATED"
 echo ""
 echo "=== Test 49: Redeploy and verify TCP health check in logs ==="
 DEPLOY10B=$(api -X POST "$BASE_URL/api/services/$SERVICE10_ID/deploy")
-DEPLOY10B_ID=$(echo "$DEPLOY10B" | jq -r '.deployment_id')
+DEPLOY10B_ID=$(echo "$DEPLOY10B" | jq -r '.deploymentId')
 echo "New deployment: $DEPLOY10B_ID"
 wait_for_deployment "$DEPLOY10B_ID"
 

--- a/src/app/api/projects/[id]/services/route.ts
+++ b/src/app/api/projects/[id]/services/route.ts
@@ -54,6 +54,8 @@ export async function POST(
     envVars = [],
     containerPort,
     templateId,
+    healthCheckPath,
+    healthCheckTimeout,
   } = body;
 
   if (!name) {
@@ -173,6 +175,8 @@ export async function POST(
         imageUrl: deployType === "image" ? imageUrl : null,
         envVars: JSON.stringify(envVars),
         containerPort: containerPort ?? null,
+        healthCheckPath: healthCheckPath ?? null,
+        healthCheckTimeout: healthCheckTimeout ?? null,
         autoDeploy: deployType === "repo" ? 1 : 0,
         createdAt: now,
       })


### PR DESCRIPTION
## Summary
- Add explicit TCP/HTTP toggle instead of implicit "empty = TCP"
- Add contextual helper text for each health check mode
- Show common paths hint for HTTP (/health, /healthz, /ready)
- Badge-style display showing type and timeout
- Add e2e tests for health check configuration (tests 46-50)

## Test plan
- [ ] Open service settings page
- [ ] Verify TCP shows by default when path is empty
- [ ] Click Edit, switch to HTTP, enter path, save
- [ ] Verify badge shows "HTTP /path" with timeout
- [ ] Switch back to TCP, save, verify badge shows "TCP"
- [ ] Deploy service, check logs show correct health check type
- [ ] Run e2e tests on VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)