### PR TITLE
fix: copy hidden files in tarball creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,8 +167,8 @@ jobs:
       - name: Create release tarball
         run: |
           VERSION="${{ steps.new.outputs.version }}"
-          mkdir -p frost-release/.next
-          cp -r .next/standalone/* frost-release/
+          mkdir -p frost-release
+          cp -r .next/standalone/. frost-release/
           cp -r .next/static frost-release/.next/static
           cp -r schema scripts frost-release/
           mkdir -p frost-release/src


### PR DESCRIPTION
## Summary
- Fix glob `*` not matching hidden directories like `.next/`
- Use `cp -r source/. dest/` to include hidden files

The v0.3.1 release failed because `.next/standalone/.next/` wasn't being copied to the tarball.

## Test plan
- [ ] CI passes
- [ ] Release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)