### PR TITLE
refactor: oRPC contract-first architecture

### DIFF
--- a/apps/app/src/contracts/api-keys.ts
+++ b/apps/app/src/contracts/api-keys.ts
@@ -1,0 +1,27 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import { apiKeysSchema } from "@/lib/db-schemas";
+
+const apiKeyOutputSchema = apiKeysSchema.omit({ keyHash: true });
+
+export const apiKeysContract = {
+  list: oc
+    .route({ method: "GET", path: "/settings/api-keys" })
+    .output(z.array(apiKeyOutputSchema)),
+
+  create: oc
+    .route({ method: "POST", path: "/settings/api-keys" })
+    .input(z.object({ name: z.string().min(1) }))
+    .output(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        key: z.string(),
+      }),
+    ),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/settings/api-keys/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+};

--- a/apps/app/src/contracts/deployments.ts
+++ b/apps/app/src/contracts/deployments.ts
@@ -1,0 +1,15 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import { deploymentsSchema } from "@/lib/db-schemas";
+
+export const deploymentsContract = {
+  get: oc
+    .route({ method: "GET", path: "/deployments/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(deploymentsSchema),
+
+  rollback: oc
+    .route({ method: "POST", path: "/deployments/{id}/rollback" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ deploymentId: z.string() })),
+};

--- a/apps/app/src/contracts/domains.ts
+++ b/apps/app/src/contracts/domains.ts
@@ -1,0 +1,73 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import { domainsSchema } from "@/lib/db-schemas";
+
+const dnsVerifyResultSchema = z.object({
+  valid: z.boolean(),
+  serverIp: z.string(),
+  domainIp: z.string().nullable(),
+  dnsVerified: z.boolean(),
+  errorType: z.enum(["no_record", "wrong_ip"]).optional(),
+});
+
+const sslVerifyResultSchema = z.object({
+  working: z.boolean(),
+  status: z.enum(["active", "pending"]),
+  error: z.string().optional(),
+});
+
+export const domainsContract = {
+  get: oc
+    .route({ method: "GET", path: "/domains/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(domainsSchema),
+
+  listByService: oc
+    .route({ method: "GET", path: "/services/{serviceId}/domains" })
+    .input(z.object({ serviceId: z.string() }))
+    .output(z.array(domainsSchema)),
+
+  listByServiceIds: oc
+    .input(z.object({ serviceIds: z.array(z.string()) }))
+    .output(z.array(domainsSchema)),
+
+  create: oc
+    .route({ method: "POST", path: "/services/{serviceId}/domains" })
+    .input(
+      z.object({
+        serviceId: z.string(),
+        domain: z.string().min(1),
+        type: z.enum(["proxy", "redirect"]).default("proxy"),
+        redirectTarget: z.string().optional(),
+        redirectCode: z.union([z.literal(301), z.literal(307)]).optional(),
+      }),
+    )
+    .output(domainsSchema),
+
+  update: oc
+    .route({ method: "PATCH", path: "/domains/{id}" })
+    .input(
+      z.object({
+        id: z.string(),
+        type: z.enum(["proxy", "redirect"]).optional(),
+        redirectTarget: z.string().optional(),
+        redirectCode: z.union([z.literal(301), z.literal(307)]).optional(),
+      }),
+    )
+    .output(domainsSchema),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/domains/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+
+  verifyDns: oc
+    .route({ method: "POST", path: "/domains/{id}/verify-dns" })
+    .input(z.object({ id: z.string() }))
+    .output(dnsVerifyResultSchema),
+
+  verifySsl: oc
+    .route({ method: "POST", path: "/domains/{id}/verify-ssl" })
+    .input(z.object({ id: z.string() }))
+    .output(sslVerifyResultSchema),
+};

--- a/apps/app/src/contracts/health.ts
+++ b/apps/app/src/contracts/health.ts
@@ -1,0 +1,12 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+
+export const healthContract = {
+  check: oc
+    .route({ method: "GET", path: "/health" })
+    .output(z.object({ ok: z.boolean(), version: z.string() })),
+
+  hostResources: oc
+    .route({ method: "GET", path: "/host-resources" })
+    .output(z.object({ cpus: z.number(), totalMemoryGB: z.number() })),
+};

--- a/apps/app/src/contracts/index.ts
+++ b/apps/app/src/contracts/index.ts
@@ -1,0 +1,28 @@
+import type {
+  InferContractRouterInputs,
+  InferContractRouterOutputs,
+} from "@orpc/contract";
+import { apiKeysContract } from "./api-keys";
+import { deploymentsContract } from "./deployments";
+import { domainsContract } from "./domains";
+import { healthContract } from "./health";
+import { projectsContract } from "./projects";
+import { registriesContract } from "./registries";
+import { servicesContract } from "./services";
+import { dbTemplatesContract, templatesContract } from "./templates";
+
+export const contract = {
+  apiKeys: apiKeysContract,
+  dbTemplates: dbTemplatesContract,
+  deployments: deploymentsContract,
+  domains: domainsContract,
+  health: healthContract,
+  projects: projectsContract,
+  registries: registriesContract,
+  services: servicesContract,
+  templates: templatesContract,
+};
+
+export type Contract = typeof contract;
+export type ContractInputs = InferContractRouterInputs<Contract>;
+export type ContractOutputs = InferContractRouterOutputs<Contract>;

--- a/apps/app/src/contracts/projects.ts
+++ b/apps/app/src/contracts/projects.ts
@@ -1,0 +1,74 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import {
+  deploymentsSchema,
+  projectsSchema,
+  servicesSchema,
+} from "@/lib/db-schemas";
+import { envVarSchema } from "./shared";
+
+const latestDeploymentSchema = z.object({
+  status: z.string(),
+  commitMessage: z.string().nullable(),
+  createdAt: z.number(),
+  branch: z.string().nullable(),
+});
+
+const projectListItemSchema = projectsSchema.extend({
+  servicesCount: z.number(),
+  latestDeployment: latestDeploymentSchema.nullable(),
+  repoUrl: z.string().nullable(),
+  runningUrl: z.string().nullable(),
+});
+
+const serviceWithDeploymentSchema = servicesSchema.extend({
+  latestDeployment: deploymentsSchema.nullable(),
+});
+
+const projectWithServicesSchema = projectsSchema.extend({
+  services: z.array(serviceWithDeploymentSchema),
+});
+
+export const projectsContract = {
+  list: oc
+    .route({ method: "GET", path: "/projects" })
+    .output(z.array(projectListItemSchema)),
+
+  get: oc
+    .route({ method: "GET", path: "/projects/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(projectWithServicesSchema),
+
+  create: oc
+    .route({ method: "POST", path: "/projects" })
+    .input(
+      z.object({
+        name: z.string().min(1),
+        envVars: z.array(envVarSchema).default([]),
+        templateId: z.string().optional(),
+      }),
+    )
+    .output(projectsSchema),
+
+  update: oc
+    .route({ method: "PATCH", path: "/projects/{id}" })
+    .input(
+      z.object({
+        id: z.string(),
+        name: z.string().optional(),
+        envVars: z.array(envVarSchema).optional(),
+        canvasPositions: z.string().optional(),
+      }),
+    )
+    .output(projectsSchema),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/projects/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+
+  deploy: oc
+    .route({ method: "POST", path: "/projects/{id}/deploy" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ deploymentIds: z.array(z.string()) })),
+};

--- a/apps/app/src/contracts/registries.ts
+++ b/apps/app/src/contracts/registries.ts
@@ -1,0 +1,39 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import { registryOutputSchema } from "@/lib/db-schemas";
+
+export const registriesContract = {
+  list: oc
+    .route({ method: "GET", path: "/registries" })
+    .output(z.array(registryOutputSchema)),
+
+  create: oc
+    .route({ method: "POST", path: "/registries" })
+    .input(
+      z.object({
+        name: z.string().min(1),
+        type: z.enum(["ghcr", "dockerhub", "custom"]),
+        url: z.string().optional(),
+        username: z.string().min(1),
+        password: z.string().min(1),
+      }),
+    )
+    .output(registryOutputSchema),
+
+  update: oc
+    .route({ method: "PATCH", path: "/registries/{id}" })
+    .input(
+      z.object({
+        id: z.string(),
+        name: z.string().min(1).optional(),
+        username: z.string().min(1).optional(),
+        password: z.string().min(1).optional(),
+      }),
+    )
+    .output(registryOutputSchema),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/registries/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+};

--- a/apps/app/src/contracts/services.ts
+++ b/apps/app/src/contracts/services.ts
@@ -1,0 +1,105 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import { deploymentsSchema, servicesSchema } from "@/lib/db-schemas";
+import { envVarSchema, volumeConfigSchema } from "./shared";
+
+const serviceWithDeploymentSchema = servicesSchema.extend({
+  latestDeployment: deploymentsSchema.nullable(),
+});
+
+const volumeInfoSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  sizeBytes: z.number().nullable(),
+});
+
+export const servicesContract = {
+  get: oc
+    .route({ method: "GET", path: "/services/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(serviceWithDeploymentSchema),
+
+  listByProject: oc
+    .route({ method: "GET", path: "/projects/{projectId}/services" })
+    .input(z.object({ projectId: z.string() }))
+    .output(z.array(serviceWithDeploymentSchema)),
+
+  create: oc
+    .route({ method: "POST", path: "/projects/{projectId}/services" })
+    .input(
+      z.object({
+        projectId: z.string(),
+        name: z.string().min(1),
+        deployType: z.enum(["repo", "image", "database"]).default("repo"),
+        repoUrl: z.string().optional(),
+        branch: z.string().default("main"),
+        dockerfilePath: z.string().default("Dockerfile"),
+        buildContext: z.string().optional(),
+        imageUrl: z.string().optional(),
+        envVars: z.array(envVarSchema).default([]),
+        containerPort: z.number().min(1).max(65535).optional(),
+        templateId: z.string().optional(),
+        healthCheckPath: z.string().optional(),
+        healthCheckTimeout: z.number().optional(),
+        memoryLimit: z
+          .string()
+          .regex(/^\d+[kmg]$/i)
+          .optional(),
+        cpuLimit: z.number().min(0.1).max(64).optional(),
+        shutdownTimeout: z.number().min(1).max(300).optional(),
+        registryId: z.string().optional(),
+      }),
+    )
+    .output(servicesSchema),
+
+  update: oc
+    .route({ method: "PATCH", path: "/services/{id}" })
+    .input(
+      z.object({
+        id: z.string(),
+        name: z.string().optional(),
+        envVars: z.array(envVarSchema).optional(),
+        containerPort: z.number().min(1).max(65535).optional(),
+        branch: z.string().optional(),
+        dockerfilePath: z.string().optional(),
+        buildContext: z.string().nullable().optional(),
+        repoUrl: z.string().optional(),
+        imageUrl: z.string().optional(),
+        healthCheckPath: z.string().nullable().optional(),
+        healthCheckTimeout: z.number().min(1).max(300).optional(),
+        autoDeployEnabled: z.boolean().optional(),
+        memoryLimit: z
+          .string()
+          .regex(/^\d+[kmg]$/i)
+          .nullable()
+          .optional(),
+        cpuLimit: z.number().min(0.1).max(64).nullable().optional(),
+        shutdownTimeout: z.number().min(1).max(300).nullable().optional(),
+        requestTimeout: z.number().min(1).max(3600).nullable().optional(),
+        volumes: z.array(volumeConfigSchema).optional(),
+        registryId: z.string().nullable().optional(),
+        command: z.string().nullable().optional(),
+      }),
+    )
+    .output(servicesSchema),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/services/{id}" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+
+  deploy: oc
+    .route({ method: "POST", path: "/services/{id}/deploy" })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ deploymentId: z.string() })),
+
+  listDeployments: oc
+    .route({ method: "GET", path: "/services/{id}/deployments" })
+    .input(z.object({ id: z.string() }))
+    .output(z.array(deploymentsSchema)),
+
+  getVolumes: oc
+    .route({ method: "GET", path: "/services/{id}/volumes" })
+    .input(z.object({ id: z.string() }))
+    .output(z.array(volumeInfoSchema)),
+};

--- a/apps/app/src/contracts/shared.ts
+++ b/apps/app/src/contracts/shared.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const envVarSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+});
+
+export const volumeConfigSchema = z.object({
+  name: z.string().regex(/^[a-z0-9-]+$/),
+  path: z.string().startsWith("/"),
+});

