### PR TITLE
feat: display preferred URL (custom > wildcard > IP:port)

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useProject } from "@/hooks/use-projects";
 import { api } from "@/lib/api";
+import { getPreferredDomain } from "@/lib/service-url";
 import { ServiceCard } from "./_components/service-card";
 
 export default function ProjectServicesPage() {
@@ -29,9 +30,9 @@ export default function ProjectServicesPage() {
       const domainMap: Record<string, string> = {};
       for (const service of project!.services || []) {
         const serviceDomains = await api.domains.list(service.id);
-        const systemDomain = serviceDomains.find((d) => d.isSystem === 1);
-        if (systemDomain) {
-          domainMap[service.id] = systemDomain.domain;
+        const preferred = getPreferredDomain(serviceDomains);
+        if (preferred) {
+          domainMap[service.id] = preferred.domain;
         }
       }
       setDomains(domainMap);

--- a/src/app/projects/[id]/services/[serviceId]/page.tsx
+++ b/src/app/projects/[id]/services/[serviceId]/page.tsx
@@ -21,6 +21,7 @@ import { useDeployService, useService } from "@/hooks/use-services";
 import type { Deployment, Domain, EnvVar } from "@/lib/api";
 import { api } from "@/lib/api";
 import { buildConnectionString } from "@/lib/db-templates";
+import { getPreferredDomain } from "@/lib/service-url";
 import { getTimeAgo } from "@/lib/time";
 import { ServiceMetricsCard } from "./_components/service-metrics-card";
 
@@ -84,7 +85,7 @@ export default function ServiceOverviewPage() {
   const queryClient = useQueryClient();
 
   const [serverIp, setServerIp] = useState<string | null>(null);
-  const [systemDomain, setSystemDomain] = useState<Domain | null>(null);
+  const [preferredDomain, setPreferredDomain] = useState<Domain | null>(null);
   const [currentDeployment, setCurrentDeployment] = useState<Deployment | null>(
     null,
   );
@@ -134,8 +135,7 @@ export default function ServiceOverviewPage() {
   useEffect(() => {
     if (!serviceId) return;
     api.domains.list(serviceId).then((domains) => {
-      const sys = domains.find((d) => d.isSystem === 1);
-      setSystemDomain(sys ?? null);
+      setPreferredDomain(getPreferredDomain(domains));
     });
   }, [serviceId]);
 
@@ -182,8 +182,8 @@ export default function ServiceOverviewPage() {
                   {service.serviceType !== "database" && (
                     <a
                       href={
-                        systemDomain
-                          ? `https://${systemDomain.domain}`
+                        preferredDomain
+                          ? `https://${preferredDomain.domain}`
                           : `http://${serverIp || "localhost"}:${currentDeployment.hostPort}`
                       }
                       target="_blank"
@@ -198,16 +198,16 @@ export default function ServiceOverviewPage() {
                 {service.serviceType !== "database" && (
                   <a
                     href={
-                      systemDomain
-                        ? `https://${systemDomain.domain}`
+                      preferredDomain
+                        ? `https://${preferredDomain.domain}`
                         : `http://${serverIp || "localhost"}:${currentDeployment.hostPort}`
                     }
                     target="_blank"
                     rel="noopener noreferrer"
                     className="block font-mono text-sm text-blue-400 hover:text-blue-300 truncate"
                   >
-                    {systemDomain
-                      ? systemDomain.domain
+                    {preferredDomain
+                      ? preferredDomain.domain
                       : `${serverIp || "localhost"}:${currentDeployment.hostPort}`}
                   </a>
                 )}

--- a/src/lib/service-url.test.ts
+++ b/src/lib/service-url.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Domain } from "./api";
 import { getPreferredDomain, getServiceUrl } from "./service-url";
 
-function makeDomain(
-  overrides: Partial<Domain> & { domain: string },
-): Domain {
+function makeDomain(overrides: Partial<Domain> & { domain: string }): Domain {
   return {
     id: "d1",
     serviceId: "s1",

--- a/src/lib/service-url.test.ts
+++ b/src/lib/service-url.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { Domain } from "./api";
+import { getPreferredDomain, getServiceUrl } from "./service-url";
+
+function makeDomain(
+  overrides: Partial<Domain> & { domain: string },
+): Domain {
+  return {
+    id: "d1",
+    serviceId: "s1",
+    type: "proxy",
+    redirectTarget: null,
+    redirectCode: null,
+    dnsVerified: 1,
+    sslStatus: "active",
+    isSystem: 0,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("getPreferredDomain", () => {
+  test("returns null for empty array", () => {
+    expect(getPreferredDomain([])).toBeNull();
+  });
+
+  test("returns null when no verified domains", () => {
+    const domains = [
+      makeDomain({ domain: "custom.com", isSystem: 0, dnsVerified: 0 }),
+      makeDomain({ domain: "app.frost.io", isSystem: 1, dnsVerified: 0 }),
+    ];
+    expect(getPreferredDomain(domains)).toBeNull();
+  });
+
+  test("prefers custom domain over wildcard", () => {
+    const domains = [
+      makeDomain({ domain: "app.frost.io", isSystem: 1, dnsVerified: 1 }),
+      makeDomain({ domain: "custom.com", isSystem: 0, dnsVerified: 1 }),
+    ];
+    expect(getPreferredDomain(domains)?.domain).toBe("custom.com");
+  });
+
+  test("falls back to wildcard when no custom domain", () => {
+    const domains = [
+      makeDomain({ domain: "app.frost.io", isSystem: 1, dnsVerified: 1 }),
+    ];
+    expect(getPreferredDomain(domains)?.domain).toBe("app.frost.io");
+  });
+
+  test("ignores unverified custom domain, returns verified wildcard", () => {
+    const domains = [
+      makeDomain({ domain: "custom.com", isSystem: 0, dnsVerified: 0 }),
+      makeDomain({ domain: "app.frost.io", isSystem: 1, dnsVerified: 1 }),
+    ];
+    expect(getPreferredDomain(domains)?.domain).toBe("app.frost.io");
+  });
+
+  test("returns first verified custom domain when multiple exist", () => {
+    const domains = [
+      makeDomain({ domain: "first.com", isSystem: 0, dnsVerified: 1 }),
+      makeDomain({ domain: "second.com", isSystem: 0, dnsVerified: 1 }),
+    ];
+    expect(getPreferredDomain(domains)?.domain).toBe("first.com");
+  });
+});
+
+describe("getServiceUrl", () => {
+  test("returns domain when available", () => {
+    const domains = [
+      makeDomain({ domain: "custom.com", isSystem: 0, dnsVerified: 1 }),
+    ];
+    expect(getServiceUrl(domains, "1.2.3.4", 3000)).toBe("custom.com");
+  });
+
+  test("returns IP:port when no verified domain", () => {
+    expect(getServiceUrl([], "1.2.3.4", 3000)).toBe("1.2.3.4:3000");
+  });
+
+  test("returns null when no domain and no IP", () => {
+    expect(getServiceUrl([], null, 3000)).toBeNull();
+  });
+
+  test("returns null when no domain and no port", () => {
+    expect(getServiceUrl([], "1.2.3.4", null)).toBeNull();
+  });
+});

--- a/src/lib/service-url.ts
+++ b/src/lib/service-url.ts
@@ -1,0 +1,21 @@
+import type { Domain } from "@/lib/api";
+
+export function getPreferredDomain(domains: Domain[]): Domain | null {
+  const verified = domains.filter((d) => d.dnsVerified === 1);
+  return (
+    verified.find((d) => d.isSystem === 0) ??
+    verified.find((d) => d.isSystem === 1) ??
+    null
+  );
+}
+
+export function getServiceUrl(
+  domains: Domain[],
+  serverIp: string | null,
+  hostPort: number | null,
+): string | null {
+  const domain = getPreferredDomain(domains);
+  if (domain) return domain.domain;
+  if (serverIp && hostPort) return `${serverIp}:${hostPort}`;
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add `getPreferredDomain` utility that prioritizes custom verified domains over wildcard ones
- Service cards show custom domain when available, falling back to wildcard then IP:port
- Service detail page uses same priority for URL display

## Test plan
- [ ] Create service without domain → shows IP:port
- [ ] Configure wildcard domain → shows wildcard
- [ ] Add custom domain → shows custom domain (not wildcard)
- [ ] Remove custom domain → falls back to wildcard

🤖 Generated with [Claude Code](https://claude.com/claude-code)