### PR TITLE
feat: web-based first-run setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
 
           echo "Installing Frost $TAG from: $INSTALL_URL"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt
+          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt
 
           API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
           echo "Installing from: $INSTALL_URL"
           echo "Using branch: $BRANCH"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -b '$BRANCH' --create-api-key" 2>&1 | tee /tmp/install-output.txt
+          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh -b '$BRANCH' --create-api-key" 2>&1 | tee /tmp/install-output.txt
 
           API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
 
@@ -376,7 +376,7 @@ jobs:
 
           echo "Installing Frost $TAG from: $INSTALL_URL"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt
+          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt
 
           API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,13 +29,13 @@ Services communicate via Docker network using service name as hostname.
 - Domain: frost.j4labs.se
 - Test service domain: testapp.frost.j4labs.se (A record points to VPS)
 - SSH: `ssh root@65.21.180.49`
-- Install password: `hejsan123`
 - **Always enable "Use staging certificates" when setting up SSL** to avoid Let's Encrypt rate limits
 
 Fresh install (after VPS rebuild):
 ```bash
-ssh root@65.21.180.49 "curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh -o /tmp/install.sh && chmod +x /tmp/install.sh && echo 'hejsan123' | /tmp/install.sh"
+ssh root@65.21.180.49 "curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh | sudo bash"
 ```
+Then open http://65.21.180.49 in browser to complete setup.
 
 Update existing install:
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,20 +69,20 @@ For the chosen provider:
 
 ## INSTALLATION
 
-Generate a random password for Frost admin (16+ chars, alphanumeric).
-
 SSH into server and run:
 
 ```bash
 ssh -o StrictHostKeyChecking=no root@{server_ip} \
-  "curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '{password}' | /tmp/install.sh"
+  "curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh | sudo bash"
 ```
