### PR TITLE
feat: allow editing service configuration after creation

### DIFF
--- a/src/app/projects/[id]/services/[serviceId]/settings/_components/build-config-card.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/_components/build-config-card.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { SettingCard } from "@/components/setting-card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  useDeployService,
+  useService,
+  useUpdateService,
+} from "@/hooks/use-services";
+
+interface BuildConfigCardProps {
+  serviceId: string;
+  projectId: string;
+}
+
+export function BuildConfigCard({
+  serviceId,
+  projectId,
+}: BuildConfigCardProps) {
+  const { data: service } = useService(serviceId);
+  const updateMutation = useUpdateService(serviceId, projectId);
+  const deployMutation = useDeployService(serviceId, projectId);
+
+  const [branch, setBranch] = useState("");
+  const [dockerfilePath, setDockerfilePath] = useState("");
+  const initialValues = useRef({ branch: "", dockerfilePath: "" });
+
+  useEffect(() => {
+    if (service) {
+      const b = service.branch ?? "main";
+      const d = service.dockerfilePath ?? "Dockerfile";
+      setBranch(b);
+      setDockerfilePath(d);
+      initialValues.current = { branch: b, dockerfilePath: d };
+    }
+  }, [service]);
+
+  const hasChanges =
+    branch !== initialValues.current.branch ||
+    dockerfilePath !== initialValues.current.dockerfilePath;
+
+  async function handleSave() {
+    try {
+      await updateMutation.mutateAsync({
+        branch: branch.trim() || "main",
+        dockerfilePath: dockerfilePath.trim() || "Dockerfile",
+      });
+      initialValues.current = { branch, dockerfilePath };
+      toast.success("Build configuration saved", {
+        description: "Redeploy required for changes to take effect",
+        duration: 10000,
+        action: {
+          label: "Redeploy",
+          onClick: () => deployMutation.mutateAsync(),
+        },
+      });
+    } catch {
+      toast.error("Failed to save");
+    }
+  }
+
+  if (!service || service.deployType !== "repo") return null;
+
+  return (
+    <SettingCard
+      title="Build Configuration"
+      description="Git branch and Dockerfile path for building this service."
+      footerRight={
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={updateMutation.isPending || !hasChanges}
+        >
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            "Save"
+          )}
+        </Button>
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <span className="mb-2 block text-sm text-neutral-400">Branch</span>
+          <Input
+            value={branch}
+            onChange={(e) => setBranch(e.target.value)}
+            placeholder="main"
+            className="max-w-sm font-mono"
+          />
+        </div>
+        <div>
+          <span className="mb-2 block text-sm text-neutral-400">
+            Dockerfile Path
+          </span>
+          <Input
+            value={dockerfilePath}
+            onChange={(e) => setDockerfilePath(e.target.value)}
+            placeholder="Dockerfile"
+            className="max-w-sm font-mono"
+          />
+        </div>
+      </div>
+    </SettingCard>
+  );
+}

