### PR TITLE
feat: inject FROST_* environment variables into containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ bun run db:gen       # regenerate db types (run after schema changes)
 ./scripts/e2e-test.sh <ip> <api-key>  # run e2e tests - extend when adding features (runs automatically via GitHub Actions on PRs)
 ```
 
+## Testing
+Create a PR to trigger e2e tests via GitHub Actions. Watch CI checks in the PR to verify tests pass.
+
 ## Test locally
 ```bash
 # create project using local fixture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Dev deploy (push local changes to test VPS):
 bun run dev          # start dev server
 bun run build        # production build
 bun run db:gen       # regenerate db types (run after schema changes)
-./scripts/e2e-test.sh <ip> <api-key>  # run e2e tests - extend when adding features
+./scripts/e2e-test.sh <ip> <api-key>  # run e2e tests - extend when adding features (runs automatically via GitHub Actions on PRs)
 ```
 
 ## Test locally

--- a/schema/018-git-metadata.sql
+++ b/schema/018-git-metadata.sql
@@ -1,0 +1,2 @@
+ALTER TABLE deployments ADD COLUMN git_commit_sha TEXT;
+ALTER TABLE deployments ADD COLUMN git_branch TEXT;

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -56,6 +56,8 @@ export interface Deployment {
   volumes: string | null;
   rollbackEligible: Generated<number | null>;
   rollbackSourceId: string | null;
+  gitCommitSha: string | null;
+  gitBranch: string | null;
 }
 
 export interface Domain {


### PR DESCRIPTION
## Summary
- Inject system environment variables (FROST_*) into all containers
- Store full git commit SHA and branch in deployments table for rollback support
- Add e2e tests for FROST_* env vars (Tests 56-59)

## Variables injected
| Variable | Value |
|----------|-------|
| `FROST` | `"1"` |
| `FROST_SERVICE_NAME` | service.name |
| `FROST_SERVICE_ID` | service.id |
| `FROST_PROJECT_NAME` | project.name |
| `FROST_PROJECT_ID` | project.id |
| `FROST_DEPLOYMENT_ID` | deploymentId |
| `FROST_INTERNAL_HOSTNAME` | service.name |
| `FROST_GIT_COMMIT_SHA` | full SHA (repo deploys only) |
| `FROST_GIT_BRANCH` | branch (repo deploys only) |

## Test plan
- [ ] e2e tests pass (Tests 56-59)
- [ ] Core FROST_* vars present in image deploys
- [ ] Git vars absent in image deploys
- [ ] User env vars can override FROST_* vars

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)