### PR TITLE
feat: make install API key optional

### DIFF
--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -136,7 +136,7 @@ jobs:
 
           echo "Installing Frost $TAG from: $INSTALL_URL"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt
+          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG'" 2>&1 | tee /tmp/install-output.txt
 
           API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
 

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -136,7 +136,7 @@ jobs:
 
           echo "Installing Frost $TAG from: $INSTALL_URL"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG'" 2>&1 | tee /tmp/install-output.txt
+          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt
 
           API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
 

--- a/.github/workflows/e2e-vps.yml
+++ b/.github/workflows/e2e-vps.yml
@@ -116,7 +116,7 @@ jobs:
           echo "Using branch: $BRANCH"
 
           # Stream output to both file and stdout for debugging
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -b '$BRANCH'" 2>&1 | tee /tmp/install-output.txt
+          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -b '$BRANCH' --create-api-key" 2>&1 | tee /tmp/install-output.txt
 
           API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
 

--- a/install.sh
+++ b/install.sh
@@ -14,12 +14,19 @@ FROST_REPO="https://github.com/elitan/frost"
 FROST_VERSION=""
 FROST_BRANCH=""
 USE_TARBALL=true
+CREATE_API_KEY=false
+
+for arg in "$@"; do
+  case $arg in
+    --create-api-key) CREATE_API_KEY=true; shift ;;
+  esac
+done
 
 while getopts "v:b:" opt; do
   case $opt in
     v) FROST_VERSION="$OPTARG" ;;
     b) FROST_BRANCH="$OPTARG"; USE_TARBALL=false ;;
-    *) echo "Usage: $0 [-v version] [-b branch]"; exit 1 ;;
+    *) echo "Usage: $0 [-v version] [-b branch] [--create-api-key]"; exit 1 ;;
   esac
 done
 
@@ -304,19 +311,19 @@ fi
 # Get server IP
 SERVER_IP=$(curl -s ifconfig.me 2>/dev/null || curl -s api.ipify.org 2>/dev/null || echo "YOUR_SERVER_IP")
 
-# Create initial API key
-echo "Creating initial API key..."
-FROST_API_KEY=$(FROST_JWT_SECRET="$FROST_JWT_SECRET" bun run scripts/create-api-key.ts install)
-
 echo ""
 echo -e "${GREEN}Installation complete!${NC}"
 echo ""
 echo -e "Frost is running at: ${GREEN}http://$SERVER_IP${NC}"
-echo ""
-echo -e "API Key: ${YELLOW}$FROST_API_KEY${NC}"
-echo "(use with X-Frost-Token header)"
-echo ""
-echo "You can manage API keys in Settings > API Keys"
+
+if [ "$CREATE_API_KEY" = true ]; then
+  echo ""
+  echo "Creating API key..."
+  FROST_API_KEY=$(FROST_JWT_SECRET="$FROST_JWT_SECRET" bun run scripts/create-api-key.ts install)
+  echo -e "API Key: ${YELLOW}$FROST_API_KEY${NC}"
+  echo "(use with X-Frost-Token header)"
+fi
+
 echo ""
 echo "Next steps:"
 echo "  1. Point your domain to $SERVER_IP"


### PR DESCRIPTION
## Summary
- Add `--create-api-key` flag to `install.sh` (default: OFF)
- API key only created when flag is passed
- CI workflows updated to pass the flag

Fixes #149

## Test plan
- [ ] CI e2e tests pass (install uses `--create-api-key`)
- [ ] Manual: fresh install without flag → no "install" key in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)