--- a/apps/app/src/contracts/templates.ts
+++ b/apps/app/src/contracts/templates.ts
@@ -1,0 +1,53 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+
+const serviceDefinitionSchema = z.object({
+  image: z.string(),
+  port: z.number(),
+  main: z.boolean().optional(),
+  type: z.enum(["database", "app"]).optional(),
+  command: z.string().optional(),
+  environment: z.record(z.string(), z.unknown()).optional(),
+  volumes: z.array(z.string()).optional(),
+  health_check: z
+    .object({
+      path: z.string().optional(),
+      timeout: z.number(),
+    })
+    .optional(),
+  ssl: z.boolean().optional(),
+});
+
+const templateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  category: z.string(),
+  docs: z.string().optional(),
+  type: z.enum(["database", "service", "project"]),
+  services: z.record(z.string(), serviceDefinitionSchema),
+});
+
+export const templatesContract = {
+  list: oc
+    .route({ method: "GET", path: "/templates" })
+    .output(z.array(templateSchema)),
+
+  services: oc
+    .route({ method: "GET", path: "/templates/services" })
+    .output(z.array(templateSchema)),
+
+  projects: oc
+    .route({ method: "GET", path: "/templates/projects" })
+    .output(z.array(templateSchema)),
+
+  databases: oc
+    .route({ method: "GET", path: "/templates/databases" })
+    .output(z.array(templateSchema)),
+};
+
+export const dbTemplatesContract = {
+  list: oc
+    .route({ method: "GET", path: "/db-templates" })
+    .output(z.array(templateSchema)),
+};

--- a/apps/app/src/hooks/use-domains.ts
+++ b/apps/app/src/hooks/use-domains.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ContractInputs } from "@/contracts";
 import { orpc } from "@/lib/orpc-client";