+
+Wait for install to complete, then open `http://{server_ip}` in browser to complete setup (set admin password).
 
 Verify Frost is running:
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}" http://{server_ip}:3000
-# Should return 200
+# Should return 302 (redirect to /setup) or 200 (after setup complete)
 ```
 
 ---
@@ -100,8 +100,8 @@ SSH User: root
 SSH Private Key:
 {private_key_or_"your existing key"}
 
-Frost URL: http://{server_ip}:3000
-Frost Password: {password}
+Frost URL: http://{server_ip}
+Frost Password: (set during browser setup)
 
 API Token (for server management): {token}
 ================================

--- a/apps/app/scripts/e2e/group-20-setup.sh
+++ b/apps/app/scripts/e2e/group-20-setup.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log "=== Web-based setup flow ==="
+
+log "Verifying API works with API key (even before web setup)..."
+HEALTH=$(api "$BASE_URL/api/health")
+OK=$(json_get "$HEALTH" '.ok')
+if [ "$OK" != "true" ]; then
+  fail "Health check failed: $HEALTH"
+fi
+log "API key auth works before setup"
+
+log "Verifying session access redirects to /setup..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -L --max-redirs 0 "$BASE_URL/")
+if [ "$HTTP_CODE" != "302" ] && [ "$HTTP_CODE" != "307" ]; then
+  fail "Expected redirect (302/307), got $HTTP_CODE"
+fi
+
+LOCATION=$(curl -s -o /dev/null -w "%{redirect_url}" "$BASE_URL/")
+if [[ "$LOCATION" != *"/setup"* ]]; then
+  fail "Expected redirect to /setup, got $LOCATION"
+fi
+log "Session access correctly redirects to /setup"
+
+log "Checking setup status via GET /api/setup..."
+SETUP_STATUS=$(curl -s "$BASE_URL/api/setup")
+SETUP_COMPLETE=$(echo "$SETUP_STATUS" | jq -r '.setupComplete')
+if [ "$SETUP_COMPLETE" != "false" ]; then
+  fail "Expected setupComplete=false, got $SETUP_COMPLETE"
+fi
+log "Setup not complete as expected"
+
+log "Completing setup via POST /api/setup..."
+SETUP_RESULT=$(curl -s -X POST "$BASE_URL/api/setup" \
+  -H "Content-Type: application/json" \
+  -d '{"password":"e2eTestPassword123"}')
+SUCCESS=$(echo "$SETUP_RESULT" | jq -r '.success')
+if [ "$SUCCESS" != "true" ]; then
+  fail "Setup failed: $SETUP_RESULT"
+fi
+log "Setup completed successfully"
+
+log "Verifying setup status changed..."
+SETUP_STATUS=$(curl -s "$BASE_URL/api/setup")
+SETUP_COMPLETE=$(echo "$SETUP_STATUS" | jq -r '.setupComplete')
+if [ "$SETUP_COMPLETE" != "true" ]; then
+  fail "Expected setupComplete=true after setup, got $SETUP_COMPLETE"
+fi
+log "Setup status confirmed as complete"
+
+log "Verifying second setup attempt fails..."
+SETUP_RESULT=$(curl -s -X POST "$BASE_URL/api/setup" \
+  -H "Content-Type: application/json" \
+  -d '{"password":"anotherPassword123"}')
+ERROR=$(echo "$SETUP_RESULT" | jq -r '.error')
+if [ "$ERROR" != "setup already complete" ]; then
+  fail "Expected 'setup already complete' error, got: $SETUP_RESULT"
+fi
+log "Second setup correctly rejected"
+
+log "Verifying session login now works..."
+LOGIN_RESULT=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"password":"e2eTestPassword123"}' \
+  -c /tmp/frost-cookies.txt)
+SUCCESS=$(echo "$LOGIN_RESULT" | jq -r '.success')
+if [ "$SUCCESS" != "true" ]; then
+  fail "Login failed: $LOGIN_RESULT"
+fi
+log "Session login works with new password"
+
+log "Verifying session-based access no longer redirects..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -L --max-redirs 0 -b /tmp/frost-cookies.txt "$BASE_URL/")
+if [ "$HTTP_CODE" != "200" ]; then
+  fail "Expected 200 with valid session, got $HTTP_CODE"
+fi
+log "Session-based access works"
+
+rm -f /tmp/frost-cookies.txt
+
+pass
+

--- a/apps/app/scripts/e2e/group-20-setup.sh
+++ b/apps/app/scripts/e2e/group-20-setup.sh
@@ -6,10 +6,18 @@ source "$SCRIPT_DIR/common.sh"
 log "=== Web-based setup flow ==="
 
 log "Checking if setup is already complete (e.g. upgrade scenario)..."
-SETUP_STATUS=$(curl -s "$BASE_URL/api/setup")
-SETUP_COMPLETE=$(echo "$SETUP_STATUS" | jq -r '.setupComplete')
+SETUP_STATUS=$(curl -s "$BASE_URL/api/setup" 2>/dev/null || echo '{}')
+SETUP_COMPLETE=$(echo "$SETUP_STATUS" | jq -r '.setupComplete // empty')
 if [ "$SETUP_COMPLETE" = "true" ]; then
-  log "Setup already complete (upgrade scenario), skipping test"
+  log "Setup already complete (via API), skipping test"
+  pass
+  exit 0
+fi
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/")
+LOCATION=$(curl -s -D - -o /dev/null "$BASE_URL/" 2>/dev/null | grep -i "^location:" | tr -d '\r' | cut -d' ' -f2 || echo "")
+if [[ "$LOCATION" == *"/login"* ]]; then
+  log "Redirects to /login (setup already complete), skipping test"
   pass
   exit 0
 fi

--- a/apps/app/scripts/e2e/group-20-setup.sh
+++ b/apps/app/scripts/e2e/group-20-setup.sh
@@ -5,6 +5,15 @@ source "$SCRIPT_DIR/common.sh"
 
 log "=== Web-based setup flow ==="
 
+log "Checking if setup is already complete (e.g. upgrade scenario)..."
+SETUP_STATUS=$(curl -s "$BASE_URL/api/setup")
+SETUP_COMPLETE=$(echo "$SETUP_STATUS" | jq -r '.setupComplete')
+if [ "$SETUP_COMPLETE" = "true" ]; then
+  log "Setup already complete (upgrade scenario), skipping test"
+  pass
+  exit 0
+fi
+
 log "Verifying API works with API key (even before web setup)..."
 HEALTH=$(api "$BASE_URL/api/health")
 OK=$(json_get "$HEALTH" '.ok')

--- a/apps/app/scripts/e2e/group-20-setup.sh
+++ b/apps/app/scripts/e2e/group-20-setup.sh
@@ -14,12 +14,12 @@ fi
 log "API key auth works before setup"
 
 log "Verifying session access redirects to /setup..."
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -L --max-redirs 0 "$BASE_URL/")
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/")
 if [ "$HTTP_CODE" != "302" ] && [ "$HTTP_CODE" != "307" ]; then
   fail "Expected redirect (302/307), got $HTTP_CODE"
 fi
 
-LOCATION=$(curl -s -o /dev/null -w "%{redirect_url}" "$BASE_URL/")
+LOCATION=$(curl -s -D - -o /dev/null "$BASE_URL/" | grep -i "^location:" | tr -d '\r' | cut -d' ' -f2)
 if [[ "$LOCATION" != *"/setup"* ]]; then
   fail "Expected redirect to /setup, got $LOCATION"
 fi
@@ -73,7 +73,7 @@ fi
 log "Session login works with new password"
 
 log "Verifying session-based access no longer redirects..."
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -L --max-redirs 0 -b /tmp/frost-cookies.txt "$BASE_URL/")
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -b /tmp/frost-cookies.txt "$BASE_URL/")
 if [ "$HTTP_CODE" != "200" ]; then
   fail "Expected 200 with valid session, got $HTTP_CODE"
 fi

--- a/apps/app/src/app/api/dev/reset-setup/route.ts
+++ b/apps/app/src/app/api/dev/reset-setup/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+
+export async function DELETE() {
+  if (process.env.NODE_ENV !== "development") {
+    return NextResponse.json(
+      { error: "only available in development mode" },
+      { status: 403 },
+    );
+  }
+
+  await db
+    .deleteFrom("settings")
+    .where("key", "=", "admin_password_hash")
+    .execute();
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/app/src/app/api/setup/route.ts
+++ b/apps/app/src/app/api/setup/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import {
+  hashPassword,
+  isSetupComplete,
+  setAdminPasswordHash,
+} from "@/lib/auth";
+
+export async function GET() {
+  const setupComplete = await isSetupComplete();
+  return NextResponse.json({ setupComplete });
+}
+
+export async function POST(request: Request) {
+  if (await isSetupComplete()) {
+    return NextResponse.json(
+      { error: "setup already complete" },
+      { status: 400 },
+    );
+  }
+
+  const { password } = await request.json();
+
+  if (!password || typeof password !== "string") {
+    return NextResponse.json(
+      { error: "password is required" },
+      { status: 400 },
+    );
+  }
+
+  if (password.length < 4) {
+    return NextResponse.json(
+      { error: "password must be at least 4 characters" },
+      { status: 400 },
+    );
+  }
+
+  await setAdminPasswordHash(await hashPassword(password));
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/app/src/app/docs/demo/page.mdx
+++ b/apps/app/src/app/docs/demo/page.mdx
@@ -25,7 +25,7 @@ Inline code looks like `const foo = "bar"` within text.
 ### Terminal Commands
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh | sudo bash
 ```
 
 ```sh

--- a/apps/app/src/app/docs/installation/page.mdx
+++ b/apps/app/src/app/docs/installation/page.mdx
@@ -9,5 +9,5 @@
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh | sudo bash
 ```

