### PR TITLE
feat: add user-configurable volumes for any service

### DIFF
--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -163,10 +163,18 @@ jobs:
           echo "Upgrading from ${{ steps.release.outputs.tag }} to branch: $BRANCH"
 
           ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "cd /opt/frost && \
+            systemctl stop frost && \
             git remote set-url origin https://github.com/${REPO}.git && \
             git fetch origin ${BRANCH} && \
             git checkout ${BRANCH} && \
-            /opt/frost/update.sh"
+            git reset --hard origin/${BRANCH} && \
+            rm -rf node_modules package-lock.json && \
+            export BUN_INSTALL=\"\$HOME/.bun\" && \
+            export PATH=\"\$BUN_INSTALL/bin:\$PATH\" && \
+            NODE_ENV=development npm install --legacy-peer-deps --silent 2>&1 && \
+            npm run build 2>&1 && \
+            bun run migrate 2>&1 && \
+            systemctl start frost"
 
       - name: Wait for Frost (post-upgrade)
         if: steps.release.outputs.skip != 'true'

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1119,7 +1119,7 @@ PROJECT15_ID=$(echo "$PROJECT15" | jq -r '.id')
 echo "Created project: $PROJECT15_ID"
 
 SERVICE15=$(api -X POST "$BASE_URL/api/projects/$PROJECT15_ID/services" \
-  -d '{"name":"volume-test","deployType":"image","imageUrl":"alpine:latest","containerPort":80}')
+  -d '{"name":"volume-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
 SERVICE15_ID=$(echo "$SERVICE15" | jq -r '.id')
 echo "Created service: $SERVICE15_ID"
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1108,6 +1108,115 @@ api -X DELETE "$BASE_URL/api/projects/$PROJECT14_ID" > /dev/null
 echo "Deleted project"
 
 echo ""