--- a/src/app/projects/[id]/services/[serviceId]/settings/_components/image-config-card.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/_components/image-config-card.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { SettingCard } from "@/components/setting-card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useDeployService,
+  useService,
+  useUpdateService,
+} from "@/hooks/use-services";
+
+interface Registry {
+  id: string;
+  name: string;
+  type: string;
+}
+
+interface ImageConfigCardProps {
+  serviceId: string;
+  projectId: string;
+}
+
+export function ImageConfigCard({
+  serviceId,
+  projectId,
+}: ImageConfigCardProps) {
+  const { data: service } = useService(serviceId);
+  const updateMutation = useUpdateService(serviceId, projectId);
+  const deployMutation = useDeployService(serviceId, projectId);
+
+  const [imageUrl, setImageUrl] = useState("");
+  const [registryId, setRegistryId] = useState("");
+  const initialValues = useRef({ imageUrl: "", registryId: "" });
+
+  const { data: registries } = useQuery({
+    queryKey: ["registries"],
+    queryFn: async () => {
+      const res = await fetch("/api/registries");
+      return res.json() as Promise<Registry[]>;
+    },
+  });
+
+  useEffect(() => {
+    if (service) {
+      const url = service.imageUrl ?? "";
+      const reg = service.registryId ?? "";
+      setImageUrl(url);
+      setRegistryId(reg);
+      initialValues.current = { imageUrl: url, registryId: reg };
+    }
+  }, [service]);
+
+  const hasChanges =
+    imageUrl !== initialValues.current.imageUrl ||
+    registryId !== initialValues.current.registryId;
+
+  async function handleSave() {
+    if (!imageUrl.trim()) {
+      toast.error("Image URL is required");
+      return;
+    }
+    try {
+      await updateMutation.mutateAsync({
+        imageUrl: imageUrl.trim(),
+        registryId: registryId || null,
+      });
+      initialValues.current = { imageUrl, registryId };
+      toast.success("Image configuration saved", {
+        description: "Redeploy required for changes to take effect",
+        duration: 10000,
+        action: {
+          label: "Redeploy",
+          onClick: () => deployMutation.mutateAsync(),
+        },
+      });
+    } catch {
+      toast.error("Failed to save");
+    }
+  }
+
+  if (!service || service.deployType !== "image") return null;
+
+  return (
+    <SettingCard
+      title="Image Configuration"
+      description="Docker image and registry for pulling this service."
+      footerRight={
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={updateMutation.isPending || !hasChanges}
+        >
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            "Save"
+          )}
+        </Button>
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <span className="mb-2 block text-sm text-neutral-400">Image URL</span>
+          <Input
+            value={imageUrl}
+            onChange={(e) => setImageUrl(e.target.value)}
+            placeholder="nginx:latest"
+            className="max-w-md font-mono"
+          />
+        </div>
+        <div>
+          <span className="mb-2 block text-sm text-neutral-400">Registry</span>
+          <Select value={registryId} onValueChange={setRegistryId}>
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="Auto-detect" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">Auto-detect</SelectItem>
+              {registries?.map((reg) => (
+                <SelectItem key={reg.id} value={reg.id}>
+                  {reg.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </SettingCard>
+  );
+}

--- a/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/settings/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import { BuildConfigCard } from "./_components/build-config-card";
 import { DangerZoneCard } from "./_components/danger-zone-card";
+import { ImageConfigCard } from "./_components/image-config-card";
 import { ServiceNameCard } from "./_components/service-name-card";
 
 export default function ServiceSettingsPage() {
@@ -12,6 +14,8 @@ export default function ServiceSettingsPage() {
   return (
     <div className="space-y-6">
       <ServiceNameCard serviceId={serviceId} projectId={projectId} />
+      <BuildConfigCard serviceId={serviceId} projectId={projectId} />
+      <ImageConfigCard serviceId={serviceId} projectId={projectId} />
       <DangerZoneCard serviceId={serviceId} projectId={projectId} />
     </div>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -228,6 +228,7 @@ export interface UpdateServiceInput {
   shutdownTimeout?: number | null;
   requestTimeout?: number | null;
   volumes?: VolumeConfig[];
+  registryId?: string | null;
 }
 
 export interface HostResources {


### PR DESCRIPTION
## Summary
- Add `BuildConfigCard` for repo services: edit branch, Dockerfile path
- Add `ImageConfigCard` for image services: edit image URL, registry
- Add `registryId` to `UpdateServiceInput` type

Changes show "Redeploy required" toast with action button after saving.

Closes #151

## Test plan
- [ ] Create repo service, verify Build Configuration card appears
- [ ] Edit branch/dockerfile path, save, verify toast
- [ ] Create image service, verify Image Configuration card appears
- [ ] Edit image URL/registry, save, verify toast
- [ ] Click Redeploy in toast, verify deployment starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)