### PR TITLE
fix: make port allocator thread-safe for concurrent deployments

### DIFF
--- a/scripts/e2e/group-16-concurrent.sh
+++ b/scripts/e2e/group-16-concurrent.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log "=== Concurrent Deployments (Port Allocation) ==="
+
+NUM_SERVICES=5
+PROJECT_IDS=()
+SERVICE_IDS=()
+DEPLOY_IDS=()
+
+log "Creating $NUM_SERVICES projects with services..."
+for i in $(seq 1 $NUM_SERVICES); do
+  PROJECT=$(api -X POST "$BASE_URL/api/projects" -d "{\"name\":\"e2e-concurrent-$i\"}")
+  PROJECT_ID=$(echo "$PROJECT" | jq -r '.id')
+  [ "$PROJECT_ID" = "null" ] || [ -z "$PROJECT_ID" ] && fail "Failed to create project $i"
+  PROJECT_IDS+=("$PROJECT_ID")
+
+  SERVICE=$(api -X POST "$BASE_URL/api/projects/$PROJECT_ID/services" \
+    -d "{\"name\":\"svc-$i\",\"deployType\":\"image\",\"imageUrl\":\"nginx:alpine\",\"containerPort\":80}")
+  SERVICE_ID=$(echo "$SERVICE" | jq -r '.id')
+  [ "$SERVICE_ID" = "null" ] || [ -z "$SERVICE_ID" ] && fail "Failed to create service $i"
+  SERVICE_IDS+=("$SERVICE_ID")
+  log "Created project $i: $PROJECT_ID, service: $SERVICE_ID"
+done
+
+log "Waiting for initial deployments..."
+for i in $(seq 0 $((NUM_SERVICES - 1))); do
+  SERVICE_ID=${SERVICE_IDS[$i]}
+  sleep 1
+  DEPLOY_ID=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments" | jq -r '.[0].id')
+  wait_for_deployment "$DEPLOY_ID" || fail "Initial deployment for service $i failed"
+  log "Service $i initial deployment complete"
+done
+
+log "Triggering $NUM_SERVICES concurrent deployments..."
+for i in $(seq 0 $((NUM_SERVICES - 1))); do
+  SERVICE_ID=${SERVICE_IDS[$i]}
+  DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+  DEPLOY_ID=$(echo "$DEPLOY" | jq -r '.deploymentId')
+  [ "$DEPLOY_ID" = "null" ] || [ -z "$DEPLOY_ID" ] && fail "Failed to trigger deployment for service $i"
+  DEPLOY_IDS+=("$DEPLOY_ID")
+  log "Triggered deployment $DEPLOY_ID for service $i"
+done
+
+log "Waiting for all concurrent deployments..."
+FAILED_COUNT=0
+for i in $(seq 0 $((NUM_SERVICES - 1))); do
+  DEPLOY_ID=${DEPLOY_IDS[$i]}
+  if ! wait_for_deployment "$DEPLOY_ID" 120; then
+    log "Deployment $DEPLOY_ID failed"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+  else
+    log "Deployment $DEPLOY_ID succeeded"
+  fi
+done
+
+[ "$FAILED_COUNT" -gt 0 ] && fail "$FAILED_COUNT of $NUM_SERVICES concurrent deployments failed"
+
+log "Verifying all containers running with unique ports..."
+PORTS=$(remote "docker ps --filter 'label=frost.managed=true' --format '{{.Ports}}' | grep -oE '0\.0\.0\.0:[0-9]+' | cut -d: -f2 | sort")
+UNIQUE_PORTS=$(echo "$PORTS" | sort -u | wc -l)
+TOTAL_PORTS=$(echo "$PORTS" | wc -l)
+
+log "Found $TOTAL_PORTS ports, $UNIQUE_PORTS unique"
+[ "$UNIQUE_PORTS" -lt "$NUM_SERVICES" ] && fail "Expected at least $NUM_SERVICES unique ports for our services"
+
+log "Cleanup..."
+for PROJECT_ID in "${PROJECT_IDS[@]}"; do
+  api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
+done
+
+pass

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -15,7 +15,9 @@ import {
   getAvailablePort,
   getRegistryUrl,
   imageExists,
+  isPortConflictError,
   pullImage,
+  type RunContainerOptions,
   runContainer,
   stopContainer,
   type VolumeMount,
@@ -104,6 +106,38 @@ function parseEnvVars(envVarsJson: string): Record<string, string> {
     envVars[e.key] = e.value;
   }
   return envVars;
+}
+
+const MAX_PORT_ATTEMPTS = 10;
+
+async function runContainerWithPortRetry(
+  options: Omit<RunContainerOptions, "hostPort">,
+  onRetry?: (port: number, attempt: number) => Promise<void>,
+): Promise<{ containerId: string; hostPort: number }> {
+  const triedPorts = new Set<number>();
+
+  for (let attempt = 0; attempt < MAX_PORT_ATTEMPTS; attempt++) {
+    const hostPort = await getAvailablePort(10000, 20000, triedPorts);
+    triedPorts.add(hostPort);
+
+    const result = await runContainer({ ...options, hostPort });
+
+    if (result.success) {
+      return { containerId: result.containerId, hostPort };
+    }
+
+    if (!isPortConflictError(result.error || "")) {
+      throw new Error(result.error || "Failed to start container");
+    }
+
+    if (onRetry) {
+      await onRetry(hostPort, attempt + 1);
+    }
+  }
+
+  throw new Error(
+    `Failed to allocate port after ${MAX_PORT_ATTEMPTS} attempts`,
+  );
 }
 
 function detectRegistryFromImage(imageUrl: string): string | null {
@@ -549,7 +583,6 @@ async function runServiceDeployment(
       await stopContainer(oldContainerName);
     }
 
-    const hostPort = await getAvailablePort();
     const gitInfo =
       service.deployType === "repo" && service.branch
         ? { commitSha: currentCommitSha, branch: service.branch }
@@ -561,33 +594,37 @@ async function runServiceDeployment(
       gitInfo,
     );
     const runtimeEnvVars = { ...frostEnvVars, ...envVars };
-    const runResult = await runContainer({
-      imageName,
-      hostPort,
-      containerPort: service.containerPort ?? undefined,
-      name: containerName,
-      envVars: runtimeEnvVars,
-      network: networkName,
-      hostname: service.name,
-      labels: {
-        ...baseLabels,
-        "frost.deployment.id": deploymentId,
-      },
-      volumes,
-      fileMounts,
-      command,
-      memoryLimit: service.memoryLimit ?? undefined,
-      cpuLimit: service.cpuLimit ?? undefined,
-      shutdownTimeout: service.shutdownTimeout ?? undefined,
-    });
 
-    if (!runResult.success) {
-      throw new Error(runResult.error || "Failed to start container");
-    }
+    const { containerId, hostPort } = await runContainerWithPortRetry(
+      {
+        imageName,
+        containerPort: service.containerPort ?? undefined,
+        name: containerName,
+        envVars: runtimeEnvVars,
+        network: networkName,
+        hostname: service.name,
+        labels: {
+          ...baseLabels,
+          "frost.deployment.id": deploymentId,
+        },
+        volumes,
+        fileMounts,
+        command,
+        memoryLimit: service.memoryLimit ?? undefined,
+        cpuLimit: service.cpuLimit ?? undefined,
+        shutdownTimeout: service.shutdownTimeout ?? undefined,
+      },
+      async (port, attempt) => {
+        await appendLog(
+          deploymentId,
+          `Port ${port} conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
+        );
+      },
+    );
 
     await appendLog(
       deploymentId,
-      `Container started: ${runResult.containerId.substring(0, 12)}\n`,
+      `Container started: ${containerId.substring(0, 12)}\n`,
     );
     const healthCheckType = service.healthCheckPath
       ? `HTTP ${service.healthCheckPath}`
@@ -598,7 +635,7 @@ async function runServiceDeployment(
     );
 
     const isHealthy = await waitForHealthy({
-      containerId: runResult.containerId,
+      containerId,
       port: hostPort,
       path: service.healthCheckPath,
       timeoutSeconds: service.healthCheckTimeout ?? 60,
@@ -609,8 +646,8 @@ async function runServiceDeployment(
 
     await updateDeployment(deploymentId, {
       status: "running",
-      containerId: runResult.containerId,
-      hostPort: hostPort,
+      containerId,
+      hostPort,
       finishedAt: Date.now(),
     });
 
@@ -862,7 +899,6 @@ async function runRollbackDeployment(
       await stopContainer(oldContainerName);
     }
 
-    const hostPort = await getAvailablePort();
     const gitInfo =
       sourceDeployment.gitCommitSha && sourceDeployment.gitBranch
         ? {
@@ -877,30 +913,38 @@ async function runRollbackDeployment(
       gitInfo,
     );
     const runtimeEnvVars = { ...frostEnvVars, ...envVars };
-    const runResult = await runContainer({
-      imageName: sourceDeployment.imageName!,
-      hostPort,
-      containerPort: sourceDeployment.containerPort ?? undefined,
-      name: containerName,
-      envVars: runtimeEnvVars,
-      network: networkName,
-      hostname: service.name,
-      labels: {
-        ...baseLabels,
-        "frost.deployment.id": deploymentId,
-      },
-      memoryLimit: service.memoryLimit ?? undefined,
-      cpuLimit: service.cpuLimit ?? undefined,
-      shutdownTimeout: service.shutdownTimeout ?? undefined,
-    });
 
-    if (!runResult.success) {
-      throw new Error(runResult.error || "Failed to start container");
+    if (!sourceDeployment.imageName) {
+      throw new Error("Source deployment has no image");
     }
+
+    const { containerId, hostPort } = await runContainerWithPortRetry(
+      {
+        imageName: sourceDeployment.imageName,
+        containerPort: sourceDeployment.containerPort ?? undefined,
+        name: containerName,
+        envVars: runtimeEnvVars,
+        network: networkName,
+        hostname: service.name,
+        labels: {
+          ...baseLabels,
+          "frost.deployment.id": deploymentId,
+        },
+        memoryLimit: service.memoryLimit ?? undefined,
+        cpuLimit: service.cpuLimit ?? undefined,
+        shutdownTimeout: service.shutdownTimeout ?? undefined,
+      },
+      async (port, attempt) => {
+        await appendLog(
+          deploymentId,
+          `Port ${port} conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
+        );
+      },
+    );
 
     await appendLog(
       deploymentId,
-      `Container started: ${runResult.containerId.substring(0, 12)}\n`,
+      `Container started: ${containerId.substring(0, 12)}\n`,
     );
 
     const healthCheckType = sourceDeployment.healthCheckPath
@@ -912,7 +956,7 @@ async function runRollbackDeployment(
     );
 
     const isHealthy = await waitForHealthy({
-      containerId: runResult.containerId,
+      containerId,
       port: hostPort,
       path: sourceDeployment.healthCheckPath,
       timeoutSeconds: sourceDeployment.healthCheckTimeout ?? 60,
@@ -924,8 +968,8 @@ async function runRollbackDeployment(
 
     await updateDeployment(deploymentId, {
       status: "running",
-      containerId: runResult.containerId,
-      hostPort: hostPort,
+      containerId,
+      hostPort,
       finishedAt: Date.now(),
     });
 

--- a/src/lib/deployer.ts
+++ b/src/lib/deployer.ts
@@ -15,6 +15,7 @@ import {
   getAvailablePort,
   getRegistryUrl,
   imageExists,
+  isContainerNameConflictError,
   isPortConflictError,
   pullImage,
   type RunContainerOptions,
@@ -126,8 +127,16 @@ async function runContainerWithPortRetry(
       return { containerId: result.containerId, hostPort };
     }
 
-    if (!isPortConflictError(result.error || "")) {
-      throw new Error(result.error || "Failed to start container");
+    const error = result.error || "";
+    const isRetryable =
+      isPortConflictError(error) || isContainerNameConflictError(error);
+
+    if (!isRetryable) {
+      throw new Error(error || "Failed to start container");
+    }
+
+    if (isContainerNameConflictError(error)) {
+      await stopContainer(options.name);
     }
 
     if (onRetry) {

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -358,9 +358,18 @@ export async function waitForHealthy(
   return false;
 }
 
+export function isPortConflictError(error: string): boolean {
+  return (
+    error.includes("port is already allocated") ||
+    error.includes("address already in use") ||
+    error.includes("Bind for 0.0.0.0:")
+  );
+}
+
 export async function getAvailablePort(
   start: number = 10000,
   end: number = 20000,
+  exclude?: Set<number>,
 ): Promise<number> {
   const usedPorts = new Set<number>();
 
@@ -375,7 +384,7 @@ export async function getAvailablePort(
   }
 
   for (let port = start; port < end; port++) {
-    if (!usedPorts.has(port)) {
+    if (!usedPorts.has(port) && !exclude?.has(port)) {
       return port;
     }
   }

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -366,6 +366,10 @@ export function isPortConflictError(error: string): boolean {
   );
 }
 
+export function isContainerNameConflictError(error: string): boolean {
+  return error.includes("is already in use by container");
+}
+
 export async function getAvailablePort(
   start: number = 10000,
   end: number = 20000,


### PR DESCRIPTION
## Summary
- Add retry logic with port exclusion for concurrent deployments
- Previously, concurrent deployments could grab the same port causing "port is already allocated" errors
- Now retries up to 10 times with different ports on conflict

## Test plan
- [ ] Verify e2e test group-16-concurrent passes (tests 5 concurrent deployments)
- [ ] Verify existing e2e tests still pass

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)