+echo "########################################"
+echo "# Test Group 14: User-Configurable Volumes"
+echo "########################################"
+
+echo ""
+echo "=== Test 67: Create service with volume ==="
+PROJECT15=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-volumes"}')
+PROJECT15_ID=$(echo "$PROJECT15" | jq -r '.id')
+echo "Created project: $PROJECT15_ID"
+
+SERVICE15=$(api -X POST "$BASE_URL/api/projects/$PROJECT15_ID/services" \
+  -d '{"name":"volume-test","deployType":"image","imageUrl":"alpine:latest","containerPort":80}')
+SERVICE15_ID=$(echo "$SERVICE15" | jq -r '.id')
+echo "Created service: $SERVICE15_ID"
+
+echo ""
+echo "=== Test 68: Add volume to service ==="
+api -X PATCH "$BASE_URL/api/services/$SERVICE15_ID" \
+  -d '{"volumes":[{"name":"data","path":"/data"}]}' > /dev/null
+
+SERVICE15_UPDATED=$(api "$BASE_URL/api/services/$SERVICE15_ID")
+VOLUMES_JSON=$(echo "$SERVICE15_UPDATED" | jq -r '.volumes')
+echo "Volumes: $VOLUMES_JSON"
+
+if ! echo "$VOLUMES_JSON" | grep -q '"path":"/data"'; then
+  echo "FAIL: Volume not added correctly"
+  exit 1
+fi
+echo "Volume added to service"
+
+echo ""
+echo "=== Test 69: Deploy and verify volume created ==="
+DEPLOY15=$(api -X POST "$BASE_URL/api/services/$SERVICE15_ID/deploy")
+DEPLOY15_ID=$(echo "$DEPLOY15" | jq -r '.deploymentId')
+echo "Deployment: $DEPLOY15_ID"
+wait_for_deployment "$DEPLOY15_ID"
+
+EXPECTED_VOLUME15="frost-${SERVICE15_ID}-data"
+VOLUME15_EXISTS=$(remote "docker volume ls --filter name=$EXPECTED_VOLUME15 --format '{{.Name}}'" 2>&1)
+if ! echo "$VOLUME15_EXISTS" | grep -q "$EXPECTED_VOLUME15"; then
+  echo "FAIL: Volume $EXPECTED_VOLUME15 not created"
+  exit 1
+fi
+echo "Volume created: $EXPECTED_VOLUME15"
+
+BUILD_LOG15=$(api "$BASE_URL/api/deployments/$DEPLOY15_ID" | jq -r '.buildLog')
+if ! echo "$BUILD_LOG15" | grep -q "Created 1 volume(s)"; then
+  echo "FAIL: Volume creation not logged"
+  echo "Build log: $BUILD_LOG15"
+  exit 1
+fi
+echo "Volume creation logged correctly"
+
+echo ""
+echo "=== Test 70: Write file to volume and verify persistence ==="
+CONTAINER15_NAME="frost-${SERVICE15_ID}-${DEPLOY15_ID}"
+CONTAINER15_NAME=$(echo "$CONTAINER15_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9.-]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
+
+remote "docker exec $CONTAINER15_NAME sh -c 'echo test-content > /data/test.txt'"
+FILE_CONTENT=$(remote "docker exec $CONTAINER15_NAME cat /data/test.txt")
+if [ "$FILE_CONTENT" != "test-content" ]; then
+  echo "FAIL: Could not write to volume"
+  exit 1
+fi
+echo "File written to volume"
+
+DEPLOY15B=$(api -X POST "$BASE_URL/api/services/$SERVICE15_ID/deploy")
+DEPLOY15B_ID=$(echo "$DEPLOY15B" | jq -r '.deploymentId')
+echo "Second deployment: $DEPLOY15B_ID"
+wait_for_deployment "$DEPLOY15B_ID"
+
+CONTAINER15B_NAME="frost-${SERVICE15_ID}-${DEPLOY15B_ID}"
+CONTAINER15B_NAME=$(echo "$CONTAINER15B_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9.-]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
+
+FILE_AFTER=$(remote "docker exec $CONTAINER15B_NAME cat /data/test.txt")
+if [ "$FILE_AFTER" != "test-content" ]; then
+  echo "FAIL: File did not persist across redeploy"
+  exit 1
+fi
+echo "File persisted across redeploy!"
+
+echo ""
+echo "=== Test 71: Get volume info via API ==="
+VOLUMES_INFO=$(api "$BASE_URL/api/services/$SERVICE15_ID/volumes")
+VOLUME_PATH=$(echo "$VOLUMES_INFO" | jq -r '.[0].path')
+if [ "$VOLUME_PATH" != "/data" ]; then
+  echo "FAIL: getVolumes endpoint returned wrong path: $VOLUME_PATH"
+  exit 1
+fi
+echo "getVolumes endpoint works"
+
+echo ""
+echo "=== Test 72: Delete service and verify volume cleanup ==="
+api -X DELETE "$BASE_URL/api/services/$SERVICE15_ID" > /dev/null
+sleep 2
+
+VOLUME15_AFTER=$(remote "docker volume ls --filter name=$EXPECTED_VOLUME15 --format '{{.Name}}'" 2>&1)
+if echo "$VOLUME15_AFTER" | grep -q "$EXPECTED_VOLUME15"; then
+  echo "FAIL: Volume should have been deleted with service"
+  exit 1
+fi
+echo "Volume deleted with service"
+
+echo ""
+echo "=== Test 73: Cleanup volumes test project ==="
+api -X DELETE "$BASE_URL/api/projects/$PROJECT15_ID" > /dev/null
+echo "Deleted project"
+
+echo ""
 echo "========================================="
 echo "All E2E tests passed!"
 echo "========================================="

--- a/src/app/projects/[id]/services/[serviceId]/settings/_components/volumes-card.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/_components/volumes-card.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { Loader2, Plus, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { SettingCard } from "@/components/setting-card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  useDeployService,
+  useService,
+  useServiceVolumes,
+  useUpdateService,
+} from "@/hooks/use-services";
+import type { VolumeConfig } from "@/lib/api";
+
+function pathToVolumeName(path: string): string {
+  return path.replace(/^\//, "").replace(/\//g, "-");
+}
+
+interface VolumesCardProps {
+  serviceId: string;
+  projectId: string;
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "-";
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / k ** i).toFixed(1))} ${sizes[i]}`;
+}
+
+export function VolumesCard({ serviceId, projectId }: VolumesCardProps) {
+  const { data: service } = useService(serviceId);
+  const { data: volumeInfo } = useServiceVolumes(serviceId);
+  const updateMutation = useUpdateService(serviceId, projectId);
+  const deployMutation = useDeployService(serviceId, projectId);
+
+  const [volumes, setVolumes] = useState<VolumeConfig[]>([]);
+  const [newPath, setNewPath] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+
+  useEffect(() => {
+    if (service?.volumes) {
+      try {
+        const parsed = JSON.parse(service.volumes) as VolumeConfig[];
+        setVolumes(parsed);
+      } catch {
+        setVolumes([]);
+      }
+    } else {
+      setVolumes([]);
+    }
+  }, [service?.volumes]);
+
+  function handleAddVolume() {
+    if (!newPath.startsWith("/")) {
+      toast.error("Mount path must start with /");
+      return;
+    }
+    if (volumes.some((v) => v.path === newPath)) {
+      toast.error("Volume with this path already exists");
+      return;
+    }
+    const name = pathToVolumeName(newPath);
+    setVolumes([...volumes, { name, path: newPath }]);
+    setNewPath("");
+    setIsAdding(false);
+  }
+
+  function handleRemoveVolume(path: string) {
+    setVolumes(volumes.filter((v) => v.path !== path));
+  }
+
+  async function handleSave() {
+    try {
+      await updateMutation.mutateAsync({ volumes });
+      toast.success("Volumes saved", {
+        description: "Redeploy required for changes to take effect",
+        duration: 10000,
+        action: {
+          label: "Redeploy",
+          onClick: () => deployMutation.mutateAsync(),
+        },
+      });
+    } catch {
+      toast.error("Failed to save");
+    }
+  }
+
+  if (!service) return null;
+
+  const sizeMap = new Map(volumeInfo?.map((v) => [v.path, v.sizeBytes]) ?? []);
+
+  return (
+    <SettingCard
+      title="Volumes"
+      description="Persistent storage that survives redeployments. Data is stored on the host machine."
+      footerLeft={
+        <span className="text-sm text-neutral-500">
+          Adding/removing volumes requires redeploy
+        </span>
+      }
+      footerRight={
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={updateMutation.isPending}
+        >
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            "Save"
+          )}
+        </Button>
+      }
+    >
+      <div className="space-y-4">
+        {volumes.length > 0 && (
+          <div className="rounded border border-neutral-800">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-neutral-800 text-left text-neutral-400">
+                  <th className="px-3 py-2 font-medium">Mount Path</th>
+                  <th className="px-3 py-2 font-medium">Size</th>
+                  <th className="px-3 py-2 font-medium w-16"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {volumes.map((vol) => (
+                  <tr
+                    key={vol.path}
+                    className="border-b border-neutral-800 last:border-0"
+                  >
+                    <td className="px-3 py-2 font-mono text-neutral-200">
+                      {vol.path}
+                    </td>
+                    <td className="px-3 py-2 text-neutral-400">
+                      {formatBytes(sizeMap.get(vol.path) ?? null)}
+                    </td>
+                    <td className="px-3 py-2">
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveVolume(vol.path)}
+                        className="text-neutral-500 hover:text-red-400"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {isAdding ? (
+          <div className="flex items-center gap-2">
+            <Input
+              type="text"
+              value={newPath}
+              onChange={(e) => setNewPath(e.target.value)}
+              placeholder="/data"
+              className="max-w-xs font-mono"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAddVolume();
+                if (e.key === "Escape") {
+                  setIsAdding(false);
+                  setNewPath("");
+                }
+              }}
+            />
+            <Button size="sm" variant="secondary" onClick={handleAddVolume}>
+              Add
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setIsAdding(false);
+                setNewPath("");
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => setIsAdding(true)}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            Add Volume
+          </Button>
+        )}
+      </div>
+    </SettingCard>
+  );
+}

--- a/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
@@ -8,6 +8,7 @@ import { HealthCheckCard } from "./_components/health-check-card";
 import { MemoryLimitCard } from "./_components/memory-limit-card";
 import { RequestTimeoutCard } from "./_components/request-timeout-card";
 import { ShutdownTimeoutCard } from "./_components/shutdown-timeout-card";
+import { VolumesCard } from "./_components/volumes-card";
 
 export default function ServiceSettingsPage() {
   const params = useParams();
@@ -18,6 +19,7 @@ export default function ServiceSettingsPage() {
     <div className="space-y-6">
       <ConfigurationCard serviceId={serviceId} />
       <HealthCheckCard serviceId={serviceId} projectId={projectId} />
+      <VolumesCard serviceId={serviceId} projectId={projectId} />
       <ShutdownTimeoutCard serviceId={serviceId} projectId={projectId} />
       <RequestTimeoutCard serviceId={serviceId} projectId={projectId} />
       <MemoryLimitCard serviceId={serviceId} projectId={projectId} />

--- a/src/hooks/use-services.ts
+++ b/src/hooks/use-services.ts
@@ -72,3 +72,10 @@ export function useDeployService(id: string, projectId: string) {
     },
   });
 }
+
+export function useServiceVolumes(id: string) {
+  return useQuery({
+    queryKey: ["services", id, "volumes"],
+    queryFn: () => api.services.getVolumes(id),
+  });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -197,6 +197,17 @@ export interface MetricsHistory {
   containers: Record<string, MetricsHistoryPoint[]>;
 }
 
+export interface VolumeConfig {
+  name: string;
+  path: string;
+}
+
+export interface VolumeInfo {
+  name: string;
+  path: string;
+  sizeBytes: number | null;
+}
+
 export interface UpdateServiceInput {
   name?: string;
   envVars?: EnvVar[];
@@ -212,6 +223,7 @@ export interface UpdateServiceInput {
   cpuLimit?: number | null;
   shutdownTimeout?: number | null;
   requestTimeout?: number | null;
+  volumes?: VolumeConfig[];
 }
 
 export interface HostResources {
@@ -291,6 +303,11 @@ export const api = {
     deploy: (id: string): Promise<{ deploymentId: string }> =>
       fetch(`/api/services/${id}/deploy`, { method: "POST" }).then((r) =>
         handleResponse<{ deploymentId: string }>(r),
+      ),
+
+    getVolumes: (id: string): Promise<VolumeInfo[]> =>
+      fetch(`/api/services/${id}/volumes`).then((r) =>
+        handleResponse<VolumeInfo[]>(r),
       ),
   },
 

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -419,7 +419,7 @@ async function runServiceDeployment(
     await createNetwork(networkName, baseLabels);
 
     let volumes: VolumeMount[] | undefined;
-    if (service.serviceType === "database" && service.volumes) {
+    if (service.volumes && service.volumes !== "[]") {
       const volumeConfig = JSON.parse(service.volumes) as {
         name: string;
         path: string;
@@ -430,10 +430,7 @@ async function runServiceDeployment(
         await createVolume(volumeName);
         volumes.push({ name: volumeName, path: v.path });
       }
-      await appendLog(
-        deploymentId,
-        `Created ${volumes.length} volume(s) for database\n`,
-      );
+      await appendLog(deploymentId, `Created ${volumes.length} volume(s)\n`);
     }
 
     let fileMounts: FileMount[] | undefined;

--- a/src/lib/docker.integration.test.ts
+++ b/src/lib/docker.integration.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./docker";
 import {
   createVolume,
+  getVolumeSize,
   listFrostVolumes,
   removeVolume,
   volumeExists,
@@ -165,4 +166,17 @@ describe("volume integration", () => {
     await stopContainer(TEST_CONTAINER);
     await removeVolume(volumeName);
   }, 60000);
+
+  test("getVolumeSize returns size for existing volume", async () => {
+    await createVolume(TEST_VOLUME_NAME);
+    const size = await getVolumeSize(TEST_VOLUME_NAME);
+    expect(typeof size).toBe("number");
+    expect(size).toBeGreaterThanOrEqual(0);
+    await removeVolume(TEST_VOLUME_NAME);
+  });
+
+  test("getVolumeSize returns null for non-existent volume", async () => {
+    const size = await getVolumeSize("frost-nonexistent-volume-99999");
+    expect(size).toBeNull();
+  });
 });

--- a/src/lib/volumes.test.ts
+++ b/src/lib/volumes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildVolumeName } from "./volumes";
+import { buildVolumeName, pathToVolumeName } from "./volumes";
 
 describe("volumes", () => {
   test("buildVolumeName creates correct format", () => {
@@ -16,5 +16,17 @@ describe("volumes", () => {
   test("buildVolumeName with nanoid-like service IDs", () => {
     const name = buildVolumeName("V1StGXR8_Z5jdHi6B-myT", "data");
     expect(name).toBe("frost-V1StGXR8_Z5jdHi6B-myT-data");
+  });
+
+  test("pathToVolumeName converts simple path", () => {
+    expect(pathToVolumeName("/data")).toBe("data");
+  });
+
+  test("pathToVolumeName converts nested path", () => {
+    expect(pathToVolumeName("/var/lib/postgres")).toBe("var-lib-postgres");
+  });
+
+  test("pathToVolumeName converts app uploads path", () => {
+    expect(pathToVolumeName("/app/uploads")).toBe("app-uploads");
   });
 });

--- a/src/lib/volumes.ts
+++ b/src/lib/volumes.ts
@@ -47,6 +47,21 @@ export function pathToVolumeName(path: string): string {
   return path.replace(/^\//, "").replace(/\//g, "-");
 }
 
+function parseDockerSize(sizeStr: string): number {
+  const match = sizeStr.match(/^([\d.]+)\s*([KMGT]?B)$/i);
+  if (!match) return 0;
+  const value = parseFloat(match[1]);
+  const unit = match[2].toUpperCase();
+  const units: Record<string, number> = {
+    B: 1,
+    KB: 1024,
+    MB: 1024 ** 2,
+    GB: 1024 ** 3,
+    TB: 1024 ** 4,
+  };
+  return Math.round(value * (units[unit] ?? 1));
+}
+
 export async function getVolumeSize(name: string): Promise<number | null> {
   try {
     const { stdout } = await execAsync(`docker system df -v --format json`);
@@ -56,7 +71,8 @@ export async function getVolumeSize(name: string): Promise<number | null> {
       if (data.Volumes) {
         for (const vol of data.Volumes) {
           if (vol.Name === name) {
-            return vol.UsageSize ?? vol.Size ?? 0;
+            const sizeStr = vol.UsageSize ?? vol.Size ?? "0B";
+            return parseDockerSize(sizeStr);
           }
         }
       }

--- a/src/lib/volumes.ts
+++ b/src/lib/volumes.ts
@@ -42,3 +42,27 @@ export async function volumeExists(name: string): Promise<boolean> {
 export function buildVolumeName(serviceId: string, volumeName: string): string {
   return `frost-${serviceId}-${volumeName}`;
 }
+
+export function pathToVolumeName(path: string): string {
+  return path.replace(/^\//, "").replace(/\//g, "-");
+}
+
+export async function getVolumeSize(name: string): Promise<number | null> {
+  try {
+    const { stdout } = await execAsync(`docker system df -v --format json`);
+    const lines = stdout.trim().split("\n");
+    for (const line of lines) {
+      const data = JSON.parse(line);
+      if (data.Volumes) {
+        for (const vol of data.Volumes) {
+          if (vol.Name === name) {
+            return vol.UsageSize ?? vol.Size ?? 0;
+          }
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Enable users to add persistent volumes to any service via the settings UI
- Volumes persist data across redeployments
- Previously only database services could have volumes (via templates)

## Changes
- Add `pathToVolumeName` and `getVolumeSize` helpers to volumes.ts
- Add volumes field to service update API  
- Add `getVolumes` endpoint for volume info with sizes
- Remove database-only restriction in deployer
- Fix service delete to clean up volumes for all services
- Add VolumesCard settings component
- Add unit/integration/e2e tests

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Unit tests pass (`bun test src/lib/volumes.test.ts`)
- [x] E2E tests pass (GitHub Actions)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)