### PR TITLE
feat: container resource limits (memory, CPU, shutdown timeout)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Types in `src/lib/db-types.ts` are auto-generated. Never modify manually.
 - Shared components in `src/components/`
 - When unsure about design decisions, do web searches to see how Vercel/Cloud Run/Railway handle it
 - React Query mutations: use `await queryClient.refetchQueries()` in onSuccess, not `invalidateQueries()` (invalidate marks stale but doesn't guarantee immediate refetch)
+- Settings requiring redeploy (env vars, resource limits, health checks): use toast with "Redeploy required" description and Redeploy action button
 
 ## Git Conventions
 

--- a/schema/019-container-limits.sql
+++ b/schema/019-container-limits.sql
@@ -1,0 +1,3 @@
+ALTER TABLE services ADD COLUMN memory_limit TEXT;
+ALTER TABLE services ADD COLUMN cpu_limit REAL;
+ALTER TABLE services ADD COLUMN shutdown_timeout INTEGER;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,8 @@
   --color-foreground: #fafafa;
   --color-card: #171717;
   --color-card-foreground: #fafafa;
+  --color-popover: #171717;
+  --color-popover-foreground: #fafafa;
   --color-primary: #fafafa;
   --color-primary-foreground: #0a0a0a;
   --color-secondary: #262626;

--- a/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
@@ -47,10 +47,20 @@ export function DeploymentRow({
     onRollback?.();
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick();
+    }
+  }
+
   return (
-    <button
-      type="button"
+    // biome-ignore lint/a11y/useSemanticElements: contains nested button for rollback
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
       className={cn(
         "group w-full px-4 py-3 text-left transition-colors hover:bg-neutral-800/50 cursor-pointer",
         selected && "bg-neutral-800",
@@ -90,6 +100,6 @@ export function DeploymentRow({
           </span>
         </div>
       </div>
-    </button>
+    </div>
   );
 }

--- a/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { Loader2, Pencil, Trash2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
@@ -7,10 +8,51 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   useDeleteService,
   useService,
   useUpdateService,
 } from "@/hooks/use-services";
+import { api } from "@/lib/api";
+
+const MEMORY_OPTIONS = [
+  { value: "", label: "No limit" },
+  { value: "256m", label: "256 MB", minGB: 1 },
+  { value: "512m", label: "512 MB", minGB: 1 },
+  { value: "1g", label: "1 GB", minGB: 2 },
+  { value: "2g", label: "2 GB", minGB: 3 },
+  { value: "4g", label: "4 GB", minGB: 5 },
+  { value: "8g", label: "8 GB", minGB: 9 },
+  { value: "16g", label: "16 GB", minGB: 17 },
+  { value: "32g", label: "32 GB", minGB: 33 },
+  { value: "64g", label: "64 GB", minGB: 65 },
+];
+
+const CPU_OPTIONS = [
+  { value: "", label: "No limit" },
+  { value: "0.25", label: "0.25 vCPU", minCpus: 1 },
+  { value: "0.5", label: "0.5 vCPU", minCpus: 1 },
+  { value: "1", label: "1 vCPU", minCpus: 1 },
+  { value: "2", label: "2 vCPU", minCpus: 2 },
+  { value: "4", label: "4 vCPU", minCpus: 4 },
+  { value: "8", label: "8 vCPU", minCpus: 8 },
+  { value: "16", label: "16 vCPU", minCpus: 16 },
+  { value: "32", label: "32 vCPU", minCpus: 32 },
+];
+
+const SHUTDOWN_OPTIONS = [
+  { value: "", label: "Default (10s)" },
+  { value: "10", label: "10 seconds" },
+  { value: "30", label: "30 seconds" },
+  { value: "60", label: "60 seconds" },
+  { value: "120", label: "120 seconds" },
+];
 
 export default function ServiceSettingsPage() {
   const params = useParams();
@@ -26,6 +68,16 @@ export default function ServiceSettingsPage() {
   const [healthType, setHealthType] = useState<"tcp" | "http">("tcp");
   const [healthPath, setHealthPath] = useState("");
   const [healthTimeout, setHealthTimeout] = useState(60);
+
+  const [editingLimits, setEditingLimits] = useState(false);
+  const [memoryLimit, setMemoryLimit] = useState("");
+  const [cpuLimit, setCpuLimit] = useState("");
+  const [shutdownTimeout, setShutdownTimeout] = useState("");
+
+  const { data: hostResources } = useQuery({
+    queryKey: ["hostResources"],
+    queryFn: () => api.health.hostResources(),
+  });
 
   function handleEditHealth() {
     if (service) {
@@ -49,6 +101,36 @@ export default function ServiceSettingsPage() {
       toast.error("Failed to save");
     }
   }
+
+  function handleEditLimits() {
+    if (service) {
+      setMemoryLimit(service.memoryLimit ?? "");
+      setCpuLimit(service.cpuLimit?.toString() ?? "");
+      setShutdownTimeout(service.shutdownTimeout?.toString() ?? "");
+      setEditingLimits(true);
+    }
+  }
+
+  async function handleSaveLimits() {
+    try {
+      await updateMutation.mutateAsync({
+        memoryLimit: memoryLimit || null,
+        cpuLimit: cpuLimit ? Number(cpuLimit) : null,
+        shutdownTimeout: shutdownTimeout ? Number(shutdownTimeout) : null,
+      });
+      toast.success("Resource limits saved");
+      setEditingLimits(false);
+    } catch {
+      toast.error("Failed to save");
+    }
+  }
+
+  const filteredMemoryOptions = MEMORY_OPTIONS.filter(
+    (opt) => !opt.minGB || (hostResources?.totalMemoryGB ?? 0) >= opt.minGB,
+  );
+  const filteredCpuOptions = CPU_OPTIONS.filter(
+    (opt) => !opt.minCpus || (hostResources?.cpus ?? 0) >= opt.minCpus,
+  );
 
   async function handleDelete() {
     if (!confirm("Delete this service? This cannot be undone.")) return;
@@ -227,6 +309,128 @@ export default function ServiceSettingsPage() {
               </span>
               <span className="text-neutral-400">
                 {service.healthCheckTimeout ?? 60}s timeout
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="bg-neutral-900 border-neutral-800">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center justify-between text-sm font-medium text-neutral-300">
+            <span>Resource Limits</span>
+            {!editingLimits && (
+              <Button variant="ghost" size="sm" onClick={handleEditLimits}>
+                <Pencil className="mr-1 h-3 w-3" />
+                Edit
+              </Button>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-4 text-xs text-neutral-500">
+            Limit container CPU and memory usage. Applies on next deployment.
+          </p>
+          {editingLimits ? (
+            <div className="space-y-4">
+              <div>
+                <span className="mb-2 block text-xs text-neutral-500">
+                  Memory Limit
+                </span>
+                <Select value={memoryLimit} onValueChange={setMemoryLimit}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="No limit" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {filteredMemoryOptions.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value || "none"}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <span className="mb-2 block text-xs text-neutral-500">
+                  CPU Limit
+                </span>
+                <Select value={cpuLimit} onValueChange={setCpuLimit}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="No limit" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {filteredCpuOptions.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value || "none"}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-neutral-600">
+                  vCPU = logical CPU (includes hyperthreading)
+                </p>
+              </div>
+
+              <div>
+                <span className="mb-2 block text-xs text-neutral-500">
+                  Shutdown Timeout
+                </span>
+                <Select
+                  value={shutdownTimeout}
+                  onValueChange={setShutdownTimeout}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Default (10s)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SHUTDOWN_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value || "none"}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-neutral-600">
+                  Time between SIGTERM and SIGKILL on stop
+                </p>
+              </div>
+
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleSaveLimits}
+                  disabled={updateMutation.isPending}
+                >
+                  {updateMutation.isPending ? (
+                    <>
+                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                      Saving
+                    </>
+                  ) : (
+                    "Save"
+                  )}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setEditingLimits(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
+                Memory: {service.memoryLimit ?? "No limit"}
+              </span>
+              <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
+                CPU:{" "}
+                {service.cpuLimit ? `${service.cpuLimit} vCPU` : "No limit"}
+              </span>
+              <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
+                Shutdown: {service.shutdownTimeout ?? 10}s
               </span>
             </div>
           )}

--- a/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import {
   useDeleteService,
+  useDeployService,
   useService,
   useUpdateService,
 } from "@/hooks/use-services";
@@ -63,6 +64,7 @@ export default function ServiceSettingsPage() {
   const { data: service } = useService(serviceId);
   const updateMutation = useUpdateService(serviceId, projectId);
   const deleteMutation = useDeleteService(projectId);
+  const deployMutation = useDeployService(serviceId, projectId);
 
   const [editingHealth, setEditingHealth] = useState(false);
   const [healthType, setHealthType] = useState<"tcp" | "http">("tcp");
@@ -98,7 +100,14 @@ export default function ServiceSettingsPage() {
         healthCheckTimeout: healthTimeout,
         shutdownTimeout: shutdownTimeout ? Number(shutdownTimeout) : null,
       });
-      toast.success("Health & lifecycle settings saved");
+      toast.success("Health & lifecycle settings saved", {
+        description: "Redeploy required for changes to take effect",
+        duration: 10000,
+        action: {
+          label: "Redeploy",
+          onClick: () => deployMutation.mutateAsync(),
+        },
+      });
       setEditingHealth(false);
     } catch {
       toast.error("Failed to save");
@@ -119,7 +128,14 @@ export default function ServiceSettingsPage() {
         memoryLimit: memoryLimit || null,
         cpuLimit: cpuLimit ? Number(cpuLimit) : null,
       });
-      toast.success("Resource limits saved");
+      toast.success("Resource limits saved", {
+        description: "Redeploy required for changes to take effect",
+        duration: 10000,
+        action: {
+          label: "Redeploy",
+          onClick: () => deployMutation.mutateAsync(),
+        },
+      });
       setEditingLimits(false);
     } catch {
       toast.error("Failed to save");

--- a/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
@@ -69,10 +69,11 @@ export default function ServiceSettingsPage() {
   const [healthPath, setHealthPath] = useState("");
   const [healthTimeout, setHealthTimeout] = useState(60);
 
+  const [shutdownTimeout, setShutdownTimeout] = useState("");
+
   const [editingLimits, setEditingLimits] = useState(false);
   const [memoryLimit, setMemoryLimit] = useState("");
   const [cpuLimit, setCpuLimit] = useState("");
-  const [shutdownTimeout, setShutdownTimeout] = useState("");
 
   const { data: hostResources } = useQuery({
     queryKey: ["hostResources"],
@@ -85,6 +86,7 @@ export default function ServiceSettingsPage() {
       setHealthType(hasPath ? "http" : "tcp");
       setHealthPath(service.healthCheckPath ?? "");
       setHealthTimeout(service.healthCheckTimeout ?? 60);
+      setShutdownTimeout(service.shutdownTimeout?.toString() ?? "");
       setEditingHealth(true);
     }
   }
@@ -94,8 +96,9 @@ export default function ServiceSettingsPage() {
       await updateMutation.mutateAsync({
         healthCheckPath: healthType === "http" ? healthPath || "/health" : null,
         healthCheckTimeout: healthTimeout,
+        shutdownTimeout: shutdownTimeout ? Number(shutdownTimeout) : null,
       });
-      toast.success("Health check settings saved");
+      toast.success("Health & lifecycle settings saved");
       setEditingHealth(false);
     } catch {
       toast.error("Failed to save");
@@ -106,7 +109,6 @@ export default function ServiceSettingsPage() {
     if (service) {
       setMemoryLimit(service.memoryLimit ?? "");
       setCpuLimit(service.cpuLimit?.toString() ?? "");
-      setShutdownTimeout(service.shutdownTimeout?.toString() ?? "");
       setEditingLimits(true);
     }
   }
@@ -116,7 +118,6 @@ export default function ServiceSettingsPage() {
       await updateMutation.mutateAsync({
         memoryLimit: memoryLimit || null,
         cpuLimit: cpuLimit ? Number(cpuLimit) : null,
-        shutdownTimeout: shutdownTimeout ? Number(shutdownTimeout) : null,
       });
       toast.success("Resource limits saved");
       setEditingLimits(false);
@@ -191,7 +192,7 @@ export default function ServiceSettingsPage() {
       <Card className="bg-neutral-900 border-neutral-800">
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center justify-between text-sm font-medium text-neutral-300">
-            <span>Health Check</span>
+            <span>Health & Lifecycle</span>
             {!editingHealth && (
               <Button variant="ghost" size="sm" onClick={handleEditHealth}>
                 <Pencil className="mr-1 h-3 w-3" />
@@ -202,7 +203,7 @@ export default function ServiceSettingsPage() {
         </CardHeader>
         <CardContent>
           <p className="mb-4 text-xs text-neutral-500">
-            Verify app is responding before marking deployment as successful.
+            Health checks and container lifecycle settings.
           </p>
           {editingHealth ? (
             <div className="space-y-4">
@@ -261,7 +262,7 @@ export default function ServiceSettingsPage() {
 
               <label className="block">
                 <span className="mb-1 block text-xs text-neutral-500">
-                  Timeout (seconds)
+                  Health Check Timeout (seconds)
                 </span>
                 <input
                   type="number"
@@ -275,6 +276,30 @@ export default function ServiceSettingsPage() {
                   Max wait for container to become healthy
                 </p>
               </label>
+
+              <div>
+                <span className="mb-2 block text-xs text-neutral-500">
+                  Shutdown Timeout
+                </span>
+                <Select
+                  value={shutdownTimeout}
+                  onValueChange={setShutdownTimeout}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Default (10s)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SHUTDOWN_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value || "none"}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-neutral-600">
+                  Time between SIGTERM and SIGKILL on stop
+                </p>
+              </div>
 
               <div className="flex gap-2">
                 <Button
@@ -301,14 +326,17 @@ export default function ServiceSettingsPage() {
               </div>
             </div>
           ) : (
-            <div className="flex items-center gap-3 text-sm">
+            <div className="flex flex-wrap items-center gap-3 text-sm">
               <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
                 {service.healthCheckPath
                   ? `HTTP ${service.healthCheckPath}`
                   : "TCP"}
               </span>
-              <span className="text-neutral-400">
-                {service.healthCheckTimeout ?? 60}s timeout
+              <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
+                Health: {service.healthCheckTimeout ?? 60}s
+              </span>
+              <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
+                Shutdown: {service.shutdownTimeout ?? 10}s
               </span>
             </div>
           )}
@@ -372,30 +400,6 @@ export default function ServiceSettingsPage() {
                 </p>
               </div>
 
-              <div>
-                <span className="mb-2 block text-xs text-neutral-500">
-                  Shutdown Timeout
-                </span>
-                <Select
-                  value={shutdownTimeout}
-                  onValueChange={setShutdownTimeout}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Default (10s)" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {SHUTDOWN_OPTIONS.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value || "none"}>
-                        {opt.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="mt-1 text-xs text-neutral-600">
-                  Time between SIGTERM and SIGKILL on stop
-                </p>
-              </div>
-
               <div className="flex gap-2">
                 <Button
                   size="sm"
@@ -428,9 +432,6 @@ export default function ServiceSettingsPage() {
               <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
                 CPU:{" "}
                 {service.cpuLimit ? `${service.cpuLimit} vCPU` : "No limit"}
-              </span>
-              <span className="rounded bg-neutral-800 px-2 py-0.5 font-mono text-xs text-neutral-300">
-                Shutdown: {service.shutdownTimeout ?? 10}s
               </span>
             </div>
           )}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-neutral-700 bg-neutral-800 text-neutral-200 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -35,6 +35,9 @@ export interface Service {
   volumes: string | null;
   tcpProxyPort: number | null;
   currentDeploymentId: string | null;
+  memoryLimit: string | null;
+  cpuLimit: number | null;
+  shutdownTimeout: number | null;
   latestDeployment?: Deployment;
 }
 
@@ -204,6 +207,14 @@ export interface UpdateServiceInput {
   healthCheckPath?: string | null;
   healthCheckTimeout?: number;
   autoDeployEnabled?: boolean;
+  memoryLimit?: string | null;
+  cpuLimit?: number | null;
+  shutdownTimeout?: number | null;
+}
+
+export interface HostResources {
+  cpus: number;
+  totalMemoryGB: number;
 }
 
 async function handleResponse<T>(res: Response): Promise<T> {
@@ -340,6 +351,13 @@ export const api = {
   settings: {
     get: (): Promise<Settings> =>
       fetch("/api/settings").then((r) => handleResponse<Settings>(r)),
+  },
+
+  health: {
+    hostResources: (): Promise<HostResources> =>
+      fetch("/api/host-resources").then((r) =>
+        handleResponse<HostResources>(r),
+      ),
   },
 
   dbTemplates: {

--- a/src/lib/db-schemas.ts
+++ b/src/lib/db-schemas.ts
@@ -312,6 +312,9 @@ export const serviceSchema = z.object({
   volumes: z.string().nullable(),
   tcpProxyPort: z.number().nullable(),
   currentDeploymentId: z.string().nullable(),
+  memoryLimit: z.string().nullable(),
+  cpuLimit: z.number().nullable(),
+  shutdownTimeout: z.number().nullable(),
 });
 
 export const newServiceSchema = z.object({
@@ -333,6 +336,9 @@ export const newServiceSchema = z.object({
   volumes: z.string().nullable().optional(),
   tcpProxyPort: z.number().nullable().optional(),
   currentDeploymentId: z.string().nullable(),
+  memoryLimit: z.string().nullable().optional(),
+  cpuLimit: z.number().nullable().optional(),
+  shutdownTimeout: z.number().nullable().optional(),
 });
 
 export const serviceUpdateSchema = z.object({
@@ -354,6 +360,9 @@ export const serviceUpdateSchema = z.object({
   volumes: z.string().nullable().optional(),
   tcpProxyPort: z.number().nullable().optional(),
   currentDeploymentId: z.string().nullable().optional(),
+  memoryLimit: z.string().nullable().optional(),
+  cpuLimit: z.number().nullable().optional(),
+  shutdownTimeout: z.number().nullable().optional(),
 });
 
 export type Service = z.infer<typeof serviceSchema>;

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -122,6 +122,9 @@ export interface Service {
   volumes: Generated<string | null>;
   tcpProxyPort: Generated<number | null>;
   currentDeploymentId: string | null;
+  memoryLimit: string | null;
+  cpuLimit: number | null;
+  shutdownTimeout: number | null;
 }
 
 export interface Setting {

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -520,6 +520,9 @@ async function runServiceDeployment(
       volumes,
       fileMounts,
       command,
+      memoryLimit: service.memoryLimit ?? undefined,
+      cpuLimit: service.cpuLimit ?? undefined,
+      shutdownTimeout: service.shutdownTimeout ?? undefined,
     });
 
     if (!runResult.success) {
@@ -830,6 +833,9 @@ async function runRollbackDeployment(
         ...baseLabels,
         "frost.deployment.id": deploymentId,
       },
+      memoryLimit: service.memoryLimit ?? undefined,
+      cpuLimit: service.cpuLimit ?? undefined,
+      shutdownTimeout: service.shutdownTimeout ?? undefined,
     });
 
     if (!runResult.success) {

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -156,6 +156,9 @@ export interface RunContainerOptions {
   volumes?: VolumeMount[];
   fileMounts?: FileMount[];
   command?: string[];
+  memoryLimit?: string;
+  cpuLimit?: number;
+  shutdownTimeout?: number;
 }
 
 export async function runContainer(
@@ -173,6 +176,9 @@ export async function runContainer(
     volumes,
     fileMounts,
     command,
+    memoryLimit,
+    cpuLimit,
+    shutdownTimeout,
   } = options;
   try {
     const allEnvVars = { PORT: String(containerPort), ...envVars };
@@ -196,8 +202,13 @@ export async function runContainer(
       : "";
     const commandPart = command ? command.join(" ") : "";
     const logOpts = "--log-opt max-size=10m --log-opt max-file=3";
+    const memoryFlag = memoryLimit ? `--memory ${memoryLimit}` : "";
+    const cpuFlag = cpuLimit ? `--cpus ${cpuLimit}` : "";
+    const stopTimeoutFlag = shutdownTimeout
+      ? `--stop-timeout ${shutdownTimeout}`
+      : "";
     const { stdout } = await execAsync(
-      `docker run -d --restart on-failure:5 ${logOpts} --name ${name} -p ${hostPort}:${containerPort} ${networkFlag} ${hostnameFlag} ${labelFlags} ${volumeFlags} ${fileMountFlags} ${envFlags} ${imageName} ${commandPart}`.replace(
+      `docker run -d --restart on-failure:5 ${logOpts} ${memoryFlag} ${cpuFlag} ${stopTimeoutFlag} --name ${name} -p ${hostPort}:${containerPort} ${networkFlag} ${hostnameFlag} ${labelFlags} ${volumeFlags} ${fileMountFlags} ${envFlags} ${imageName} ${commandPart}`.replace(
         /\s+/g,
         " ",
       ),

--- a/src/server/health.ts
+++ b/src/server/health.ts
@@ -1,3 +1,4 @@
+import * as nodeOs from "node:os";
 import { z } from "zod";
 import { os } from "@/lib/orpc";
 import packageJson from "../../package.json";
@@ -8,5 +9,14 @@ export const health = {
     .output(z.object({ ok: z.boolean(), version: z.string() }))
     .handler(async () => {
       return { ok: true, version: packageJson.version };
+    }),
+
+  hostResources: os
+    .route({ method: "GET", path: "/host-resources" })
+    .output(z.object({ cpus: z.number(), totalMemoryGB: z.number() }))
+    .handler(async () => {
+      const cpus = nodeOs.cpus().length;
+      const totalMemoryGB = Math.floor(nodeOs.totalmem() / 1024 / 1024 / 1024);
+      return { cpus, totalMemoryGB };
     }),
 };

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -97,6 +97,12 @@ export const services = {
         templateId: z.string().optional(),
         healthCheckPath: z.string().optional(),
         healthCheckTimeout: z.number().optional(),
+        memoryLimit: z
+          .string()
+          .regex(/^\d+[kmg]$/i)
+          .optional(),
+        cpuLimit: z.number().min(0.1).max(64).optional(),
+        shutdownTimeout: z.number().min(1).max(300).optional(),
       }),
     )
     .output(serviceSchema)
@@ -200,6 +206,9 @@ export const services = {
             healthCheckPath: input.healthCheckPath ?? null,
             healthCheckTimeout: input.healthCheckTimeout ?? null,
             autoDeploy: input.deployType === "repo" ? 1 : 0,
+            memoryLimit: input.memoryLimit ?? null,
+            cpuLimit: input.cpuLimit ?? null,
+            shutdownTimeout: input.shutdownTimeout ?? null,
             createdAt: now,
           })
           .execute();
@@ -243,6 +252,13 @@ export const services = {
         healthCheckPath: z.string().nullable().optional(),
         healthCheckTimeout: z.number().min(1).max(300).optional(),
         autoDeployEnabled: z.boolean().optional(),
+        memoryLimit: z
+          .string()
+          .regex(/^\d+[kmg]$/i)
+          .nullable()
+          .optional(),
+        cpuLimit: z.number().min(0.1).max(64).nullable().optional(),
+        shutdownTimeout: z.number().min(1).max(300).nullable().optional(),
       }),
     )
     .output(serviceSchema)
@@ -278,6 +294,11 @@ export const services = {
         updates.healthCheckTimeout = input.healthCheckTimeout;
       if (input.autoDeployEnabled !== undefined)
         updates.autoDeploy = input.autoDeployEnabled ? 1 : 0;
+      if (input.memoryLimit !== undefined)
+        updates.memoryLimit = input.memoryLimit;
+      if (input.cpuLimit !== undefined) updates.cpuLimit = input.cpuLimit;
+      if (input.shutdownTimeout !== undefined)
+        updates.shutdownTimeout = input.shutdownTimeout;
 
       if (Object.keys(updates).length > 0) {
         await db


### PR DESCRIPTION
## Summary
- Add memory limit per service (`--memory` docker flag)
- Add CPU limit per service (`--cpus` docker flag)
- Add graceful shutdown timeout (`--stop-timeout` docker flag)
- Auto-detect host resources to filter dropdown options

## UI
User-friendly dropdowns filtered by host capacity:
- Memory: No limit, 256 MB, 512 MB, ... up to 64 GB
- CPU: No limit, 0.25, 0.5, 1, 2, ... up to 32 vCPU
- Shutdown: 10s (default), 30s, 60s, 120s

## Test plan
- [ ] E2E tests pass (Tests 60-62)
- [ ] Resource limits stored in DB correctly
- [ ] Docker inspect shows correct memory/CPU settings
- [ ] Dropdown options filtered based on host resources

Closes #91, #88, #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)