### PR TITLE
fix: handle deployment race conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,10 @@ jobs:
 
       - run: bun install
 
+      - name: Setup database
+        run: bun migrate
+        env:
+          NODE_ENV: development
+
       - name: Test
         run: bun test

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -215,7 +215,7 @@ sleep 2
 DEPLOY3_ID=$(api "$BASE_URL/api/services/$SERVICE3_ID/deployments" | jq -r '.[0].id')
 wait_for_deployment "$DEPLOY3_ID"
 
-CONTAINER_NAME="frost-${PROJECT3_ID}-envcheck"
+CONTAINER_NAME="frost-${SERVICE3_ID}-${DEPLOY3_ID}"
 CONTAINER_NAME=$(echo "$CONTAINER_NAME" | tr '[:upper:]' '[:lower:]')
 SHARED_VAL=$(remote "docker exec $CONTAINER_NAME printenv SHARED")
 PROJECT_ONLY_VAL=$(remote "docker exec $CONTAINER_NAME printenv PROJECT_ONLY")

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -859,6 +859,72 @@ api -X DELETE "$BASE_URL/api/projects/$PROJECT10_ID" > /dev/null
 echo "Deleted project"
 
 echo ""
+echo "########################################"
+echo "# Test Group 10: Deployment Race Conditions"
+echo "########################################"
+
+echo ""
+echo "=== Test 51: Create service for race test ==="
+PROJECT11=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-race"}')
+PROJECT11_ID=$(echo "$PROJECT11" | jq -r '.id')
+echo "Created project: $PROJECT11_ID"
+
+SERVICE11=$(api -X POST "$BASE_URL/api/projects/$PROJECT11_ID/services" \
+  -d '{"name":"race-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
+SERVICE11_ID=$(echo "$SERVICE11" | jq -r '.id')
+echo "Created service: $SERVICE11_ID"
+
+sleep 2
+DEPLOY11_INITIAL=$(api "$BASE_URL/api/services/$SERVICE11_ID/deployments" | jq -r '.[0].id')
+echo "Waiting for initial auto-deployment: $DEPLOY11_INITIAL"
+wait_for_deployment "$DEPLOY11_INITIAL"
+
+echo ""
+echo "=== Test 52: Rapid double-deploy cancels first ==="
+DEPLOY11A=$(api -X POST "$BASE_URL/api/services/$SERVICE11_ID/deploy")
+DEPLOY11A_ID=$(echo "$DEPLOY11A" | jq -r '.deploymentId')
+echo "First deploy: $DEPLOY11A_ID"
+
+DEPLOY11B=$(api -X POST "$BASE_URL/api/services/$SERVICE11_ID/deploy")
+DEPLOY11B_ID=$(echo "$DEPLOY11B" | jq -r '.deploymentId')
+echo "Second deploy: $DEPLOY11B_ID"
+
+wait_for_deployment "$DEPLOY11B_ID"
+
+STATUS11A=$(api "$BASE_URL/api/deployments/$DEPLOY11A_ID" | jq -r '.status')
+if [ "$STATUS11A" != "cancelled" ]; then
+  echo "FAIL: First deployment should be cancelled, got: $STATUS11A"
+  exit 1
+fi
+echo "First deployment correctly cancelled"
+
+echo ""
+echo "=== Test 53: Verify only one container running ==="
+CONTAINER_COUNT=$(remote "docker ps --filter 'label=frost.service.id=$SERVICE11_ID' --format '{{.Names}}' | wc -l")
+CONTAINER_COUNT=$(echo "$CONTAINER_COUNT" | tr -d ' ')
+if [ "$CONTAINER_COUNT" != "1" ]; then
+  echo "FAIL: Expected 1 container, found: $CONTAINER_COUNT"
+  exit 1
+fi
+echo "Exactly 1 container running"
+
+echo ""
+echo "=== Test 54: Verify container name format ==="
+CONTAINER_NAME=$(remote "docker ps --filter 'label=frost.service.id=$SERVICE11_ID' --format '{{.Names}}'")
+SERVICE11_ID_LOWER=$(echo "$SERVICE11_ID" | tr '[:upper:]' '[:lower:]')
+EXPECTED_PREFIX="frost-${SERVICE11_ID_LOWER}-"
+if [[ "$CONTAINER_NAME" != $EXPECTED_PREFIX* ]]; then
+  echo "FAIL: Container name should start with $EXPECTED_PREFIX, got: $CONTAINER_NAME"
+  exit 1
+fi
+echo "Container name format correct: $CONTAINER_NAME"
+
+echo ""
+echo "=== Test 55: Cleanup race test project ==="
+api -X DELETE "$BASE_URL/api/projects/$PROJECT11_ID" > /dev/null
+echo "Deleted project"
+
+echo ""
 echo "========================================="
 echo "All E2E tests passed!"
 echo "========================================="

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -177,7 +177,7 @@ wait_for_deployment "$DEPLOY_FRONTEND_ID"
 
 echo ""
 echo "=== Test 9: Verify inter-service communication ==="
-NETWORK_NAME="frost-net-$(echo $PROJECT2_ID | tr '[:upper:]' '[:lower:]')"
+NETWORK_NAME=$(echo "frost-net-$PROJECT2_ID" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9.-]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
 CURL_RESULT=$(remote "docker run --rm --network $NETWORK_NAME curlimages/curl -sf http://backend:80")
 if echo "$CURL_RESULT" | grep -q "nginx"; then
   echo "Inter-service communication works!"
@@ -216,7 +216,7 @@ DEPLOY3_ID=$(api "$BASE_URL/api/services/$SERVICE3_ID/deployments" | jq -r '.[0]
 wait_for_deployment "$DEPLOY3_ID"
 
 CONTAINER_NAME="frost-${SERVICE3_ID}-${DEPLOY3_ID}"
-CONTAINER_NAME=$(echo "$CONTAINER_NAME" | tr '[:upper:]' '[:lower:]')
+CONTAINER_NAME=$(echo "$CONTAINER_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9.-]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
 SHARED_VAL=$(remote "docker exec $CONTAINER_NAME printenv SHARED")
 PROJECT_ONLY_VAL=$(remote "docker exec $CONTAINER_NAME printenv PROJECT_ONLY")
 SERVICE_ONLY_VAL=$(remote "docker exec $CONTAINER_NAME printenv SERVICE_ONLY")
@@ -911,8 +911,8 @@ echo "Exactly 1 container running"
 echo ""
 echo "=== Test 54: Verify container name format ==="
 CONTAINER_NAME=$(remote "docker ps --filter 'label=frost.service.id=$SERVICE11_ID' --format '{{.Names}}'")
-SERVICE11_ID_LOWER=$(echo "$SERVICE11_ID" | tr '[:upper:]' '[:lower:]')
-EXPECTED_PREFIX="frost-${SERVICE11_ID_LOWER}-"
+SERVICE11_ID_SANITIZED=$(echo "$SERVICE11_ID" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9.-]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
+EXPECTED_PREFIX="frost-${SERVICE11_ID_SANITIZED}-"
 if [[ "$CONTAINER_NAME" != $EXPECTED_PREFIX* ]]; then
   echo "FAIL: Container name should start with $EXPECTED_PREFIX, got: $CONTAINER_NAME"
   exit 1

--- a/src/lib/deployer.integration.test.ts
+++ b/src/lib/deployer.integration.test.ts
@@ -1,8 +1,15 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { nanoid } from "nanoid";
 import { db } from "./db";
 import { deployService } from "./deployer";
 import { stopContainer } from "./docker";
+
+const DB_PATH = join(process.cwd(), "data/frost.db");
+const SKIP_REASON = existsSync(DB_PATH)
+  ? null
+  : "Skipping: database not available (run on VPS via e2e tests)";
 
 const TEST_PROJECT_ID = `test-${nanoid(8)}`;
 const TEST_SERVICE_ID = `test-${nanoid(8)}`;
@@ -32,7 +39,7 @@ async function waitForDeploymentStatus(
   throw new Error(`Timeout waiting for deployment ${deploymentId}`);
 }
 
-describe("deployment race conditions", () => {
+describe.skipIf(SKIP_REASON !== null)("deployment race conditions", () => {
   beforeAll(async () => {
     await db
       .insertInto("projects")

--- a/src/lib/deployer.integration.test.ts
+++ b/src/lib/deployer.integration.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { nanoid } from "nanoid";
+import { db } from "./db";
+import { deployService } from "./deployer";
+import { stopContainer } from "./docker";
+
+const TEST_PROJECT_ID = `test-${nanoid(8)}`;
+const TEST_SERVICE_ID = `test-${nanoid(8)}`;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForDeploymentStatus(
+  deploymentId: string,
+  targetStatuses: string[],
+  timeoutMs = 120000,
+): Promise<string> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const deployment = await db
+      .selectFrom("deployments")
+      .select("status")
+      .where("id", "=", deploymentId)
+      .executeTakeFirst();
+
+    if (deployment && targetStatuses.includes(deployment.status)) {
+      return deployment.status;
+    }
+    await sleep(1000);
+  }
+  throw new Error(`Timeout waiting for deployment ${deploymentId}`);
+}
+
+describe("deployment race conditions", () => {
+  beforeAll(async () => {
+    await db
+      .insertInto("projects")
+      .values({
+        id: TEST_PROJECT_ID,
+        name: "race-test",
+        envVars: "[]",
+        createdAt: Date.now(),
+      })
+      .execute();
+
+    await db
+      .insertInto("services")
+      .values({
+        id: TEST_SERVICE_ID,
+        projectId: TEST_PROJECT_ID,
+        name: "race-test-svc",
+        deployType: "image",
+        imageUrl: "nginx:alpine",
+        containerPort: 80,
+        envVars: "[]",
+        createdAt: Date.now(),
+      })
+      .execute();
+  }, 60000);
+
+  afterAll(async () => {
+    const deployments = await db
+      .selectFrom("deployments")
+      .select("id")
+      .where("serviceId", "=", TEST_SERVICE_ID)
+      .execute();
+
+    for (const d of deployments) {
+      const containerName = `frost-${TEST_SERVICE_ID}-${d.id}`.toLowerCase();
+      await stopContainer(containerName);
+    }
+
+    await db
+      .updateTable("services")
+      .set({ currentDeploymentId: null })
+      .where("id", "=", TEST_SERVICE_ID)
+      .execute();
+    await db
+      .deleteFrom("deployments")
+      .where("serviceId", "=", TEST_SERVICE_ID)
+      .execute();
+    await db.deleteFrom("services").where("id", "=", TEST_SERVICE_ID).execute();
+    await db.deleteFrom("projects").where("id", "=", TEST_PROJECT_ID).execute();
+  });
+
+  test("concurrent deploys cancel previous", async () => {
+    const deploy1Id = await deployService(TEST_SERVICE_ID);
+    const deploy2Id = await deployService(TEST_SERVICE_ID);
+
+    const status2 = await waitForDeploymentStatus(deploy2Id, [
+      "running",
+      "failed",
+    ]);
+    expect(status2).toBe("running");
+
+    const deploy1 = await db
+      .selectFrom("deployments")
+      .select("status")
+      .where("id", "=", deploy1Id)
+      .executeTakeFirst();
+
+    expect(deploy1?.status).toBe("cancelled");
+  }, 120000);
+
+  test("rapid deploys don't leave zombie containers", async () => {
+    const deploy1Id = await deployService(TEST_SERVICE_ID);
+    const deploy2Id = await deployService(TEST_SERVICE_ID);
+    const deploy3Id = await deployService(TEST_SERVICE_ID);
+
+    const status3 = await waitForDeploymentStatus(deploy3Id, [
+      "running",
+      "failed",
+    ]);
+    expect(status3).toBe("running");
+
+    const deployments = await db
+      .selectFrom("deployments")
+      .select(["id", "status"])
+      .where("id", "in", [deploy1Id, deploy2Id, deploy3Id])
+      .execute();
+
+    const runningCount = deployments.filter(
+      (d) => d.status === "running",
+    ).length;
+    const cancelledCount = deployments.filter(
+      (d) => d.status === "cancelled",
+    ).length;
+
+    expect(runningCount).toBe(1);
+    expect(cancelledCount).toBe(2);
+  }, 120000);
+});

--- a/src/lib/deployer.integration.test.ts
+++ b/src/lib/deployer.integration.test.ts
@@ -1,15 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
 import { nanoid } from "nanoid";
 import { db } from "./db";
 import { deployService } from "./deployer";
 import { stopContainer } from "./docker";
-
-const DB_PATH = join(process.cwd(), "data/frost.db");
-const SKIP_REASON = existsSync(DB_PATH)
-  ? null
-  : "Skipping: database not available (run on VPS via e2e tests)";
 
 const TEST_PROJECT_ID = `test-${nanoid(8)}`;
 const TEST_SERVICE_ID = `test-${nanoid(8)}`;
@@ -39,7 +32,7 @@ async function waitForDeploymentStatus(
   throw new Error(`Timeout waiting for deployment ${deploymentId}`);
 }
 
-describe.skipIf(SKIP_REASON !== null)("deployment race conditions", () => {
+describe("deployment race conditions", () => {
   beforeAll(async () => {
     await db
       .insertInto("projects")

--- a/src/lib/deployer.integration.test.ts
+++ b/src/lib/deployer.integration.test.ts
@@ -11,6 +11,14 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function sanitizeDockerName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 async function waitForDeploymentStatus(
   deploymentId: string,
   targetStatuses: string[],
@@ -67,7 +75,9 @@ describe("deployment race conditions", () => {
       .execute();
 
     for (const d of deployments) {
-      const containerName = `frost-${TEST_SERVICE_ID}-${d.id}`.toLowerCase();
+      const containerName = sanitizeDockerName(
+        `frost-${TEST_SERVICE_ID}-${d.id}`,
+      );
       await stopContainer(containerName);
     }
 

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -45,7 +45,8 @@ export type DeploymentStatus =
   | "building"
   | "deploying"
   | "running"
-  | "failed";
+  | "failed"
+  | "cancelled";
 
 async function updateDeployment(
   id: string,
@@ -74,6 +75,15 @@ async function appendLog(id: string, log: string) {
 
   const existingLog = deployment?.buildLog || "";
   await updateDeployment(id, { buildLog: existingLog + log });
+}
+
+async function isDeploymentCancelled(deploymentId: string): Promise<boolean> {
+  const deployment = await db
+    .selectFrom("deployments")
+    .select("status")
+    .where("id", "=", deploymentId)
+    .executeTakeFirst();
+  return deployment?.status === "cancelled";
 }
 
 function parseEnvVars(envVarsJson: string): Record<string, string> {
@@ -155,6 +165,31 @@ export async function deployService(
     throw new Error("Project not found");
   }
 
+  const inProgressStatuses = [
+    "pending",
+    "cloning",
+    "pulling",
+    "building",
+    "deploying",
+  ];
+  const activeDeployments = await db
+    .selectFrom("deployments")
+    .select(["id", "containerId"])
+    .where("serviceId", "=", serviceId)
+    .where("status", "in", inProgressStatuses)
+    .execute();
+
+  for (const dep of activeDeployments) {
+    if (dep.containerId) {
+      await stopContainer(dep.containerId);
+    }
+    await db
+      .updateTable("deployments")
+      .set({ status: "cancelled", finishedAt: Date.now() })
+      .where("id", "=", dep.id)
+      .execute();
+  }
+
   const deploymentId = nanoid();
   const now = Date.now();
 
@@ -185,7 +220,7 @@ async function runServiceDeployment(
   options?: DeployOptions,
 ) {
   let currentCommitSha = options?.commitSha || "HEAD";
-  const containerName = `frost-${project.id}-${service.name}`.toLowerCase();
+  const containerName = `frost-${service.id}-${deploymentId}`.toLowerCase();
   const networkName = `frost-net-${project.id}`.toLowerCase();
 
   const baseLabels = {
@@ -221,6 +256,10 @@ async function runServiceDeployment(
 
       if (!pullResult.success) {
         throw new Error(pullResult.error || "Pull failed");
+      }
+
+      if (await isDeploymentCancelled(deploymentId)) {
+        return;
       }
 
       await db
@@ -320,6 +359,10 @@ async function runServiceDeployment(
       if (!buildResult.success) {
         throw new Error(buildResult.error || "Build failed");
       }
+
+      if (await isDeploymentCancelled(deploymentId)) {
+        return;
+      }
     }
 
     await db
@@ -403,6 +446,16 @@ async function runServiceDeployment(
       })
       .where("id", "=", deploymentId)
       .execute();
+
+    if (await isDeploymentCancelled(deploymentId)) {
+      return;
+    }
+
+    if (service.currentDeploymentId) {
+      const oldContainerName =
+        `frost-${service.id}-${service.currentDeploymentId}`.toLowerCase();
+      await stopContainer(oldContainerName);
+    }
 
     const hostPort = await getAvailablePort();
     const runResult = await runContainer({
@@ -616,6 +669,32 @@ export async function rollbackDeployment(
     throw new Error("Image no longer available");
   }
 
+  const inProgressStatuses = [
+    "pending",
+    "cloning",
+    "pulling",
+    "building",
+    "deploying",
+  ];
+  const activeDeployments = await db
+    .selectFrom("deployments")
+    .select(["id", "containerId"])
+    .where("serviceId", "=", service.id)
+    .where("id", "!=", deploymentId)
+    .where("status", "in", inProgressStatuses)
+    .execute();
+
+  for (const dep of activeDeployments) {
+    if (dep.containerId) {
+      await stopContainer(dep.containerId);
+    }
+    await db
+      .updateTable("deployments")
+      .set({ status: "cancelled", finishedAt: Date.now() })
+      .where("id", "=", dep.id)
+      .execute();
+  }
+
   await updateDeployment(deploymentId, { status: "deploying" });
 
   runRollbackDeployment(deploymentId, targetDeployment, service, project).catch(
@@ -639,7 +718,7 @@ async function runRollbackDeployment(
   service: Selectable<Service>,
   project: Selectable<Project>,
 ) {
-  const containerName = `frost-${project.id}-${service.name}`.toLowerCase();
+  const containerName = `frost-${service.id}-${deploymentId}`.toLowerCase();
   const networkName = `frost-net-${project.id}`.toLowerCase();
 
   const baseLabels = {
@@ -665,6 +744,12 @@ async function runRollbackDeployment(
     );
 
     await createNetwork(networkName, baseLabels);
+
+    if (service.currentDeploymentId) {
+      const oldContainerName =
+        `frost-${service.id}-${service.currentDeploymentId}`.toLowerCase();
+      await stopContainer(oldContainerName);
+    }
 
     const hostPort = await getAvailablePort();
     const runResult = await runContainer({

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -86,6 +86,14 @@ async function isDeploymentCancelled(deploymentId: string): Promise<boolean> {
   return deployment?.status === "cancelled";
 }
 
+function sanitizeDockerName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 function parseEnvVars(envVarsJson: string): Record<string, string> {
   const envVarsList: EnvVar[] = envVarsJson ? JSON.parse(envVarsJson) : [];
   const envVars: Record<string, string> = {};
@@ -220,8 +228,10 @@ async function runServiceDeployment(
   options?: DeployOptions,
 ) {
   let currentCommitSha = options?.commitSha || "HEAD";
-  const containerName = `frost-${service.id}-${deploymentId}`.toLowerCase();
-  const networkName = `frost-net-${project.id}`.toLowerCase();
+  const containerName = sanitizeDockerName(
+    `frost-${service.id}-${deploymentId}`,
+  );
+  const networkName = sanitizeDockerName(`frost-net-${project.id}`);
 
   const baseLabels = {
     "frost.managed": "true",
@@ -344,8 +354,7 @@ async function runServiceDeployment(
         deploymentId,
       );
 
-      imageName =
-        `frost-${project.id}-${service.name}:${commitSha}`.toLowerCase();
+      imageName = `${sanitizeDockerName(`frost-${project.id}-${service.name}`)}:${commitSha}`;
       const buildResult = await buildImage({
         repoPath,
         imageName,
@@ -452,8 +461,9 @@ async function runServiceDeployment(
     }
 
     if (service.currentDeploymentId) {
-      const oldContainerName =
-        `frost-${service.id}-${service.currentDeploymentId}`.toLowerCase();
+      const oldContainerName = sanitizeDockerName(
+        `frost-${service.id}-${service.currentDeploymentId}`,
+      );
       await stopContainer(oldContainerName);
     }
 
@@ -718,8 +728,10 @@ async function runRollbackDeployment(
   service: Selectable<Service>,
   project: Selectable<Project>,
 ) {
-  const containerName = `frost-${service.id}-${deploymentId}`.toLowerCase();
-  const networkName = `frost-net-${project.id}`.toLowerCase();
+  const containerName = sanitizeDockerName(
+    `frost-${service.id}-${deploymentId}`,
+  );
+  const networkName = sanitizeDockerName(`frost-net-${project.id}`);
 
   const baseLabels = {
     "frost.managed": "true",
@@ -746,8 +758,9 @@ async function runRollbackDeployment(
     await createNetwork(networkName, baseLabels);
 
     if (service.currentDeploymentId) {
-      const oldContainerName =
-        `frost-${service.id}-${service.currentDeploymentId}`.toLowerCase();
+      const oldContainerName = sanitizeDockerName(
+        `frost-${service.id}-${service.currentDeploymentId}`,
+      );
       await stopContainer(oldContainerName);
     }
 

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -175,8 +175,6 @@ export async function runContainer(
     command,
   } = options;
   try {
-    await stopContainer(name);
-
     const allEnvVars = { PORT: String(containerPort), ...envVars };
     const envFlags = Object.entries(allEnvVars)
       .map(([k, v]) => `-e ${k}=${JSON.stringify(v)}`)


### PR DESCRIPTION
## Summary
- Add `cancelled` status to DeploymentStatus type  
- Cancel in-progress deployments when new deploy starts (latest wins)
- Change container naming to `frost-{serviceId}-{deploymentId}` to avoid conflicts
- Stop old container using `currentDeploymentId` before starting new one
- Add cancellation checks in `runServiceDeployment` to abort early if cancelled
- Remove preemptive `stopContainer` from `runContainer()` since we now stop explicitly

## Test plan
- [x] Integration tests for concurrent deploys pass locally
- [x] E2E tests (Test Group 10) verify race condition handling on VPS
- [x] Verify first deployment gets `cancelled` status
- [x] Verify only one container runs per service after rapid deploys
- [x] Verify container name format is `frost-{serviceId}-{deploymentId}`

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)