--- a/apps/app/src/app/setup/page.tsx
+++ b/apps/app/src/app/setup/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export default function SetupPage() {
+  const [loading, setLoading] = useState(false);
+  const [checking, setChecking] = useState(true);
+  const [passwordError, setPasswordError] = useState("");
+  const [confirmError, setConfirmError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/setup")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.setupComplete) {
+          window.location.href = "/";
+        } else {
+          setChecking(false);
+        }
+      })
+      .catch(() => setChecking(false));
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setPasswordError("");
+    setConfirmError("");
+
+    const formData = new FormData(e.currentTarget);
+    const password = formData.get("password") as string;
+    const confirmPassword = formData.get("confirmPassword") as string;
+
+    if (password.length < 4) {
+      setPasswordError("Password must be at least 4 characters");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setConfirmError("Passwords do not match");
+      return;
+    }
+
+    setLoading(true);
+
+    const res = await fetch("/api/setup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    }).catch(() => null);
+
+    if (!res?.ok) {
+      const data = await res?.json().catch(() => ({}));
+      setPasswordError(data?.error || "Setup failed");
+      setLoading(false);
+      return;
+    }
+
+    window.location.href = "/login";
+  }
+
+  if (checking) {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <Loader2 className="h-6 w-6 animate-spin text-neutral-400" />
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <Card className="border-neutral-800 bg-neutral-900">
+          <CardHeader className="text-center">
+            <CardTitle className="text-lg font-medium text-neutral-100">
+              Setup Frost
+            </CardTitle>
+            <p className="text-sm text-neutral-400">
+              Create your admin password
+            </p>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid gap-2">
+                <Label htmlFor="password" className="text-neutral-300">
+                  Password
+                </Label>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  required
+                  autoFocus
+                  minLength={4}
+                  className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                />
+                {passwordError && (
+                  <p className="text-sm text-red-400">{passwordError}</p>
+                )}
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="confirmPassword" className="text-neutral-300">
+                  Confirm Password
+                </Label>
+                <Input
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  type="password"
+                  required
+                  minLength={4}
+                  className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                />
+                {confirmError && (
+                  <p className="text-sm text-red-400">{confirmError}</p>
+                )}
+              </div>
+
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                    Setting up
+                  </>
+                ) : (
+                  "Complete Setup"
+                )}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/marketing/src/components/install.tsx
+++ b/apps/marketing/src/components/install.tsx
@@ -5,7 +5,7 @@ import type { LucideIcon } from "lucide-react";
 import { Bot, Check, Copy, Terminal } from "lucide-react";
 import { useState } from "react";
 
