### PR TITLE
feat: improved domain status progress UX

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -104,6 +104,7 @@ export interface DnsStatus {
   serverIp: string;
   domainIp: string | null;
   dnsVerified: boolean;
+  errorType?: "no_record" | "wrong_ip";
 }
 
 export interface SslStatus {

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -17,6 +17,7 @@ export interface DnsStatus {
   valid: boolean;
   serverIp: string;
   domainIp: string | null;
+  errorType?: "no_record" | "wrong_ip";
 }
 
 export async function addDomain(serviceId: string, input: DomainInput) {
@@ -243,10 +244,17 @@ export async function verifyDomainDns(domain: string): Promise<DnsStatus> {
     resolveDomain(domain),
   ]);
 
+  const valid = domainIps.includes(serverIp);
+  let errorType: "no_record" | "wrong_ip" | undefined;
+  if (!valid) {
+    errorType = domainIps.length === 0 ? "no_record" : "wrong_ip";
+  }
+
   return {
-    valid: domainIps.includes(serverIp),
+    valid,
     serverIp,
     domainIp: domainIps[0] || null,
+    errorType,
   };
 }
 

--- a/src/server/domains.ts
+++ b/src/server/domains.ts
@@ -18,9 +18,10 @@ import { os } from "@/lib/orpc";
 
 const dnsVerifyResultSchema = z.object({
   valid: z.boolean(),
-  ip: z.string().nullable().optional(),
-  expectedIp: z.string().nullable().optional(),
+  serverIp: z.string(),
+  domainIp: z.string().nullable(),
   dnsVerified: z.boolean(),
+  errorType: z.enum(["no_record", "wrong_ip"]).optional(),
 });
 
 const sslVerifyResultSchema = z.object({


### PR DESCRIPTION
## Summary
- Show clearer progress states as domains go from added → fully working
- Add `errorType` to classify DNS failures (`no_record` vs `wrong_ip`)
- Track verification attempts in React state with better feedback
- After 3+ failed attempts, show actionable error messages

## Changes
- `src/lib/domains.ts` - Add `errorType` to DnsStatus interface
- `src/lib/api.ts` - Update client-side DnsStatus type
- `src/server/domains.ts` - Include errorType in API response
- `src/app/.../domains-section.tsx` - State tracking + improved UI

## Status Messages
| State | Display |
|-------|---------|
| Active check | `[spinner] Checking DNS...` |
| DNS not propagated (3+ attempts) | `Waiting for DNS propagation (attempt N)` |
| Wrong IP (3+ attempts) | `DNS points to X.X.X.X, expected Y.Y.Y.Y` |
| SSL provisioning | `[spinner] Requesting certificate...` |

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)