### PR TITLE
fix: sync badge update with DNS/SSL verification toast

### DIFF
--- a/src/hooks/use-domains.ts
+++ b/src/hooks/use-domains.ts
@@ -48,11 +48,14 @@ export function useDeleteDomain(serviceId: string) {
 export function useVerifyDomainDns(serviceId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.domains.verifyDns(id),
-    onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: ["services", serviceId, "domains"],
-      });
+    mutationFn: async (id: string) => {
+      const result = await api.domains.verifyDns(id);
+      if (result.dnsVerified) {
+        await queryClient.refetchQueries({
+          queryKey: ["services", serviceId, "domains"],
+        });
+      }
+      return result;
     },
   });
 }
@@ -60,11 +63,14 @@ export function useVerifyDomainDns(serviceId: string) {
 export function useVerifyDomainSsl(serviceId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.domains.verifySsl(id),
-    onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: ["services", serviceId, "domains"],
-      });
+    mutationFn: async (id: string) => {
+      const result = await api.domains.verifySsl(id);
+      if (result.working) {
+        await queryClient.refetchQueries({
+          queryKey: ["services", serviceId, "domains"],
+        });
+      }
+      return result;
     },
   });
 }


### PR DESCRIPTION
## Summary
- Move `refetchQueries` from `onSuccess` into `mutationFn` for domain verification mutations
- Badge now updates simultaneously with toast when DNS/SSL verification succeeds
- Fixes race condition where `mutateAsync` resolved before `onSuccess` finished refetching

## Test plan
- [ ] Add custom domain to service
- [ ] Configure DNS to point to server IP
- [ ] Wait for polling to detect verified DNS
- [ ] Verify toast and badge update happen simultaneously (no hard refresh needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)