### PR TITLE
fix: hide project nav on add service page

### DIFF
--- a/src/app/projects/[id]/layout.tsx
+++ b/src/app/projects/[id]/layout.tsx
@@ -19,7 +19,9 @@ export default function ProjectLayout({
   const pathname = usePathname();
   const projectId = params.id as string;
 
-  const isServiceRoute = pathname.includes("/services/") && params.serviceId;
+  const isServiceRoute =
+    (pathname.includes("/services/") && params.serviceId) ||
+    pathname.endsWith("/services/new");
 
   const { data: project, isLoading } = useProject(projectId);
   const deployProjectMutation = useDeployProject(projectId);


### PR DESCRIPTION
## Summary
- Extend `isServiceRoute` check to also match `/services/new` path
- Fixes double navigation (project TabNav + page BreadcrumbHeader) when adding a new service

Closes #146

## Test plan
- [ ] Navigate to `/projects/{id}/services/new`
- [ ] Verify single navigation header appears
- [ ] Verify existing service routes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)