### PR TITLE
fix: settings containers take full width (#192)

### DIFF
--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/layout.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/layout.tsx
@@ -39,7 +39,7 @@ export default function ServiceSettingsLayout({
         </div>
       </aside>
 
-      <div className="max-w-2xl flex-1">{children}</div>
+      <div className="flex-1">{children}</div>
     </div>
   );
 }

--- a/apps/app/src/app/projects/[id]/settings/layout.tsx
+++ b/apps/app/src/app/projects/[id]/settings/layout.tsx
@@ -36,7 +36,7 @@ export default function ProjectSettingsLayout({
         </div>
       </aside>
 
-      <div className="max-w-2xl flex-1">{children}</div>
+      <div className="flex-1">{children}</div>
     </div>
   );
 }

--- a/apps/app/src/app/settings/layout.tsx
+++ b/apps/app/src/app/settings/layout.tsx
@@ -33,7 +33,7 @@ export default function SettingsLayout({
             </div>
           </aside>
 
-          <div className="max-w-2xl flex-1">{children}</div>
+          <div className="flex-1">{children}</div>
         </div>
       </main>
     </>


### PR DESCRIPTION
## Summary
- Remove `max-w-2xl` from settings layout containers so they expand to fill available width

## Test plan
- [x] `bun run typecheck && bun run lint` passes
- [ ] Visual check: settings pages expand to fill available width

🤖 Generated with [Claude Code](https://claude.com/claude-code)