### PR TITLE
feat: persist update status to DB

### DIFF
--- a/src/app/api/updates/result/route.ts
+++ b/src/app/api/updates/result/route.ts
@@ -1,12 +1,25 @@
 import { NextResponse } from "next/server";
-import { clearUpdateResult, getUpdateResult } from "@/lib/updater";
+import {
+  clearPersistedUpdateResult,
+  getPersistedUpdateResult,
+} from "@/lib/updater";
 
 export async function GET() {
-  const result = getUpdateResult();
+  const result = await getPersistedUpdateResult();
 
-  if (result.completed) {
-    clearUpdateResult();
+  if (!result) {
+    return NextResponse.json({
+      completed: false,
+      success: false,
+      newVersion: null,
+      log: null,
+    });
   }
 
   return NextResponse.json(result);
+}
+
+export async function DELETE() {
+  await clearPersistedUpdateResult();
+  return NextResponse.json({ success: true });
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -3,6 +3,9 @@ export async function register() {
     const { runMigrations } = await import("./lib/migrate");
     runMigrations();
 
+    const { persistUpdateResult } = await import("./lib/updater");
+    await persistUpdateResult();
+
     const { startMetricsCollector } = await import("./lib/metrics-collector");
     startMetricsCollector();
   }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -321,3 +321,42 @@ export function clearUpdateResult(): void {
     unlinkSync(UPDATE_LOG_PATH);
   }
 }
+
+export async function persistUpdateResult(): Promise<void> {
+  const result = getUpdateResult();
+  if (!result.completed) {
+    return;
+  }
+
+  await setSetting("update_result_success", result.success ? "true" : "false");
+  await setSetting("update_result_version", result.newVersion || "");
+  await setSetting("update_result_log", result.log || "");
+  await setSetting("update_result_at", Date.now().toString());
+
+  clearUpdateResult();
+}
+
+export async function getPersistedUpdateResult(): Promise<UpdateResult | null> {
+  const resultAt = await getSetting("update_result_at");
+  if (!resultAt) {
+    return null;
+  }
+
+  const success = (await getSetting("update_result_success")) === "true";
+  const newVersion = await getSetting("update_result_version");
+  const log = await getSetting("update_result_log");
+
+  return {
+    completed: true,
+    success,
+    newVersion: newVersion || null,
+    log: log || null,
+  };
+}
+
+export async function clearPersistedUpdateResult(): Promise<void> {
+  await setSetting("update_result_success", "");
+  await setSetting("update_result_version", "");
+  await setSetting("update_result_log", "");
+  await setSetting("update_result_at", "");
+}


### PR DESCRIPTION
## Summary
- On app startup, persists update result from file to DB settings table
- Frontend fetches persisted result on mount and shows success/failure banner
- Dismiss button clears from DB via DELETE endpoint

Fixes issue where users couldn't see update result if they closed browser mid-update.

## Test plan
- [ ] Trigger update from UI
- [ ] Close browser immediately
- [ ] Wait for update to complete (~30s)
- [ ] Reopen browser, navigate to Settings > System
- [ ] Should see "Update complete" or "Update failed" banner
- [ ] Click dismiss, banner should disappear
- [ ] Refresh page, banner should stay gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)