### PR TITLE
fix: show deploying status on first deploy

### DIFF
--- a/apps/app/src/app/projects/[id]/_components/sidebar-overview.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-overview.tsx
@@ -99,13 +99,23 @@ export function SidebarOverview({ service, projectId }: SidebarOverviewProps) {
   useEffect(() => {
     if (!service) return;
     async function fetchCurrentDeployment() {
-      if (!service?.currentDeploymentId) {
-        setCurrentDeployment(null);
-        return;
-      }
       const deps = await api.deployments.listByService(service.id);
-      const current = deps.find((d) => d.id === service.currentDeploymentId);
-      setCurrentDeployment(current ?? null);
+      if (service.currentDeploymentId) {
+        const current = deps.find((d) => d.id === service.currentDeploymentId);
+        setCurrentDeployment(current ?? null);
+      } else {
+        const inProgressStatuses = [
+          "pending",
+          "cloning",
+          "pulling",
+          "building",
+          "deploying",
+        ];
+        const inProgress = deps.find((d) =>
+          inProgressStatuses.includes(d.status),
+        );
+        setCurrentDeployment(inProgress ?? null);
+      }
     }
     fetchCurrentDeployment();
     const interval = setInterval(fetchCurrentDeployment, 2000);


### PR DESCRIPTION
## Summary
- Fix service overview showing "Ready to deploy" during first deployment
- Now checks for in-progress deployments when no current deployment exists

## Test plan
- [ ] Create a new service and trigger first deploy
- [ ] Verify the overview shows the deployment status, not "Ready to deploy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)