### PR TITLE
feat: add request ID and error logging for E2E observability

### DIFF
--- a/src/lib/orpc.ts
+++ b/src/lib/orpc.ts
@@ -12,10 +12,9 @@ export const os = baseOs
   })
   .use(
     onError((error, { context }) => {
-      const requestId = context.requestId ?? "unknown";
-      console.error(`[${requestId}] API Error:`, error);
+      console.error(`[${context.requestId}] API Error:`, error);
       if (error.cause) {
-        console.error(`[${requestId}] Cause:`, error.cause);
+        console.error(`[${context.requestId}] Cause:`, error.cause);
       }
     }),
   );

--- a/src/lib/orpc.ts
+++ b/src/lib/orpc.ts
@@ -1,3 +1,21 @@
-import { os } from "@orpc/server";
+import { os as baseOs, onError } from "@orpc/server";
+import type { Context } from "@/server/context";
 
-export { os };
+export const os = baseOs
+  .$context<Context>()
+  .use(async ({ context, next }) => {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    console.log(`[${context.requestId}] ${duration}ms`);
+    return result;
+  })
+  .use(
+    onError((error, { context }) => {
+      const requestId = context.requestId ?? "unknown";
+      console.error(`[${requestId}] API Error:`, error);
+      if (error.cause) {
+        console.error(`[${requestId}] Cause:`, error.cause);
+      }
+    }),
+  );

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,3 +1,4 @@
 export interface Context {
   headers: Headers;
+  requestId?: string;
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,4 +1,4 @@
 export interface Context {
   headers: Headers;
-  requestId?: string;
+  requestId: string;
 }


### PR DESCRIPTION
## Summary
- Add request ID to all API responses (`X-Request-Id` header)
- Log errors with request ID and full stack trace server-side
- E2E tests now fetch server logs on 500 errors automatically
- `fail()` function dumps recent server logs for debugging

## How it works

When a 500 error occurs in E2E tests:
```
API error (HTTP 500): {"code":"INTERNAL_SERVER_ERROR"...}
Request ID: qZ17-H3hYk
--- Server logs for request qZ17-H3hYk ---
[qZ17-H3hYk] API Error: Error: SQLITE_BUSY: database is locked
    at file://.../src/server/projects.ts:165:17
--- End server logs ---
```

## Test plan
- [ ] CI passes (E2E tests use the new observability)
- [ ] Trigger a 500 error in E2E to verify logs are captured

🤖 Generated with [Claude Code](https://claude.ai/claude-code)