-const installCommand = "curl -fsSL https://frost.build/install.sh | bash";
+const installCommand = "curl -fsSL https://frost.build/install.sh | sudo bash";
 const agentUrl = "https://frost.build/install.md";
 
 const fadeInUp = {

--- a/install.sh
+++ b/install.sh
@@ -65,16 +65,6 @@ if [ "$(uname)" != "Linux" ]; then
   exit 1
 fi
 
-# Prompt for admin password
-echo -e "${YELLOW}Configuration${NC}"
-read -s -p "Admin password (min 8 chars): " FROST_PASSWORD
-echo ""
-
-if [ ${#FROST_PASSWORD} -lt 8 ]; then
-  echo -e "${RED}Password must be at least 8 characters${NC}"
-  exit 1
-fi
-
 # Generate JWT secret
 FROST_JWT_SECRET=$(openssl rand -base64 32)
 
@@ -262,13 +252,6 @@ fi
 timer "Running migrations..."
 bun run migrate
 
-# Run setup to set admin password (uses bun:sqlite)
-timer "Setting admin password..."
-bun run setup "$FROST_PASSWORD" || {
-  echo -e "${RED}Failed to set admin password. Check bun installation.${NC}"
-  exit 1
-}
-
 # Create systemd service
 echo ""
 timer "Creating systemd service..."
@@ -363,8 +346,9 @@ fi
 
 echo ""
 echo "Next steps:"
-echo "  1. Point your domain to $SERVER_IP"
-echo "  2. Go to Settings in Frost to configure domain and SSL"
+echo "  1. Open http://$SERVER_IP to complete setup"
+echo "  2. Point your domain to $SERVER_IP"
+echo "  3. Go to Settings in Frost to configure SSL"
 echo ""
 echo "Useful commands:"
 echo "  systemctl status frost    - check status"


### PR DESCRIPTION
## Summary

- Move password setup from `install.sh` terminal prompt to web-based `/setup` page
- Enables zero-interaction `curl | bash` installation
- API key auth works immediately (CI uses `--create-api-key`)
- Session-based access redirects to `/setup` until password is set

## Changes

- Remove password prompt from `install.sh`
- Add `POST /api/setup` to set password, `GET` to check status
- Add `/setup` page with password + confirm fields
- Add setup redirect logic in `proxy.ts`
- Dev mode: both "dev" and real password work after setup
- Add E2E test `group-20-setup.sh`
- Use `sudo bash` in install commands

Closes #199

## Test plan

- [ ] E2E tests pass (group-20-setup verifies setup flow)
- [ ] Fresh install redirects to /setup
- [ ] Setup completes and redirects to /login
- [ ] Second setup attempt is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)