### PR TITLE
feat: add smooth menu transitions across all navigation

### DIFF
--- a/src/app/projects/[id]/layout.tsx
+++ b/src/app/projects/[id]/layout.tsx
@@ -108,7 +108,7 @@ export default function ProjectLayout({
   return (
     <>
       <BreadcrumbHeader items={[{ label: project.name }]} actions={actions} />
-      <TabNav tabs={tabs} />
+      <TabNav tabs={tabs} layoutId="project-tabs" />
       <main className="container mx-auto px-4 py-8">{children}</main>
     </>
   );

--- a/src/app/projects/[id]/services/[serviceId]/layout.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/layout.tsx
@@ -115,7 +115,7 @@ export default function ServiceLayout({
         ]}
         actions={actions}
       />
-      <TabNav tabs={tabs} />
+      <TabNav tabs={tabs} layoutId="service-tabs" />
       <main className="container mx-auto px-4 py-8">{children}</main>
     </>
   );

--- a/src/app/projects/[id]/settings/_components/settings-sidebar.tsx
+++ b/src/app/projects/[id]/settings/_components/settings-sidebar.tsx
@@ -9,23 +9,25 @@ interface NavItem {
   href: string;
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { id: "general", label: "General", href: "/settings" },
-  { id: "monitoring", label: "Monitoring", href: "/settings/monitoring" },
-  { id: "domain", label: "Domain & SSL", href: "/settings/domain" },
-  { id: "api-keys", label: "API Keys", href: "/settings/api-keys" },
-  { id: "github", label: "GitHub", href: "/settings/github" },
-  { id: "cleanup", label: "Cleanup", href: "/settings/cleanup" },
-];
+function getNavItems(projectId: string): NavItem[] {
+  const base = `/projects/${projectId}/settings`;
+  return [{ id: "general", label: "General", href: base }];
+}
 
 interface SettingsSidebarProps {
+  projectId: string;
   activeSection: string;
 }
 
-export function SettingsSidebar({ activeSection }: SettingsSidebarProps) {
+export function SettingsSidebar({
+  projectId,
+  activeSection,
+}: SettingsSidebarProps) {
+  const navItems = getNavItems(projectId);
+
   return (
     <nav className="space-y-0.5">
-      {NAV_ITEMS.map((item) => {
+      {navItems.map((item) => {
         const isActive =
           activeSection === item.id ||
           (activeSection === "settings" && item.id === "general");
@@ -37,7 +39,7 @@ export function SettingsSidebar({ activeSection }: SettingsSidebarProps) {
           >
             {isActive && (
               <motion.div
-                layoutId="global-settings-indicator"
+                layoutId="project-settings-indicator"
                 className="absolute inset-0 rounded-md bg-neutral-800/80"
                 transition={{ type: "spring", bounce: 0.15, duration: 0.5 }}
               />
@@ -54,10 +56,15 @@ export function SettingsSidebar({ activeSection }: SettingsSidebarProps) {
   );
 }
 
-export function SettingsMobileTabs({ activeSection }: SettingsSidebarProps) {
+export function SettingsMobileTabs({
+  projectId,
+  activeSection,
+}: SettingsSidebarProps) {
+  const navItems = getNavItems(projectId);
+
   return (
     <nav className="flex gap-1 overflow-x-auto pb-4">
-      {NAV_ITEMS.map((item) => {
+      {navItems.map((item) => {
         const isActive =
           activeSection === item.id ||
           (activeSection === "settings" && item.id === "general");
@@ -69,7 +76,7 @@ export function SettingsMobileTabs({ activeSection }: SettingsSidebarProps) {
           >
             {isActive && (
               <motion.div
-                layoutId="global-settings-mobile-indicator"
+                layoutId="project-settings-mobile-indicator"
                 className="absolute inset-0 rounded-md bg-neutral-800/80"
                 transition={{ type: "spring", bounce: 0.15, duration: 0.5 }}
               />

--- a/src/app/projects/[id]/settings/layout.tsx
+++ b/src/app/projects/[id]/settings/layout.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useParams, usePathname } from "next/navigation";
+import {
+  SettingsMobileTabs,
+  SettingsSidebar,
+} from "./_components/settings-sidebar";
+
+export default function ProjectSettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const params = useParams();
+  const projectId = params.id as string;
+
+  const pathname = usePathname();
+  const parts = pathname.split("/");
+  const activeSection = parts[parts.length - 1] || "general";
+
+  return (
+    <div className="flex flex-col gap-8 md:flex-row">
+      <div className="md:hidden">
+        <SettingsMobileTabs
+          projectId={projectId}
+          activeSection={activeSection}
+        />
+      </div>
+
+      <aside className="hidden w-48 shrink-0 md:block">
+        <div className="sticky top-20">
+          <SettingsSidebar
+            projectId={projectId}
+            activeSection={activeSection}
+          />
+        </div>
+      </aside>
+
+      <div className="max-w-2xl flex-1">{children}</div>
+    </div>
+  );
+}

--- a/src/components/tab-nav.tsx
+++ b/src/components/tab-nav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { motion } from "framer-motion";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -11,9 +12,10 @@ interface Tab {
 
 interface TabNavProps {
   tabs: Tab[];
+  layoutId: string;
 }
 
-export function TabNav({ tabs }: TabNavProps) {
+export function TabNav({ tabs, layoutId }: TabNavProps) {
   const pathname = usePathname();
 
   return (
@@ -37,7 +39,11 @@ export function TabNav({ tabs }: TabNavProps) {
             >
               {tab.label}
               {isActive && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-neutral-100" />
+                <motion.span
+                  layoutId={layoutId}
+                  className="absolute bottom-0 left-0 right-0 h-0.5 bg-neutral-100"
+                  transition={{ type: "spring", bounce: 0.15, duration: 0.5 }}
+                />
               )}
             </Link>
           );


### PR DESCRIPTION
## Summary
- Add framer-motion animated indicators to TabNav (underline slides between tabs)
- Add smooth background transitions to global settings sidebar
- Create project settings submenu with animated sidebar (General tab for now)

## Test plan
- [ ] Navigate between project tabs (Services/Variables/Settings) - underline animates
- [ ] Navigate between service tabs (Overview/Deployments/Logs/Settings) - underline animates
- [ ] Navigate between global settings tabs - background animates
- [ ] Navigate to project settings - shows General submenu with animated background
- [ ] Test mobile views for all above

🤖 Generated with [Claude Code](https://claude.com/claude-code)