-import type { RouterInputs } from "@/server/index";
 
 export function useDomains(serviceId: string) {
   return useQuery(
@@ -11,8 +11,9 @@ export function useDomains(serviceId: string) {
 export function useAddDomain(serviceId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: Omit<RouterInputs["domains"]["create"], "serviceId">) =>
-      orpc.domains.create.call({ serviceId, ...data }),
+    mutationFn: (
+      data: Omit<ContractInputs["domains"]["create"], "serviceId">,
+    ) => orpc.domains.create.call({ serviceId, ...data }),
     onSuccess: async () => {
       await queryClient.refetchQueries({
         queryKey: orpc.domains.listByService.key({ input: { serviceId } }),
@@ -29,7 +30,7 @@ export function useUpdateDomain(serviceId: string) {
       data,
     }: {
       id: string;
-      data: Omit<RouterInputs["domains"]["update"], "id">;
+      data: Omit<ContractInputs["domains"]["update"], "id">;
     }) => orpc.domains.update.call({ id, ...data }),
     onSuccess: async () => {
       await queryClient.refetchQueries({
@@ -82,7 +83,7 @@ export function useVerifyDomainSsl(serviceId: string) {
 }
 
 export type AddDomainInput = Omit<
-  RouterInputs["domains"]["create"],
+  ContractInputs["domains"]["create"],
   "serviceId"
 >;
-export type UpdateDomainInput = Omit<RouterInputs["domains"]["update"], "id">;
+export type UpdateDomainInput = Omit<ContractInputs["domains"]["update"], "id">;

--- a/apps/app/src/hooks/use-projects.ts
+++ b/apps/app/src/hooks/use-projects.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ContractInputs } from "@/contracts";
 import { orpc } from "@/lib/orpc-client";
-import type { RouterInputs } from "@/server/index";
 
 export function useProjects() {
   return useQuery(orpc.projects.list.queryOptions());
@@ -16,7 +16,7 @@ export function useProject(id: string) {
 export function useCreateProject() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: RouterInputs["projects"]["create"]) =>
+    mutationFn: (data: ContractInputs["projects"]["create"]) =>
       orpc.projects.create.call(data),
     onSuccess: async () => {
       await queryClient.refetchQueries({
@@ -29,7 +29,7 @@ export function useCreateProject() {
 export function useUpdateProject(id: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: Omit<RouterInputs["projects"]["update"], "id">) =>
+    mutationFn: (data: Omit<ContractInputs["projects"]["update"], "id">) =>
       orpc.projects.update.call({ id, ...data }),
     onSuccess: async () => {
       await queryClient.refetchQueries({

--- a/apps/app/src/hooks/use-services.ts
+++ b/apps/app/src/hooks/use-services.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ContractInputs } from "@/contracts";
 import { orpc } from "@/lib/orpc-client";
-import type { RouterInputs } from "@/server/index";
 
 export function useServices(projectId: string) {
   return useQuery(
@@ -18,8 +18,9 @@ export function useService(id: string) {
 export function useCreateService(projectId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: Omit<RouterInputs["services"]["create"], "projectId">) =>
-      orpc.services.create.call({ projectId, ...data }),
+    mutationFn: (
+      data: Omit<ContractInputs["services"]["create"], "projectId">,
+    ) => orpc.services.create.call({ projectId, ...data }),
     onSuccess: async () => {
       await queryClient.refetchQueries({
         queryKey: orpc.services.listByProject.key({ input: { projectId } }),
@@ -34,7 +35,7 @@ export function useCreateService(projectId: string) {
 export function useUpdateService(id: string, projectId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: Omit<RouterInputs["services"]["update"], "id">) =>
+    mutationFn: (data: Omit<ContractInputs["services"]["update"], "id">) =>
       orpc.services.update.call({ id, ...data }),
     onSuccess: async () => {
       await queryClient.refetchQueries({

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -1,18 +1,18 @@
-import type { RouterInputs, RouterOutputs } from "@/server/index";
+import type { ContractInputs, ContractOutputs } from "@/contracts";
 
-export type Project = RouterOutputs["projects"]["get"];
-export type ProjectListItem = RouterOutputs["projects"]["list"][number];
-export type Service = RouterOutputs["services"]["get"];
-export type Deployment = RouterOutputs["deployments"]["get"];
-export type Domain = RouterOutputs["domains"]["get"];
+export type Project = ContractOutputs["projects"]["get"];
+export type ProjectListItem = ContractOutputs["projects"]["list"][number];
+export type Service = ContractOutputs["services"]["get"];
+export type Deployment = ContractOutputs["deployments"]["get"];
+export type Domain = ContractOutputs["domains"]["get"];
 
 export type ProjectLatestDeployment = NonNullable<
   ProjectListItem["latestDeployment"]
 >;
 
-export type CreateProjectInput = RouterInputs["projects"]["create"];
+export type CreateProjectInput = ContractInputs["projects"]["create"];
 export type CreateServiceInput = Omit<
-  RouterInputs["services"]["create"],
+  ContractInputs["services"]["create"],
   "projectId"
 >;
 

--- a/apps/app/src/lib/orpc-client.ts
+++ b/apps/app/src/lib/orpc-client.ts
@@ -1,13 +1,20 @@
 import { createORPCClient } from "@orpc/client";
-import { RPCLink } from "@orpc/client/fetch";
+import type { ContractRouterClient } from "@orpc/contract";
+import type { JsonifiedClient } from "@orpc/openapi-client";
+import { OpenAPILink } from "@orpc/openapi-client/fetch";
 import { createORPCReactQueryUtils } from "@orpc/react-query";
-import type { RouterClient } from "@orpc/server";
-import type { Router } from "@/server/index";
+import { type Contract, contract } from "@/contracts";
 
-const link = new RPCLink({
-  url: "/api/rpc",
+const link = new OpenAPILink(contract, {
+  url: () => {
+    if (typeof window !== "undefined") {
+      return `${window.location.origin}/api`;
+    }
+    return "http://localhost:3000/api";
+  },
 });
 
-export const client: RouterClient<Router> = createORPCClient(link);
+export const client: JsonifiedClient<ContractRouterClient<Contract>> =
+  createORPCClient(link);
 
 export const orpc = createORPCReactQueryUtils(client);

--- a/apps/app/src/server/api-keys.ts
+++ b/apps/app/src/server/api-keys.ts
@@ -1,60 +1,38 @@
 import { nanoid } from "nanoid";
-import { z } from "zod";
 import { generateApiKey, hashApiKey } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { apiKeysSchema } from "@/lib/db-schemas";
-import { os } from "@/lib/orpc";
-
-const apiKeyOutputSchema = apiKeysSchema.omit({ keyHash: true });
+import { os } from "./orpc";
 
 export const apiKeys = {
-  list: os
-    .route({ method: "GET", path: "/settings/api-keys" })
-    .output(z.array(apiKeyOutputSchema))
-    .handler(async () => {
-      const keys = await db
-        .selectFrom("apiKeys")
-        .select(["id", "name", "keyPrefix", "createdAt", "lastUsedAt"])
-        .orderBy("createdAt", "desc")
-        .execute();
-      return keys;
-    }),
+  list: os.apiKeys.list.handler(() =>
+    db
+      .selectFrom("apiKeys")
+      .select(["id", "name", "keyPrefix", "createdAt", "lastUsedAt"])
+      .orderBy("createdAt", "desc")
+      .execute(),
+  ),
 
-  create: os
-    .route({ method: "POST", path: "/settings/api-keys" })
-    .input(z.object({ name: z.string().min(1) }))
-    .output(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        key: z.string(),
-      }),
-    )
-    .handler(async ({ input }) => {
-      const id = nanoid();
-      const key = generateApiKey();
-      const keyHash = hashApiKey(key);
-      const keyPrefix = key.slice(0, 12);
+  create: os.apiKeys.create.handler(async ({ input }) => {
+    const id = nanoid();
+    const key = generateApiKey();
+    const keyHash = hashApiKey(key);
+    const keyPrefix = key.slice(0, 12);
 
-      await db
-        .insertInto("apiKeys")
-        .values({
-          id,
-          name: input.name,
-          keyPrefix,
-          keyHash,
-        })
-        .execute();
+    await db
+      .insertInto("apiKeys")
+      .values({
+        id,
+        name: input.name,
+        keyPrefix,
+        keyHash,
+      })
+      .execute();
 
-      return { id, name: input.name, key };
-    }),
+    return { id, name: input.name, key };
+  }),
 
-  delete: os
-    .route({ method: "DELETE", path: "/settings/api-keys/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(z.object({ success: z.boolean() }))
-    .handler(async ({ input }) => {
-      await db.deleteFrom("apiKeys").where("id", "=", input.id).execute();
-      return { success: true };
-    }),
+  delete: os.apiKeys.delete.handler(async ({ input }) => {
+    await db.deleteFrom("apiKeys").where("id", "=", input.id).execute();
+    return { success: true };
+  }),
 };

--- a/apps/app/src/server/deployments.ts
+++ b/apps/app/src/server/deployments.ts
@@ -1,69 +1,59 @@
 import { ORPCError } from "@orpc/server";
-import { z } from "zod";
 import { db } from "@/lib/db";
-import { deploymentsSchema } from "@/lib/db-schemas";
 import { rollbackDeployment } from "@/lib/deployer";
 import { imageExists } from "@/lib/docker";
-import { os } from "@/lib/orpc";
+import { os } from "./orpc";
 
 export const deployments = {
-  get: os
-    .route({ method: "GET", path: "/deployments/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(deploymentsSchema)
-    .handler(async ({ input }) => {
-      const deployment = await db
-        .selectFrom("deployments")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
+  get: os.deployments.get.handler(async ({ input }) => {
+    const deployment = await db
+      .selectFrom("deployments")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
 
-      if (!deployment) {
-        throw new ORPCError("NOT_FOUND", { message: "Deployment not found" });
-      }
+    if (!deployment) {
+      throw new ORPCError("NOT_FOUND", { message: "Deployment not found" });
+    }
 
-      return deployment;
-    }),
+    return deployment;
+  }),
 
-  rollback: os
-    .route({ method: "POST", path: "/deployments/{id}/rollback" })
-    .input(z.object({ id: z.string() }))
-    .output(z.object({ deploymentId: z.string() }))
-    .handler(async ({ input }) => {
-      const deployment = await db
-        .selectFrom("deployments")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
+  rollback: os.deployments.rollback.handler(async ({ input }) => {
+    const deployment = await db
+      .selectFrom("deployments")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
 
-      if (!deployment) {
-        throw new ORPCError("NOT_FOUND", { message: "Deployment not found" });
-      }
+    if (!deployment) {
+      throw new ORPCError("NOT_FOUND", { message: "Deployment not found" });
+    }
 
-      if (!deployment.imageName) {
-        throw new ORPCError("BAD_REQUEST", {
-          message: "Deployment has no image snapshot",
-        });
-      }
+    if (!deployment.imageName) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "Deployment has no image snapshot",
+      });
+    }
 
-      const service = await db
-        .selectFrom("services")
-        .select("volumes")
-        .where("id", "=", deployment.serviceId)
-        .executeTakeFirst();
+    const service = await db
+      .selectFrom("services")
+      .select("volumes")
+      .where("id", "=", deployment.serviceId)
+      .executeTakeFirst();
 
-      if (service?.volumes && service.volumes !== "[]") {
-        throw new ORPCError("BAD_REQUEST", {
-          message: "Cannot rollback services with volumes",
-        });
-      }
+    if (service?.volumes && service.volumes !== "[]") {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "Cannot rollback services with volumes",
+      });
+    }
 
-      const exists = await imageExists(deployment.imageName);
-      if (!exists) {
-        throw new ORPCError("GONE", { message: "Image no longer available" });
-      }
+    const exists = await imageExists(deployment.imageName);
+    if (!exists) {
+      throw new ORPCError("GONE", { message: "Image no longer available" });
+    }
 
-      const newDeploymentId = await rollbackDeployment(input.id);
-      return { deploymentId: newDeploymentId };
-    }),
+    const newDeploymentId = await rollbackDeployment(input.id);
+    return { deploymentId: newDeploymentId };
+  }),
 };

--- a/apps/app/src/server/domains.ts
+++ b/apps/app/src/server/domains.ts
@@ -1,9 +1,7 @@
 import https from "node:https";
 import { ORPCError } from "@orpc/server";
-import { z } from "zod";
 import { getSetting } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { domainsSchema } from "@/lib/db-schemas";
 import {
   addDomain,
   getDomain,
@@ -14,21 +12,7 @@ import {
   updateDomain,
   verifyDomainDns,
 } from "@/lib/domains";
-import { os } from "@/lib/orpc";
-
-const dnsVerifyResultSchema = z.object({
-  valid: z.boolean(),
-  serverIp: z.string(),
-  domainIp: z.string().nullable(),
-  dnsVerified: z.boolean(),
-  errorType: z.enum(["no_record", "wrong_ip"]).optional(),
-});
-
-const sslVerifyResultSchema = z.object({
-  working: z.boolean(),
-  status: z.enum(["active", "pending"]),
-  error: z.string().optional(),
-});
+import { os } from "./orpc";
 
 function checkHttps(
   domain: string,
@@ -62,221 +46,173 @@ function checkHttps(
 }
 
 export const domains = {
-  get: os
-    .route({ method: "GET", path: "/domains/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(domainsSchema)
-    .handler(async ({ input }) => {
-      const domain = await getDomain(input.id);
-      if (!domain) {
-        throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
-      }
-      return domain;
-    }),
+  get: os.domains.get.handler(async ({ input }) => {
+    const domain = await getDomain(input.id);
+    if (!domain) {
+      throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
+    }
+    return domain;
+  }),
 
-  listByService: os
-    .route({ method: "GET", path: "/services/{serviceId}/domains" })
-    .input(z.object({ serviceId: z.string() }))
-    .output(z.array(domainsSchema))
-    .handler(async ({ input }) => {
-      const service = await db
-        .selectFrom("services")
-        .select("id")
-        .where("id", "=", input.serviceId)
-        .executeTakeFirst();
+  listByService: os.domains.listByService.handler(async ({ input }) => {
+    const service = await db
+      .selectFrom("services")
+      .select("id")
+      .where("id", "=", input.serviceId)
+      .executeTakeFirst();
 
-      if (!service) {
-        throw new ORPCError("NOT_FOUND", { message: "Service not found" });
-      }
+    if (!service) {
+      throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
 
-      return await getDomainsForService(input.serviceId);
-    }),
+    return getDomainsForService(input.serviceId);
+  }),
 
-  listByServiceIds: os
-    .input(z.object({ serviceIds: z.array(z.string()) }))
-    .output(z.array(domainsSchema))
-    .handler(async ({ input }) => {
-      if (input.serviceIds.length === 0) {
-        return [];
-      }
-      return await db
+  listByServiceIds: os.domains.listByServiceIds.handler(async ({ input }) => {
+    if (input.serviceIds.length === 0) {
+      return [];
+    }
+    return db
+      .selectFrom("domains")
+      .selectAll()
+      .where("serviceId", "in", input.serviceIds)
+      .execute();
+  }),
+
+  create: os.domains.create.handler(async ({ input }) => {
+    const service = await db
+      .selectFrom("services")
+      .select("id")
+      .where("id", "=", input.serviceId)
+      .executeTakeFirst();
+
+    if (!service) {
+      throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
+
+    const existing = await getDomainByName(input.domain);
+    if (existing) {
+      throw new ORPCError("CONFLICT", { message: "Domain already exists" });
+    }
+
+    if (input.type === "redirect" && !input.redirectTarget) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "redirectTarget is required for redirect type",
+      });
+    }
+
+    return addDomain(input.serviceId, {
+      domain: input.domain,
+      type: input.type,
+      redirectTarget: input.redirectTarget,
+      redirectCode: input.redirectCode,
+    });
+  }),
+
+  update: os.domains.update.handler(async ({ input }) => {
+    const domain = await getDomain(input.id);
+    if (!domain) {
+      throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
+    }
+
+    const updates: Parameters<typeof updateDomain>[1] = {};
+    if (input.type !== undefined) updates.type = input.type;
+    if (input.redirectTarget !== undefined)
+      updates.redirectTarget = input.redirectTarget;
+    if (input.redirectCode !== undefined)
+      updates.redirectCode = input.redirectCode;
+
+    const updated = await updateDomain(input.id, updates);
+
+    if (domain.dnsVerified) {
+      try {
+        await syncCaddyConfig();
+      } catch {}
+    }
+
+    return updated;
+  }),
+
+  delete: os.domains.delete.handler(async ({ input }) => {
+    const domain = await getDomain(input.id);
+    if (!domain) {
+      throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
+    }
+
+    if (domain.isSystem) {
+      const otherVerifiedDomains = await db
         .selectFrom("domains")
-        .selectAll()
-        .where("serviceId", "in", input.serviceIds)
-        .execute();
-    }),
-
-  create: os
-    .route({ method: "POST", path: "/services/{serviceId}/domains" })
-    .input(
-      z.object({
-        serviceId: z.string(),
-        domain: z.string().min(1),
-        type: z.enum(["proxy", "redirect"]).default("proxy"),
-        redirectTarget: z.string().optional(),
-        redirectCode: z.union([z.literal(301), z.literal(307)]).optional(),
-      }),
-    )
-    .output(domainsSchema)
-    .handler(async ({ input }) => {
-      const service = await db
-        .selectFrom("services")
         .select("id")
-        .where("id", "=", input.serviceId)
-        .executeTakeFirst();
+        .where("serviceId", "=", domain.serviceId)
+        .where("id", "!=", input.id)
+        .where("dnsVerified", "=", true)
+        .execute();
 
-      if (!service) {
-        throw new ORPCError("NOT_FOUND", { message: "Service not found" });
-      }
-
-      const existing = await getDomainByName(input.domain);
-      if (existing) {
-        throw new ORPCError("CONFLICT", { message: "Domain already exists" });
-      }
-
-      if (input.type === "redirect" && !input.redirectTarget) {
+      if (otherVerifiedDomains.length === 0) {
         throw new ORPCError("BAD_REQUEST", {
-          message: "redirectTarget is required for redirect type",
+          message:
+            "Cannot delete system domain when no other verified domain exists",
         });
       }
+    }
 
-      const newDomain = await addDomain(input.serviceId, {
-        domain: input.domain,
-        type: input.type,
-        redirectTarget: input.redirectTarget,
-        redirectCode: input.redirectCode,
-      });
+    await removeDomain(input.id);
 
-      return newDomain;
-    }),
+    if (domain.dnsVerified) {
+      try {
+        await syncCaddyConfig();
+      } catch {}
+    }
 
-  update: os
-    .route({ method: "PATCH", path: "/domains/{id}" })
-    .input(
-      z.object({
-        id: z.string(),
-        type: z.enum(["proxy", "redirect"]).optional(),
-        redirectTarget: z.string().optional(),
-        redirectCode: z.union([z.literal(301), z.literal(307)]).optional(),
-      }),
-    )
-    .output(domainsSchema)
-    .handler(async ({ input }) => {
-      const domain = await getDomain(input.id);
-      if (!domain) {
-        throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
+    return { success: true };
+  }),
+
+  verifyDns: os.domains.verifyDns.handler(async ({ input }) => {
+    const domain = await getDomain(input.id);
+    if (!domain) {
+      throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
+    }
+
+    const dnsStatus = await verifyDomainDns(domain.domain);
+
+    if (dnsStatus.valid && !domain.dnsVerified) {
+      await updateDomain(input.id, { dnsVerified: true });
+      try {
+        await syncCaddyConfig();
+      } catch (err) {
+        console.error("Failed to sync Caddy config:", err);
       }
+    }
 
-      const updates: Parameters<typeof updateDomain>[1] = {};
-      if (input.type !== undefined) updates.type = input.type;
-      if (input.redirectTarget !== undefined)
-        updates.redirectTarget = input.redirectTarget;
-      if (input.redirectCode !== undefined)
-        updates.redirectCode = input.redirectCode;
+    return { ...dnsStatus, dnsVerified: dnsStatus.valid };
+  }),
 
-      const updated = await updateDomain(input.id, updates);
+  verifySsl: os.domains.verifySsl.handler(async ({ input }) => {
+    const domain = await getDomain(input.id);
+    if (!domain) {
+      throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
+    }
 
-      if (domain.dnsVerified) {
-        try {
-          await syncCaddyConfig();
-        } catch {}
-      }
+    if (!domain.dnsVerified) {
+      throw new ORPCError("BAD_REQUEST", { message: "DNS not verified" });
+    }
 
-      return updated;
-    }),
+    if (domain.sslStatus === "active") {
+      return { working: true, status: "active" as const };
+    }
 
-  delete: os
-    .route({ method: "DELETE", path: "/domains/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(z.object({ success: z.boolean() }))
-    .handler(async ({ input }) => {
-      const domain = await getDomain(input.id);
-      if (!domain) {
-        throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
-      }
+    const staging = (await getSetting("ssl_staging")) === "true";
+    const result = await checkHttps(domain.domain, !staging);
 
-      if (domain.isSystem) {
-        const otherVerifiedDomains = await db
-          .selectFrom("domains")
-          .select("id")
-          .where("serviceId", "=", domain.serviceId)
-          .where("id", "!=", input.id)
-          .where("dnsVerified", "=", true)
-          .execute();
+    if (result.ok) {
+      await updateDomain(input.id, { sslStatus: "active" });
+      return { working: true, status: "active" as const };
+    }
 
-        if (otherVerifiedDomains.length === 0) {
-          throw new ORPCError("BAD_REQUEST", {
-            message:
-              "Cannot delete system domain when no other verified domain exists",
-          });
-        }
-      }
-
-      await removeDomain(input.id);
-
-      if (domain.dnsVerified) {
-        try {
-          await syncCaddyConfig();
-        } catch {}
-      }
-
-      return { success: true };
-    }),
-
-  verifyDns: os
-    .route({ method: "POST", path: "/domains/{id}/verify-dns" })
-    .input(z.object({ id: z.string() }))
-    .output(dnsVerifyResultSchema)
-    .handler(async ({ input }) => {
-      const domain = await getDomain(input.id);
-      if (!domain) {
-        throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
-      }
-
-      const dnsStatus = await verifyDomainDns(domain.domain);
-
-      if (dnsStatus.valid && !domain.dnsVerified) {
-        await updateDomain(input.id, { dnsVerified: true });
-        try {
-          await syncCaddyConfig();
-        } catch (err) {
-          console.error("Failed to sync Caddy config:", err);
-        }
-      }
-
-      return { ...dnsStatus, dnsVerified: dnsStatus.valid };
-    }),
-
-  verifySsl: os
-    .route({ method: "POST", path: "/domains/{id}/verify-ssl" })
-    .input(z.object({ id: z.string() }))
-    .output(sslVerifyResultSchema)
-    .handler(async ({ input }) => {
-      const domain = await getDomain(input.id);
-      if (!domain) {
-        throw new ORPCError("NOT_FOUND", { message: "Domain not found" });
-      }
-
-      if (!domain.dnsVerified) {
-        throw new ORPCError("BAD_REQUEST", { message: "DNS not verified" });
-      }
-
-      if (domain.sslStatus === "active") {
-        return { working: true, status: "active" as const };
-      }
-
-      const staging = (await getSetting("ssl_staging")) === "true";
-      const result = await checkHttps(domain.domain, !staging);
-
-      if (result.ok) {
-        await updateDomain(input.id, { sslStatus: "active" });
-        return { working: true, status: "active" as const };
-      }
-
-      return {
-        working: false,
-        status: "pending" as const,
-        error: result.error,
-      };
-    }),
+    return {
+      working: false,
+      status: "pending" as const,
+      error: result.error,
+    };
+  }),
 };

--- a/apps/app/src/server/health.ts
+++ b/apps/app/src/server/health.ts
@@ -1,22 +1,15 @@
 import * as nodeOs from "node:os";
-import { z } from "zod";
-import { os } from "@/lib/orpc";
 import packageJson from "../../package.json";
+import { os } from "./orpc";
 
 export const health = {
-  check: os
-    .route({ method: "GET", path: "/health" })
-    .output(z.object({ ok: z.boolean(), version: z.string() }))
-    .handler(async () => {
-      return { ok: true, version: packageJson.version };
-    }),
+  check: os.health.check.handler(() => ({
+    ok: true,
+    version: packageJson.version,
+  })),
 
-  hostResources: os
-    .route({ method: "GET", path: "/host-resources" })
-    .output(z.object({ cpus: z.number(), totalMemoryGB: z.number() }))
-    .handler(async () => {
-      const cpus = nodeOs.cpus().length;
-      const totalMemoryGB = Math.floor(nodeOs.totalmem() / 1024 / 1024 / 1024);
-      return { cpus, totalMemoryGB };
-    }),
+  hostResources: os.health.hostResources.handler(() => ({
+    cpus: nodeOs.cpus().length,
+    totalMemoryGB: Math.floor(nodeOs.totalmem() / 1024 / 1024 / 1024),
+  })),
 };

--- a/apps/app/src/server/index.ts
+++ b/apps/app/src/server/index.ts
@@ -1,14 +1,14 @@
-import type { InferRouterInputs, InferRouterOutputs } from "@orpc/server";
 import { apiKeys } from "./api-keys";
 import { deployments } from "./deployments";
 import { domains } from "./domains";
 import { health } from "./health";
+import { os } from "./orpc";
 import { projects } from "./projects";
 import { registries } from "./registries";
 import { services } from "./services";
 import { dbTemplates, templates } from "./templates";
 
-export const router = {
+export const router = os.router({
   apiKeys,
   dbTemplates,
   deployments,
@@ -18,8 +18,6 @@ export const router = {
   registries,
   services,
   templates,
-};
+});
 
 export type Router = typeof router;
-export type RouterInputs = InferRouterInputs<Router>;
-export type RouterOutputs = InferRouterOutputs<Router>;

--- a/apps/app/src/server/orpc.ts
+++ b/apps/app/src/server/orpc.ts
@@ -1,7 +1,8 @@
-import { os as baseOs, onError } from "@orpc/server";
+import { implement, onError } from "@orpc/server";
+import { contract } from "@/contracts";
 import type { Context } from "@/server/context";
 
-export const os = baseOs
+export const os = implement(contract)
   .$context<Context>()
   .use(async ({ context, next }) => {
     const start = Date.now();

--- a/apps/app/src/server/projects.ts
+++ b/apps/app/src/server/projects.ts
@@ -1,344 +1,272 @@
 import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
-import { z } from "zod";
 import { getSetting } from "@/lib/auth";
 import { db } from "@/lib/db";
-import {
-  deploymentsSchema,
-  projectsSchema,
-  servicesSchema,
-} from "@/lib/db-schemas";
 import { deployProject, deployService } from "@/lib/deployer";
 import { removeNetwork, stopContainer } from "@/lib/docker";
-import { os } from "@/lib/orpc";
 import { slugify } from "@/lib/slugify";
 import { generateSelfSignedCert } from "@/lib/ssl";
 import { getTemplate, resolveTemplateServices } from "@/lib/templates";
-
-const envVarSchema = z.object({
-  key: z.string(),
-  value: z.string(),
-});
-
-const latestDeploymentSchema = z.object({
-  status: z.string(),
-  commitMessage: z.string().nullable(),
-  createdAt: z.number(),
-  branch: z.string().nullable(),
-});
-
-const projectListItemSchema = projectsSchema.extend({
-  servicesCount: z.number(),
-  latestDeployment: latestDeploymentSchema.nullable(),
-  repoUrl: z.string().nullable(),
-  runningUrl: z.string().nullable(),
-});
-
-const serviceWithDeploymentSchema = servicesSchema.extend({
-  latestDeployment: deploymentsSchema.nullable(),
-});
-
-const projectWithServicesSchema = projectsSchema.extend({
-  services: z.array(serviceWithDeploymentSchema),
-});
+import { os } from "./orpc";
 
 export const projects = {
-  list: os
-    .route({ method: "GET", path: "/projects" })
-    .output(z.array(projectListItemSchema))
-    .handler(async () => {
-      const [projectRows, domain] = await Promise.all([
-        db.selectFrom("projects").selectAll().execute(),
-        getSetting("domain"),
-      ]);
+  list: os.projects.list.handler(async () => {
+    const [projectRows, domain] = await Promise.all([
+      db.selectFrom("projects").selectAll().execute(),
+      getSetting("domain"),
+    ]);
 
-      const projectsWithDetails = await Promise.all(
-        projectRows.map(async (project) => {
-          const services = await db
-            .selectFrom("services")
-            .selectAll()
-            .where("projectId", "=", project.id)
-            .execute();
+    return Promise.all(
+      projectRows.map(async (project) => {
+        const services = await db
+          .selectFrom("services")
+          .selectAll()
+          .where("projectId", "=", project.id)
+          .execute();
 
-          const latestDeployment = await db
-            .selectFrom("deployments")
-            .innerJoin("services", "services.id", "deployments.serviceId")
-            .select([
-              "deployments.status",
-              "deployments.commitMessage",
-              "deployments.createdAt",
-              "services.branch",
-            ])
-            .where("deployments.projectId", "=", project.id)
-            .orderBy("deployments.createdAt", "desc")
-            .executeTakeFirst();
+        const latestDeployment = await db
+          .selectFrom("deployments")
+          .innerJoin("services", "services.id", "deployments.serviceId")
+          .select([
+            "deployments.status",
+            "deployments.commitMessage",
+            "deployments.createdAt",
+            "services.branch",
+          ])
+          .where("deployments.projectId", "=", project.id)
+          .orderBy("deployments.createdAt", "desc")
+          .executeTakeFirst();
 
-          const runningDeployment = await db
-            .selectFrom("deployments")
-            .select(["hostPort"])
-            .where("projectId", "=", project.id)
-            .where("status", "=", "running")
-            .where("hostPort", "is not", null)
-            .executeTakeFirst();
+        const runningDeployment = await db
+          .selectFrom("deployments")
+          .select(["hostPort"])
+          .where("projectId", "=", project.id)
+          .where("status", "=", "running")
+          .where("hostPort", "is not", null)
+          .executeTakeFirst();
 
-          const firstService = services[0];
-          const repoUrl = firstService?.repoUrl ?? null;
+        const repoUrl = services[0]?.repoUrl ?? null;
 
-          let runningUrl: string | null = null;
-          if (runningDeployment?.hostPort) {
-            runningUrl = domain
-              ? `${domain}:${runningDeployment.hostPort}`
-              : `localhost:${runningDeployment.hostPort}`;
-          }
+        let runningUrl: string | null = null;
+        if (runningDeployment?.hostPort) {
+          runningUrl = domain
+            ? `${domain}:${runningDeployment.hostPort}`
+            : `localhost:${runningDeployment.hostPort}`;
+        }
 
-          return {
-            ...project,
-            servicesCount: services.length,
-            latestDeployment: latestDeployment
-              ? {
-                  status: latestDeployment.status,
-                  commitMessage: latestDeployment.commitMessage,
-                  createdAt: latestDeployment.createdAt,
-                  branch: latestDeployment.branch,
-                }
-              : null,
-            repoUrl,
-            runningUrl,
-          };
-        }),
-      );
-
-      return projectsWithDetails;
-    }),
-
-  get: os
-    .route({ method: "GET", path: "/projects/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(projectWithServicesSchema)
-    .handler(async ({ input }) => {
-      const project = await db
-        .selectFrom("projects")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
-
-      if (!project) {
-        throw new ORPCError("NOT_FOUND", { message: "Project not found" });
-      }
-
-      const services = await db
-        .selectFrom("services")
-        .selectAll()
-        .where("projectId", "=", input.id)
-        .execute();
-
-      const servicesWithDeployments = await Promise.all(
-        services.map(async (service) => {
-          const latestDeployment = await db
-            .selectFrom("deployments")
-            .selectAll()
-            .where("serviceId", "=", service.id)
-            .orderBy("createdAt", "desc")
-            .limit(1)
-            .executeTakeFirst();
-
-          return { ...service, latestDeployment: latestDeployment ?? null };
-        }),
-      );
-
-      return { ...project, services: servicesWithDeployments };
-    }),
-
-  create: os
-    .route({ method: "POST", path: "/projects" })
-    .input(
-      z.object({
-        name: z.string().min(1),
-        envVars: z.array(envVarSchema).default([]),
-        templateId: z.string().optional(),
+        return {
+          ...project,
+          servicesCount: services.length,
+          latestDeployment: latestDeployment
+            ? {
+                status: latestDeployment.status,
+                commitMessage: latestDeployment.commitMessage,
+                createdAt: latestDeployment.createdAt,
+                branch: latestDeployment.branch,
+              }
+            : null,
+          repoUrl,
+          runningUrl,
+        };
       }),
-    )
-    .output(projectsSchema)
-    .handler(async ({ input }) => {
-      if (input.templateId) {
-        const template = getTemplate(input.templateId);
-        if (!template) {
-          throw new ORPCError("BAD_REQUEST", {
-            message: "Unknown template",
-          });
-        }
-        if (template.type !== "project") {
-          throw new ORPCError("BAD_REQUEST", {
-            message: "Template is not a project template",
-          });
-        }
-      }
+    );
+  }),
 
-      const id = nanoid();
-      const now = Date.now();
-      const hostname = slugify(input.name);
+  get: os.projects.get.handler(async ({ input }) => {
+    const project = await db
+      .selectFrom("projects")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
 
-      await db
-        .insertInto("projects")
-        .values({
-          id,
-          name: input.name,
-          hostname,
-          envVars: JSON.stringify(input.envVars),
-          createdAt: now,
-        })
-        .execute();
+    if (!project) {
+      throw new ORPCError("NOT_FOUND", { message: "Project not found" });
+    }
 
-      const project = await db
-        .selectFrom("projects")
-        .selectAll()
-        .where("id", "=", id)
-        .executeTakeFirst();
+    const services = await db
+      .selectFrom("services")
+      .selectAll()
+      .where("projectId", "=", input.id)
+      .execute();
 
-      if (!project) {
-        throw new ORPCError("INTERNAL_SERVER_ERROR", {
-          message: "Failed to create project",
+    const servicesWithDeployments = await Promise.all(
+      services.map(async (service) => {
+        const latestDeployment = await db
+          .selectFrom("deployments")
+          .selectAll()
+          .where("serviceId", "=", service.id)
+          .orderBy("createdAt", "desc")
+          .limit(1)
+          .executeTakeFirst();
+
+        return { ...service, latestDeployment: latestDeployment ?? null };
+      }),
+    );
+
+    return { ...project, services: servicesWithDeployments };
+  }),
+
+  create: os.projects.create.handler(async ({ input }) => {
+    if (input.templateId) {
+      const template = getTemplate(input.templateId);
+      if (!template) {
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Unknown template",
         });
       }
-
-      if (input.templateId) {
-        const template = getTemplate(input.templateId)!;
-        const resolved = resolveTemplateServices(template);
-
-        for (const svc of resolved) {
-          const serviceId = nanoid();
-          const serviceHostname = slugify(svc.name);
-
-          await db
-            .insertInto("services")
-            .values({
-              id: serviceId,
-              projectId: id,
-              name: svc.name,
-              hostname: serviceHostname,
-              deployType: "image",
-              repoUrl: null,
-              branch: null,
-              dockerfilePath: null,
-              imageUrl: svc.image,
-              envVars: JSON.stringify(svc.envVars),
-              containerPort: svc.port,
-              healthCheckPath: svc.healthCheckPath ?? null,
-              healthCheckTimeout: svc.healthCheckTimeout,
-              autoDeploy: 0,
-              serviceType: svc.isDatabase ? "database" : "app",
-              volumes: JSON.stringify(svc.volumes),
-              command: svc.command ?? null,
-              createdAt: now,
-            })
-            .execute();
-
-          if (svc.ssl) {
-            await generateSelfSignedCert(serviceId);
-          }
-
-          deployService(serviceId).catch((err) => {
-            console.error(`Auto-deploy failed for service ${serviceId}:`, err);
-          });
-        }
+      if (template.type !== "project") {
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Template is not a project template",
+        });
       }
+    }
 
-      return project;
-    }),
+    const id = nanoid();
+    const now = Date.now();
+    const hostname = slugify(input.name);
 
-  update: os
-    .route({ method: "PATCH", path: "/projects/{id}" })
-    .input(
-      z.object({
-        id: z.string(),
-        name: z.string().optional(),
-        envVars: z.array(envVarSchema).optional(),
-        canvasPositions: z.string().optional(),
-      }),
-    )
-    .output(projectsSchema)
-    .handler(async ({ input }) => {
-      const project = await db
-        .selectFrom("projects")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
+    await db
+      .insertInto("projects")
+      .values({
+        id,
+        name: input.name,
+        hostname,
+        envVars: JSON.stringify(input.envVars),
+        createdAt: now,
+      })
+      .execute();
 
-      if (!project) {
-        throw new ORPCError("NOT_FOUND", { message: "Project not found" });
-      }
+    const project = await db
+      .selectFrom("projects")
+      .selectAll()
+      .where("id", "=", id)
+      .executeTakeFirst();
 
-      const updates: Record<string, unknown> = {};
-      if (input.name !== undefined) {
-        updates.name = input.name;
-      }
-      if (input.envVars !== undefined) {
-        updates.envVars = JSON.stringify(input.envVars);
-      }
-      if (input.canvasPositions !== undefined) {
-        updates.canvasPositions = input.canvasPositions;
-      }
+    if (!project) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "Failed to create project",
+      });
+    }
 
-      if (Object.keys(updates).length > 0) {
+    if (input.templateId) {
+      const template = getTemplate(input.templateId)!;
+      const resolved = resolveTemplateServices(template);
+
+      for (const svc of resolved) {
+        const serviceId = nanoid();
+        const serviceHostname = slugify(svc.name);
+
         await db
-          .updateTable("projects")
-          .set(updates)
-          .where("id", "=", input.id)
+          .insertInto("services")
+          .values({
+            id: serviceId,
+            projectId: id,
+            name: svc.name,
+            hostname: serviceHostname,
+            deployType: "image",
+            repoUrl: null,
+            branch: null,
+            dockerfilePath: null,
+            imageUrl: svc.image,
+            envVars: JSON.stringify(svc.envVars),
+            containerPort: svc.port,
+            healthCheckPath: svc.healthCheckPath ?? null,
+            healthCheckTimeout: svc.healthCheckTimeout,
+            autoDeploy: 0,
+            serviceType: svc.isDatabase ? "database" : "app",
+            volumes: JSON.stringify(svc.volumes),
+            command: svc.command ?? null,
+            createdAt: now,
+          })
           .execute();
-      }
 
-      const updated = await db
-        .selectFrom("projects")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
-
-      if (!updated) {
-        throw new ORPCError("NOT_FOUND", { message: "Project not found" });
-      }
-
-      return updated;
-    }),
-
-  delete: os
-    .route({ method: "DELETE", path: "/projects/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(z.object({ success: z.boolean() }))
-    .handler(async ({ input }) => {
-      const deployments = await db
-        .selectFrom("deployments")
-        .select(["id", "containerId"])
-        .where("projectId", "=", input.id)
-        .execute();
-
-      for (const deployment of deployments) {
-        if (deployment.containerId) {
-          await stopContainer(deployment.containerId);
+        if (svc.ssl) {
+          await generateSelfSignedCert(serviceId);
         }
+
+        deployService(serviceId).catch((err) => {
+          console.error(`Auto-deploy failed for service ${serviceId}:`, err);
+        });
       }
+    }
 
-      await removeNetwork(`frost-net-${input.id}`.toLowerCase());
-      await db.deleteFrom("projects").where("id", "=", input.id).execute();
+    return project;
+  }),
 
-      return { success: true };
-    }),
+  update: os.projects.update.handler(async ({ input }) => {
+    const project = await db
+      .selectFrom("projects")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
 
-  deploy: os
-    .route({ method: "POST", path: "/projects/{id}/deploy" })
-    .input(z.object({ id: z.string() }))
-    .output(z.object({ deploymentIds: z.array(z.string()) }))
-    .handler(async ({ input }) => {
-      const project = await db
-        .selectFrom("projects")
-        .select("id")
+    if (!project) {
+      throw new ORPCError("NOT_FOUND", { message: "Project not found" });
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (input.name !== undefined) {
+      updates.name = input.name;
+    }
+    if (input.envVars !== undefined) {
+      updates.envVars = JSON.stringify(input.envVars);
+    }
+    if (input.canvasPositions !== undefined) {
+      updates.canvasPositions = input.canvasPositions;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await db
+        .updateTable("projects")
+        .set(updates)
         .where("id", "=", input.id)
-        .executeTakeFirst();
+        .execute();
+    }
 
-      if (!project) {
-        throw new ORPCError("NOT_FOUND", { message: "Project not found" });
+    const updated = await db
+      .selectFrom("projects")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    if (!updated) {
+      throw new ORPCError("NOT_FOUND", { message: "Project not found" });
+    }
+
+    return updated;
+  }),
+
+  delete: os.projects.delete.handler(async ({ input }) => {
+    const deployments = await db
+      .selectFrom("deployments")
+      .select(["id", "containerId"])
+      .where("projectId", "=", input.id)
+      .execute();
+
+    for (const deployment of deployments) {
+      if (deployment.containerId) {
+        await stopContainer(deployment.containerId);
       }
+    }
 
-      const deploymentIds = await deployProject(input.id);
-      return { deploymentIds };
-    }),
+    await removeNetwork(`frost-net-${input.id}`.toLowerCase());
+    await db.deleteFrom("projects").where("id", "=", input.id).execute();
+
+    return { success: true };
+  }),
+
+  deploy: os.projects.deploy.handler(async ({ input }) => {
+    const project = await db
+      .selectFrom("projects")
+      .select("id")
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    if (!project) {
+      throw new ORPCError("NOT_FOUND", { message: "Project not found" });
+    }
+
+    const deploymentIds = await deployProject(input.id);
+    return { deploymentIds };
+  }),
 };

--- a/apps/app/src/server/registries.ts
+++ b/apps/app/src/server/registries.ts
@@ -1,51 +1,85 @@
 import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
-import { z } from "zod";
 import { encrypt } from "@/lib/crypto";
 import { db } from "@/lib/db";
-import { registryOutputSchema } from "@/lib/db-schemas";
 import { dockerLogin, getRegistryUrl } from "@/lib/docker";
-import { os } from "@/lib/orpc";
+import { os } from "./orpc";
+
+type RegistryType = "ghcr" | "dockerhub" | "custom";
 
 export const registries = {
-  list: os
-    .route({ method: "GET", path: "/registries" })
-    .output(z.array(registryOutputSchema))
-    .handler(async () => {
-      const rows = await db
-        .selectFrom("registries")
-        .select(["id", "name", "type", "url", "username", "createdAt"])
-        .orderBy("createdAt", "desc")
-        .execute();
-      return rows.map((row) => ({
-        ...row,
-        type: row.type as "ghcr" | "dockerhub" | "custom",
-      }));
-    }),
+  list: os.registries.list.handler(async () => {
+    const rows = await db
+      .selectFrom("registries")
+      .select(["id", "name", "type", "url", "username", "createdAt"])
+      .orderBy("createdAt", "desc")
+      .execute();
+    return rows.map((row) => ({ ...row, type: row.type as RegistryType }));
+  }),
 
-  create: os
-    .route({ method: "POST", path: "/registries" })
-    .input(
-      z.object({
-        name: z.string().min(1),
-        type: z.enum(["ghcr", "dockerhub", "custom"]),
-        url: z.string().optional(),
-        username: z.string().min(1),
-        password: z.string().min(1),
-      }),
-    )
-    .output(registryOutputSchema)
-    .handler(async ({ input }) => {
-      if (input.type === "custom" && !input.url) {
-        throw new ORPCError("BAD_REQUEST", {
-          message: "URL is required for custom registries",
-        });
-      }
+  create: os.registries.create.handler(async ({ input }) => {
+    if (input.type === "custom" && !input.url) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "URL is required for custom registries",
+      });
+    }
 
-      const registryUrl = getRegistryUrl(input.type, input.url ?? null);
+    const registryUrl = getRegistryUrl(input.type, input.url ?? null);
+    const loginResult = await dockerLogin(
+      registryUrl,
+      input.username,
+      input.password,
+    );
+    if (!loginResult.success) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: `Invalid registry credentials: ${loginResult.error}`,
+      });
+    }
+
+    const id = nanoid();
+    const now = Date.now();
+    const passwordEncrypted = encrypt(input.password);
+
+    await db
+      .insertInto("registries")
+      .values({
+        id,
+        name: input.name,
+        type: input.type,
+        url: input.url ?? null,
+        username: input.username,
+        passwordEncrypted,
+        createdAt: now,
+      })
+      .execute();
+
+    return {
+      id,
+      name: input.name,
+      type: input.type,
+      url: input.url ?? null,
+      username: input.username,
+      createdAt: now,
+    };
+  }),
+
+  update: os.registries.update.handler(async ({ input }) => {
+    const existing = await db
+      .selectFrom("registries")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    if (!existing) {
+      throw new ORPCError("NOT_FOUND", { message: "Registry not found" });
+    }
+
+    if (input.password) {
+      const registryUrl = getRegistryUrl(existing.type, existing.url);
+      const username = input.username ?? existing.username;
       const loginResult = await dockerLogin(
         registryUrl,
-        input.username,
+        username,
         input.password,
       );
       if (!loginResult.success) {
@@ -53,114 +87,44 @@ export const registries = {
           message: `Invalid registry credentials: ${loginResult.error}`,
         });
       }
+    }
 
-      const id = nanoid();
-      const now = Date.now();
-      const passwordEncrypted = encrypt(input.password);
+    const updates: Record<string, unknown> = {};
+    if (input.name) updates.name = input.name;
+    if (input.username) updates.username = input.username;
+    if (input.password) updates.passwordEncrypted = encrypt(input.password);
 
+    if (Object.keys(updates).length > 0) {
       await db
-        .insertInto("registries")
-        .values({
-          id,
-          name: input.name,
-          type: input.type,
-          url: input.url ?? null,
-          username: input.username,
-          passwordEncrypted,
-          createdAt: now,
-        })
-        .execute();
-
-      return {
-        id,
-        name: input.name,
-        type: input.type,
-        url: input.url ?? null,
-        username: input.username,
-        createdAt: now,
-      };
-    }),
-
-  update: os
-    .route({ method: "PATCH", path: "/registries/{id}" })
-    .input(
-      z.object({
-        id: z.string(),
-        name: z.string().min(1).optional(),
-        username: z.string().min(1).optional(),
-        password: z.string().min(1).optional(),
-      }),
-    )
-    .output(registryOutputSchema)
-    .handler(async ({ input }) => {
-      const existing = await db
-        .selectFrom("registries")
-        .selectAll()
+        .updateTable("registries")
+        .set(updates)
         .where("id", "=", input.id)
-        .executeTakeFirst();
-
-      if (!existing) {
-        throw new ORPCError("NOT_FOUND", { message: "Registry not found" });
-      }
-
-      if (input.password) {
-        const registryUrl = getRegistryUrl(existing.type, existing.url);
-        const username = input.username ?? existing.username;
-        const loginResult = await dockerLogin(
-          registryUrl,
-          username,
-          input.password,
-        );
-        if (!loginResult.success) {
-          throw new ORPCError("BAD_REQUEST", {
-            message: `Invalid registry credentials: ${loginResult.error}`,
-          });
-        }
-      }
-
-      const updates: Record<string, unknown> = {};
-      if (input.name) updates.name = input.name;
-      if (input.username) updates.username = input.username;
-      if (input.password) updates.passwordEncrypted = encrypt(input.password);
-
-      if (Object.keys(updates).length > 0) {
-        await db
-          .updateTable("registries")
-          .set(updates)
-          .where("id", "=", input.id)
-          .execute();
-      }
-
-      const updated = await db
-        .selectFrom("registries")
-        .select(["id", "name", "type", "url", "username", "createdAt"])
-        .where("id", "=", input.id)
-        .executeTakeFirstOrThrow();
-
-      return {
-        ...updated,
-        type: updated.type as "ghcr" | "dockerhub" | "custom",
-      };
-    }),
-
-  delete: os
-    .route({ method: "DELETE", path: "/registries/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(z.object({ success: z.boolean() }))
-    .handler(async ({ input }) => {
-      const servicesUsingRegistry = await db
-        .selectFrom("services")
-        .select("id")
-        .where("registryId", "=", input.id)
         .execute();
+    }
 
-      if (servicesUsingRegistry.length > 0) {
-        throw new ORPCError("BAD_REQUEST", {
-          message: `Registry is in use by ${servicesUsingRegistry.length} service(s)`,
-        });
-      }
+    const updated = await db
+      .selectFrom("registries")
+      .select(["id", "name", "type", "url", "username", "createdAt"])
+      .where("id", "=", input.id)
+      .executeTakeFirstOrThrow();
 
-      await db.deleteFrom("registries").where("id", "=", input.id).execute();
-      return { success: true };
-    }),
+    return { ...updated, type: updated.type as RegistryType };
+  }),
+
+  delete: os.registries.delete.handler(async ({ input }) => {
+    const servicesUsingRegistry = await db
+      .selectFrom("services")
+      .select("id")
+      .where("registryId", "=", input.id)
+      .execute();
+
+    if (servicesUsingRegistry.length > 0) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: `Registry is in use by ${servicesUsingRegistry.length} service(s)`,
+      });
+    }
+
+    await db.deleteFrom("registries").where("id", "=", input.id).execute();
+    return { success: true };
+  }),
 };

--- a/apps/app/src/server/services.ts
+++ b/apps/app/src/server/services.ts
@@ -1,475 +1,363 @@
 import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
-import { z } from "zod";
 import { db } from "@/lib/db";
-import { deploymentsSchema, servicesSchema } from "@/lib/db-schemas";
 import { deployService } from "@/lib/deployer";
 import { stopContainer } from "@/lib/docker";
 import { createWildcardDomain, syncCaddyConfig } from "@/lib/domains";
-import { os } from "@/lib/orpc";
 import { slugify } from "@/lib/slugify";
 import { generateSelfSignedCert, removeSSLCerts } from "@/lib/ssl";
 import { getTemplate, resolveTemplateServices } from "@/lib/templates";
 import { buildVolumeName, getVolumeSize, removeVolume } from "@/lib/volumes";
-
-const envVarSchema = z.object({
-  key: z.string(),
-  value: z.string(),
-});
-
-const idParamSchema = z.object({ id: z.string() });
-
-const serviceWithDeploymentSchema = servicesSchema.extend({
-  latestDeployment: deploymentsSchema.nullable(),
-});
+import { os } from "./orpc";
 
 export const services = {
-  get: os
-    .route({ method: "GET", path: "/services/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(serviceWithDeploymentSchema)
-    .handler(async ({ input }) => {
-      const service = await db
-        .selectFrom("services")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
+  get: os.services.get.handler(async ({ input }) => {
+    const service = await db
+      .selectFrom("services")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
 
-      if (!service) {
-        throw new ORPCError("NOT_FOUND", { message: "Service not found" });
-      }
+    if (!service) {
+      throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
 
-      const latestDeployment = await db
-        .selectFrom("deployments")
-        .selectAll()
-        .where("serviceId", "=", input.id)
-        .orderBy("createdAt", "desc")
-        .limit(1)
-        .executeTakeFirst();
+    const latestDeployment = await db
+      .selectFrom("deployments")
+      .selectAll()
+      .where("serviceId", "=", input.id)
+      .orderBy("createdAt", "desc")
+      .limit(1)
+      .executeTakeFirst();
 
-      return { ...service, latestDeployment: latestDeployment ?? null };
-    }),
+    return { ...service, latestDeployment: latestDeployment ?? null };
+  }),
 
-  listByProject: os
-    .route({ method: "GET", path: "/projects/{projectId}/services" })
-    .input(z.object({ projectId: z.string() }))
-    .output(z.array(serviceWithDeploymentSchema))
-    .handler(async ({ input }) => {
-      const services = await db
-        .selectFrom("services")
-        .selectAll()
-        .where("projectId", "=", input.projectId)
-        .execute();
+  listByProject: os.services.listByProject.handler(async ({ input }) => {
+    const services = await db
+      .selectFrom("services")
+      .selectAll()
+      .where("projectId", "=", input.projectId)
+      .execute();
 
-      const servicesWithDeployments = await Promise.all(
-        services.map(async (service) => {
-          const latestDeployment = await db
-            .selectFrom("deployments")
-            .selectAll()
-            .where("serviceId", "=", service.id)
-            .orderBy("createdAt", "desc")
-            .limit(1)
-            .executeTakeFirst();
+    return Promise.all(
+      services.map(async (service) => {
+        const latestDeployment = await db
+          .selectFrom("deployments")
+          .selectAll()
+          .where("serviceId", "=", service.id)
+          .orderBy("createdAt", "desc")
+          .limit(1)
+          .executeTakeFirst();
 
-          return { ...service, latestDeployment: latestDeployment ?? null };
-        }),
-      );
-
-      return servicesWithDeployments;
-    }),
-
-  create: os
-    .route({ method: "POST", path: "/projects/{projectId}/services" })
-    .input(
-      z.object({
-        projectId: z.string(),
-        name: z.string().min(1),
-        deployType: z.enum(["repo", "image", "database"]).default("repo"),
-        repoUrl: z.string().optional(),
-        branch: z.string().default("main"),
-        dockerfilePath: z.string().default("Dockerfile"),
-        buildContext: z.string().optional(),
-        imageUrl: z.string().optional(),
-        envVars: z.array(envVarSchema).default([]),
-        containerPort: z.number().min(1).max(65535).optional(),
-        templateId: z.string().optional(),
-        healthCheckPath: z.string().optional(),
-        healthCheckTimeout: z.number().optional(),
-        memoryLimit: z
-          .string()
-          .regex(/^\d+[kmg]$/i)
-          .optional(),
-        cpuLimit: z.number().min(0.1).max(64).optional(),
-        shutdownTimeout: z.number().min(1).max(300).optional(),
-        registryId: z.string().optional(),
+        return { ...service, latestDeployment: latestDeployment ?? null };
       }),
-    )
-    .output(servicesSchema)
-    .handler(async ({ input }) => {
-      if (input.deployType === "repo" && !input.repoUrl) {
-        throw new ORPCError("BAD_REQUEST", {
-          message: "repoUrl is required for repo deployments",
-        });
-      }
-      if (input.deployType === "image" && !input.imageUrl) {
-        throw new ORPCError("BAD_REQUEST", {
-          message: "imageUrl is required for image deployments",
-        });
-      }
-      if (input.deployType === "database" && !input.templateId) {
-        throw new ORPCError("BAD_REQUEST", {
-          message: "templateId is required for database deployments",
-        });
-      }
-      if (input.deployType === "database") {
-        const template = getTemplate(input.templateId!);
-        if (!template) {
-          throw new ORPCError("BAD_REQUEST", {
-            message: "Unknown database template",
-          });
-        }
-      }
+    );
+  }),
 
-      const project = await db
-        .selectFrom("projects")
-        .select(["id", "name", "hostname"])
-        .where("id", "=", input.projectId)
-        .executeTakeFirst();
-
-      if (!project) {
-        throw new ORPCError("NOT_FOUND", { message: "Project not found" });
-      }
-
-      const existing = await db
-        .selectFrom("services")
-        .select("id")
-        .where("projectId", "=", input.projectId)
-        .where("name", "=", input.name)
-        .executeTakeFirst();
-
-      if (existing) {
-        throw new ORPCError("CONFLICT", {
-          message: "Service with this name already exists in project",
-        });
-      }
-
-      const id = nanoid();
-      const now = Date.now();
-      const hostname = slugify(input.name);
-
-      if (input.deployType === "database") {
-        const template = getTemplate(input.templateId!)!;
-        const resolved = resolveTemplateServices(template);
-        const serviceConfig = resolved[0];
-
-        await db
-          .insertInto("services")
-          .values({
-            id,
-            projectId: input.projectId,
-            name: input.name,
-            hostname,
-            deployType: "image",
-            repoUrl: null,
-            branch: null,
-            dockerfilePath: null,
-            imageUrl: serviceConfig.image,
-            envVars: JSON.stringify(serviceConfig.envVars),
-            containerPort: serviceConfig.port,
-            healthCheckPath: serviceConfig.healthCheckPath ?? null,
-            healthCheckTimeout: serviceConfig.healthCheckTimeout,
-            autoDeploy: 0,
-            serviceType: "database",
-            volumes: JSON.stringify(serviceConfig.volumes),
-            command: serviceConfig.command ?? null,
-            createdAt: now,
-          })
-          .execute();
-
-        if (serviceConfig.ssl) {
-          await generateSelfSignedCert(id);
-        }
-      } else {
-        await db
-          .insertInto("services")
-          .values({
-            id,
-            projectId: input.projectId,
-            name: input.name,
-            hostname,
-            deployType: input.deployType,
-            repoUrl: input.deployType === "repo" ? input.repoUrl! : null,
-            branch: input.deployType === "repo" ? input.branch : null,
-            dockerfilePath:
-              input.deployType === "repo" ? input.dockerfilePath : null,
-            buildContext:
-              input.deployType === "repo" ? (input.buildContext ?? null) : null,
-            imageUrl: input.deployType === "image" ? input.imageUrl! : null,
-            envVars: JSON.stringify(input.envVars),
-            containerPort: input.containerPort ?? null,
-            healthCheckPath: input.healthCheckPath ?? null,
-            healthCheckTimeout: input.healthCheckTimeout ?? null,
-            autoDeploy: input.deployType === "repo" ? 1 : 0,
-            memoryLimit: input.memoryLimit ?? null,
-            cpuLimit: input.cpuLimit ?? null,
-            shutdownTimeout: input.shutdownTimeout ?? null,
-            registryId:
-              input.deployType === "image" ? (input.registryId ?? null) : null,
-            createdAt: now,
-          })
-          .execute();
-      }
-
-      const service = await db
-        .selectFrom("services")
-        .selectAll()
-        .where("id", "=", id)
-        .executeTakeFirst();
-
-      if (!service) {
-        throw new ORPCError("INTERNAL_SERVER_ERROR", {
-          message: "Failed to create service",
-        });
-      }
-
-      if (input.deployType !== "database") {
-        await createWildcardDomain(
-          id,
-          hostname,
-          project.hostname ?? slugify(project.name),
-        );
-      }
-
-      deployService(id).catch((err) => {
-        console.error(`Auto-deploy failed for service ${id}:`, err);
+  create: os.services.create.handler(async ({ input }) => {
+    if (input.deployType === "repo" && !input.repoUrl) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "repoUrl is required for repo deployments",
       });
-
-      return service;
-    }),
-
-  update: os
-    .route({ method: "PATCH", path: "/services/{id}" })
-    .input(
-      z.object({
-        id: z.string(),
-        name: z.string().optional(),
-        envVars: z.array(envVarSchema).optional(),
-        containerPort: z.number().min(1).max(65535).optional(),
-        branch: z.string().optional(),
-        dockerfilePath: z.string().optional(),
-        buildContext: z.string().nullable().optional(),
-        repoUrl: z.string().optional(),
-        imageUrl: z.string().optional(),
-        healthCheckPath: z.string().nullable().optional(),
-        healthCheckTimeout: z.number().min(1).max(300).optional(),
-        autoDeployEnabled: z.boolean().optional(),
-        memoryLimit: z
-          .string()
-          .regex(/^\d+[kmg]$/i)
-          .nullable()
-          .optional(),
-        cpuLimit: z.number().min(0.1).max(64).nullable().optional(),
-        shutdownTimeout: z.number().min(1).max(300).nullable().optional(),
-        requestTimeout: z.number().min(1).max(3600).nullable().optional(),
-        volumes: z
-          .array(
-            z.object({
-              name: z.string().regex(/^[a-z0-9-]+$/),
-              path: z.string().startsWith("/"),
-            }),
-          )
-          .optional(),
-        registryId: z.string().nullable().optional(),
-        command: z.string().nullable().optional(),
-      }),
-    )
-    .output(servicesSchema)
-    .handler(async ({ input }) => {
-      const service = await db
-        .selectFrom("services")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
-
-      if (!service) {
-        throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
+    if (input.deployType === "image" && !input.imageUrl) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "imageUrl is required for image deployments",
+      });
+    }
+    if (input.deployType === "database" && !input.templateId) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "templateId is required for database deployments",
+      });
+    }
+    if (input.deployType === "database") {
+      const template = getTemplate(input.templateId!);
+      if (!template) {
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Unknown database template",
+        });
       }
+    }
 
-      const updates: Record<string, unknown> = {};
-      if (input.name !== undefined) updates.name = input.name;
-      if (input.envVars !== undefined)
-        updates.envVars = JSON.stringify(input.envVars);
-      if (input.containerPort !== undefined)
-        updates.containerPort = input.containerPort;
-      if (service.deployType === "repo") {
-        if (input.branch !== undefined) updates.branch = input.branch;
-        if (input.dockerfilePath !== undefined)
-          updates.dockerfilePath = input.dockerfilePath;
-        if (input.buildContext !== undefined)
-          updates.buildContext = input.buildContext;
-        if (input.repoUrl !== undefined) updates.repoUrl = input.repoUrl;
-      }
-      if (service.deployType === "image" && input.imageUrl !== undefined) {
-        updates.imageUrl = input.imageUrl;
-      }
-      if (input.healthCheckPath !== undefined)
-        updates.healthCheckPath = input.healthCheckPath;
-      if (input.healthCheckTimeout !== undefined)
-        updates.healthCheckTimeout = input.healthCheckTimeout;
-      if (input.autoDeployEnabled !== undefined)
-        updates.autoDeploy = input.autoDeployEnabled ? 1 : 0;
-      if (input.memoryLimit !== undefined)
-        updates.memoryLimit = input.memoryLimit;
-      if (input.cpuLimit !== undefined) updates.cpuLimit = input.cpuLimit;
-      if (input.shutdownTimeout !== undefined)
-        updates.shutdownTimeout = input.shutdownTimeout;
-      if (input.requestTimeout !== undefined)
-        updates.requestTimeout = input.requestTimeout;
-      if (input.volumes !== undefined)
-        updates.volumes = JSON.stringify(input.volumes);
-      if (input.registryId !== undefined) updates.registryId = input.registryId;
-      if (input.command !== undefined) updates.command = input.command;
+    const project = await db
+      .selectFrom("projects")
+      .select(["id", "name", "hostname"])
+      .where("id", "=", input.projectId)
+      .executeTakeFirst();
 
-      if (Object.keys(updates).length > 0) {
-        await db
-          .updateTable("services")
-          .set(updates)
-          .where("id", "=", input.id)
-          .execute();
-      }
+    if (!project) {
+      throw new ORPCError("NOT_FOUND", { message: "Project not found" });
+    }
 
-      const updated = await db
-        .selectFrom("services")
-        .selectAll()
-        .where("id", "=", input.id)
-        .executeTakeFirst();
+    const existing = await db
+      .selectFrom("services")
+      .select("id")
+      .where("projectId", "=", input.projectId)
+      .where("name", "=", input.name)
+      .executeTakeFirst();
 
-      if (!updated) {
-        throw new ORPCError("NOT_FOUND", { message: "Service not found" });
-      }
+    if (existing) {
+      throw new ORPCError("CONFLICT", {
+        message: "Service with this name already exists in project",
+      });
+    }
 
-      return updated;
-    }),
+    const id = nanoid();
+    const now = Date.now();
+    const hostname = slugify(input.name);
 
-  delete: os
-    .route({ method: "DELETE", path: "/services/{id}" })
-    .input(z.object({ id: z.string() }))
-    .output(z.object({ success: z.boolean() }))
-    .handler(async ({ input }) => {
-      const service = await db
-        .selectFrom("services")
-        .select(["serviceType", "volumes"])
-        .where("id", "=", input.id)
-        .executeTakeFirst();
+    if (input.deployType === "database") {
+      const template = getTemplate(input.templateId!)!;
+      const resolved = resolveTemplateServices(template);
+      const serviceConfig = resolved[0];
 
-      const deployments = await db
-        .selectFrom("deployments")
-        .select("containerId")
-        .where("serviceId", "=", input.id)
+      await db
+        .insertInto("services")
+        .values({
+          id,
+          projectId: input.projectId,
+          name: input.name,
+          hostname,
+          deployType: "image",
+          repoUrl: null,
+          branch: null,
+          dockerfilePath: null,
+          imageUrl: serviceConfig.image,
+          envVars: JSON.stringify(serviceConfig.envVars),
+          containerPort: serviceConfig.port,
+          healthCheckPath: serviceConfig.healthCheckPath ?? null,
+          healthCheckTimeout: serviceConfig.healthCheckTimeout,
+          autoDeploy: 0,
+          serviceType: "database",
+          volumes: JSON.stringify(serviceConfig.volumes),
+          command: serviceConfig.command ?? null,
+          createdAt: now,
+        })
         .execute();
 
-      for (const deployment of deployments) {
-        if (deployment.containerId) {
-          await stopContainer(deployment.containerId);
-        }
+      if (serviceConfig.ssl) {
+        await generateSelfSignedCert(id);
       }
-
-      if (service?.volumes && service.volumes !== "[]") {
-        const volumeConfig = JSON.parse(service.volumes) as {
-          name: string;
-          path: string;
-        }[];
-        for (const v of volumeConfig) {
-          await removeVolume(buildVolumeName(input.id, v.name));
-        }
-      }
-      if (service?.serviceType === "database") {
-        await removeSSLCerts(input.id);
-      }
-
-      await db.deleteFrom("services").where("id", "=", input.id).execute();
-
-      try {
-        await syncCaddyConfig();
-      } catch {}
-
-      return { success: true };
-    }),
-
-  deploy: os
-    .route({ method: "POST", path: "/services/{id}/deploy" })
-    .input(idParamSchema)
-    .output(z.object({ deploymentId: z.string() }))
-    .handler(async ({ input }) => {
-      const service = await db
-        .selectFrom("services")
-        .select("id")
-        .where("id", "=", input.id)
-        .executeTakeFirst();
-
-      if (!service) {
-        throw new ORPCError("NOT_FOUND", { message: "Service not found" });
-      }
-
-      const deploymentId = await deployService(input.id);
-      return { deploymentId };
-    }),
-
-  listDeployments: os
-    .route({ method: "GET", path: "/services/{id}/deployments" })
-    .input(idParamSchema)
-    .output(z.array(deploymentsSchema))
-    .handler(async ({ input }) => {
-      const deployments = await db
-        .selectFrom("deployments")
-        .selectAll()
-        .where("serviceId", "=", input.id)
-        .orderBy("createdAt", "desc")
-        .limit(20)
+    } else {
+      await db
+        .insertInto("services")
+        .values({
+          id,
+          projectId: input.projectId,
+          name: input.name,
+          hostname,
+          deployType: input.deployType,
+          repoUrl: input.deployType === "repo" ? input.repoUrl! : null,
+          branch: input.deployType === "repo" ? input.branch : null,
+          dockerfilePath:
+            input.deployType === "repo" ? input.dockerfilePath : null,
+          buildContext:
+            input.deployType === "repo" ? (input.buildContext ?? null) : null,
+          imageUrl: input.deployType === "image" ? input.imageUrl! : null,
+          envVars: JSON.stringify(input.envVars),
+          containerPort: input.containerPort ?? null,
+          healthCheckPath: input.healthCheckPath ?? null,
+          healthCheckTimeout: input.healthCheckTimeout ?? null,
+          autoDeploy: input.deployType === "repo" ? 1 : 0,
+          memoryLimit: input.memoryLimit ?? null,
+          cpuLimit: input.cpuLimit ?? null,
+          shutdownTimeout: input.shutdownTimeout ?? null,
+          registryId:
+            input.deployType === "image" ? (input.registryId ?? null) : null,
+          createdAt: now,
+        })
         .execute();
-      return deployments;
-    }),
+    }
 
-  getVolumes: os
-    .route({ method: "GET", path: "/services/{id}/volumes" })
-    .input(idParamSchema)
-    .output(
-      z.array(
-        z.object({
-          name: z.string(),
-          path: z.string(),
-          sizeBytes: z.number().nullable(),
-        }),
-      ),
-    )
-    .handler(async ({ input }) => {
-      const service = await db
-        .selectFrom("services")
-        .select("volumes")
+    const service = await db
+      .selectFrom("services")
+      .selectAll()
+      .where("id", "=", id)
+      .executeTakeFirst();
+
+    if (!service) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "Failed to create service",
+      });
+    }
+
+    if (input.deployType !== "database") {
+      await createWildcardDomain(
+        id,
+        hostname,
+        project.hostname ?? slugify(project.name),
+      );
+    }
+
+    deployService(id).catch((err) => {
+      console.error(`Auto-deploy failed for service ${id}:`, err);
+    });
+
+    return service;
+  }),
+
+  update: os.services.update.handler(async ({ input }) => {
+    const service = await db
+      .selectFrom("services")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    if (!service) {
+      throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (input.name !== undefined) updates.name = input.name;
+    if (input.envVars !== undefined)
+      updates.envVars = JSON.stringify(input.envVars);
+    if (input.containerPort !== undefined)
+      updates.containerPort = input.containerPort;
+    if (service.deployType === "repo") {
+      if (input.branch !== undefined) updates.branch = input.branch;
+      if (input.dockerfilePath !== undefined)
+        updates.dockerfilePath = input.dockerfilePath;
+      if (input.buildContext !== undefined)
+        updates.buildContext = input.buildContext;
+      if (input.repoUrl !== undefined) updates.repoUrl = input.repoUrl;
+    }
+    if (service.deployType === "image" && input.imageUrl !== undefined) {
+      updates.imageUrl = input.imageUrl;
+    }
+    if (input.healthCheckPath !== undefined)
+      updates.healthCheckPath = input.healthCheckPath;
+    if (input.healthCheckTimeout !== undefined)
+      updates.healthCheckTimeout = input.healthCheckTimeout;
+    if (input.autoDeployEnabled !== undefined)
+      updates.autoDeploy = input.autoDeployEnabled ? 1 : 0;
+    if (input.memoryLimit !== undefined)
+      updates.memoryLimit = input.memoryLimit;
+    if (input.cpuLimit !== undefined) updates.cpuLimit = input.cpuLimit;
+    if (input.shutdownTimeout !== undefined)
+      updates.shutdownTimeout = input.shutdownTimeout;
+    if (input.requestTimeout !== undefined)
+      updates.requestTimeout = input.requestTimeout;
+    if (input.volumes !== undefined)
+      updates.volumes = JSON.stringify(input.volumes);
+    if (input.registryId !== undefined) updates.registryId = input.registryId;
+    if (input.command !== undefined) updates.command = input.command;
+
+    if (Object.keys(updates).length > 0) {
+      await db
+        .updateTable("services")
+        .set(updates)
         .where("id", "=", input.id)
-        .executeTakeFirst();
+        .execute();
+    }
 
-      if (!service) {
-        throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    const updated = await db
+      .selectFrom("services")
+      .selectAll()
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    if (!updated) {
+      throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
+
+    return updated;
+  }),
+
+  delete: os.services.delete.handler(async ({ input }) => {
+    const service = await db
+      .selectFrom("services")
+      .select(["serviceType", "volumes"])
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    const deployments = await db
+      .selectFrom("deployments")
+      .select("containerId")
+      .where("serviceId", "=", input.id)
+      .execute();
+
+    for (const deployment of deployments) {
+      if (deployment.containerId) {
+        await stopContainer(deployment.containerId);
       }
+    }
 
-      if (!service.volumes || service.volumes === "[]") {
-        return [];
-      }
-
+    if (service?.volumes && service.volumes !== "[]") {
       const volumeConfig = JSON.parse(service.volumes) as {
         name: string;
         path: string;
       }[];
+      for (const v of volumeConfig) {
+        await removeVolume(buildVolumeName(input.id, v.name));
+      }
+    }
+    if (service?.serviceType === "database") {
+      await removeSSLCerts(input.id);
+    }
 
-      const result = await Promise.all(
-        volumeConfig.map(async (v) => {
-          const dockerVolumeName = buildVolumeName(input.id, v.name);
-          const sizeBytes = await getVolumeSize(dockerVolumeName);
-          return { name: v.name, path: v.path, sizeBytes };
-        }),
-      );
+    await db.deleteFrom("services").where("id", "=", input.id).execute();
 
-      return result;
-    }),
+    try {
+      await syncCaddyConfig();
+    } catch {}
+
+    return { success: true };
+  }),
+
+  deploy: os.services.deploy.handler(async ({ input }) => {
+    const service = await db
+      .selectFrom("services")
+      .select("id")
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    if (!service) {
+      throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
+
+    const deploymentId = await deployService(input.id);
+    return { deploymentId };
+  }),
+
+  listDeployments: os.services.listDeployments.handler(async ({ input }) =>
+    db
+      .selectFrom("deployments")
+      .selectAll()
+      .where("serviceId", "=", input.id)
+      .orderBy("createdAt", "desc")
+      .limit(20)
+      .execute(),
+  ),
+
+  getVolumes: os.services.getVolumes.handler(async ({ input }) => {
+    const service = await db
+      .selectFrom("services")
+      .select("volumes")
+      .where("id", "=", input.id)
+      .executeTakeFirst();
+
+    if (!service) {
+      throw new ORPCError("NOT_FOUND", { message: "Service not found" });
+    }
+
+    if (!service.volumes || service.volumes === "[]") {
+      return [];
+    }
+
+    const volumeConfig = JSON.parse(service.volumes) as {
+      name: string;
+      path: string;
+    }[];
+
+    const result = await Promise.all(
+      volumeConfig.map(async (v) => {
+        const dockerVolumeName = buildVolumeName(input.id, v.name);
+        const sizeBytes = await getVolumeSize(dockerVolumeName);
+        return { name: v.name, path: v.path, sizeBytes };
+      }),
+    );
+
+    return result;
+  }),
 };

--- a/apps/app/src/server/templates.ts
+++ b/apps/app/src/server/templates.ts
@@ -1,74 +1,18 @@
-import { z } from "zod";
-import { os } from "@/lib/orpc";
 import {
   getDatabaseTemplates,
   getProjectTemplates,
   getServiceTemplates,
   getTemplates,
 } from "@/lib/templates";
-
-const serviceDefinitionSchema = z.object({
-  image: z.string(),
-  port: z.number(),
-  main: z.boolean().optional(),
-  type: z.enum(["database", "app"]).optional(),
-  command: z.string().optional(),
-  environment: z.record(z.string(), z.unknown()).optional(),
-  volumes: z.array(z.string()).optional(),
-  health_check: z
-    .object({
-      path: z.string().optional(),
-      timeout: z.number(),
-    })
-    .optional(),
-  ssl: z.boolean().optional(),
-});
-
-const templateSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string(),
-  category: z.string(),
-  docs: z.string().optional(),
-  type: z.enum(["database", "service", "project"]),
-  services: z.record(z.string(), serviceDefinitionSchema),
-});
+import { os } from "./orpc";
 
 export const templates = {
-  list: os
-    .route({ method: "GET", path: "/templates" })
-    .output(z.array(templateSchema))
-    .handler(async () => {
-      return getTemplates();
-    }),
-
-  services: os
-    .route({ method: "GET", path: "/templates/services" })
-    .output(z.array(templateSchema))
-    .handler(async () => {
-      return getServiceTemplates();
-    }),
-
-  projects: os
-    .route({ method: "GET", path: "/templates/projects" })
-    .output(z.array(templateSchema))
-    .handler(async () => {
-      return getProjectTemplates();
-    }),
-
-  databases: os
-    .route({ method: "GET", path: "/templates/databases" })
-    .output(z.array(templateSchema))
-    .handler(async () => {
-      return getDatabaseTemplates();
-    }),
+  list: os.templates.list.handler(getTemplates),
+  services: os.templates.services.handler(getServiceTemplates),
+  projects: os.templates.projects.handler(getProjectTemplates),
+  databases: os.templates.databases.handler(getDatabaseTemplates),
 };
 
 export const dbTemplates = {
-  list: os
-    .route({ method: "GET", path: "/db-templates" })
-    .output(z.array(templateSchema))
-    .handler(async () => {
-      return getDatabaseTemplates();
-    }),
+  list: os.dbTemplates.list.handler(getDatabaseTemplates),
 };


### PR DESCRIPTION
## Summary
- Separate contracts (client-safe) from implementations (server-only) to prevent `node:fs`, `better-sqlite3`, etc. from being pulled into browser bundle
- Add `src/contracts/` with client-safe contract definitions
- Client now imports contract instead of router
- Server modules use `os.<module>.<procedure>.handler()` pattern

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] App loads at localhost:3000
- [ ] Project creation works
- [ ] e2e tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)