### PR TITLE
fix: clear update notification after successful update

### DIFF
--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -226,7 +226,13 @@ export async function getUpdateStatus(): Promise<UpdateInfo> {
   const lastCheck = lastCheckStr ? Number.parseInt(lastCheckStr, 10) : null;
   const availableVersion = await getSetting("update_available");
 
-  if (!availableVersion) {
+  if (
+    !availableVersion ||
+    compareVersions(currentVersion, availableVersion) >= 0
+  ) {
+    if (availableVersion) {
+      await setSetting("update_available", "");
+    }
     return {
       currentVersion,
       availableVersion: null,


### PR DESCRIPTION
## Summary
- Auto-clear stale `update_available` setting when `currentVersion >= availableVersion`
- Fixes update badge/button showing after successful Frost update

Fixes #147

## Test plan
- [ ] CI passes (typecheck, lint, e2e tests)
- [ ] Manual test: apply update on test VPS, verify notification clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)