### PR TITLE
feat: enable HTTPS with self-signed cert by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,9 @@ jobs:
 
       - name: Wait for Frost
         run: |
-          echo "Waiting for Frost..."
+          echo "Waiting for Frost (HTTPS with self-signed cert)..."
           for i in {1..12}; do
-            if curl -s -o /dev/null -w "%{http_code}" "http://${{ steps.server.outputs.ip }}/api/health" | grep -q "200"; then
+            if curl -sk -o /dev/null -w "%{http_code}" "https://${{ steps.server.outputs.ip }}/api/health" | grep -q "200"; then
               echo "Frost is ready!"
               exit 0
             fi
@@ -410,7 +410,7 @@ jobs:
         run: |
           echo "Waiting for Frost..."
           for i in {1..12}; do
-            if curl -s -o /dev/null -w "%{http_code}" "http://${{ steps.server.outputs.ip }}/api/health" | grep -q "200"; then
+            if curl -s -o /dev/null -w "%{http_code}" "http://${{ steps.server.outputs.ip }}:3000/api/health" | grep -q "200"; then
               echo "Frost is ready!"
               exit 0
             fi
@@ -470,7 +470,7 @@ jobs:
         run: |
           echo "Waiting for Frost after upgrade..."
           for i in {1..12}; do
-            if curl -s -o /dev/null -w "%{http_code}" "http://${{ steps.server.outputs.ip }}/api/health" | grep -q "200"; then
+            if curl -s -o /dev/null -w "%{http_code}" "http://${{ steps.server.outputs.ip }}:3000/api/health" | grep -q "200"; then
               echo "Frost is ready!"
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,18 +216,33 @@ jobs:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           chmod +x ./apps/app/scripts/e2e-test.sh
-          ./apps/app/scripts/e2e-test.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}"
+          ./apps/app/scripts/e2e-test.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}" 2>&1 | tee /tmp/e2e-tests.log
 
       - name: Collect logs on failure
         if: failure()
         run: |
+          echo "=========================================="
+          echo "=== LOCAL TEST SCRIPT OUTPUT ==="
+          echo "=========================================="
+          if [ -f /tmp/e2e-tests.log ]; then
+            cat /tmp/e2e-tests.log
+          fi
+
+          echo ""
+          echo "=========================================="
+          echo "=== REMOTE SERVER LOGS ==="
+          echo "=========================================="
+
+          echo ""
           echo "=== Frost logs (last 500 lines) ==="
           ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 500" || true
+
           echo ""
           echo "=== Caddy logs ==="
           ssh root@${{ steps.server.outputs.ip }} "journalctl -u caddy --no-pager -n 50" || true
+
           echo ""
-          echo "=== Docker ==="
+          echo "=== Docker containers ==="
           ssh root@${{ steps.server.outputs.ip }} "docker ps -a" || true
 
       - name: Delete server
@@ -411,7 +426,7 @@ jobs:
         id: predata
         run: |
           chmod +x ./apps/app/scripts/e2e-upgrade-create.sh
-          ./apps/app/scripts/e2e-upgrade-create.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}"
+          ./apps/app/scripts/e2e-upgrade-create.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}" 2>&1 | tee /tmp/e2e-create.log
 
       - name: Upgrade to PR branch
         if: steps.release.outputs.skip != 'true'
@@ -432,13 +447,13 @@ jobs:
             else \
               git remote set-url origin https://github.com/${REPO}.git; \
             fi && \
-            git fetch origin ${BRANCH}:refs/remotes/origin/main -f"
+            git fetch origin ${BRANCH}:refs/remotes/origin/main -f" 2>&1 | tee /tmp/e2e-git-setup.log
 
           scp /tmp/update.sh root@${{ steps.server.outputs.ip }}:/opt/frost/update.sh
           ssh root@${{ steps.server.outputs.ip }} "chmod +x /opt/frost/update.sh && \
             sed -i 's|git fetch origin main.*|:|' /opt/frost/update.sh"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "/opt/frost/update.sh"
+          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "/opt/frost/update.sh" 2>&1 | tee /tmp/e2e-upgrade.log
 
       - name: Initialize test fixture git repos
         if: steps.release.outputs.skip != 'true'
@@ -475,13 +490,13 @@ jobs:
             "${{ steps.install.outputs.api_key }}" \
             "${{ steps.predata.outputs.project_id }}" \
             "${{ steps.predata.outputs.service_id }}" \
-            "${{ steps.predata.outputs.deployment_id }}"
+            "${{ steps.predata.outputs.deployment_id }}" 2>&1 | tee /tmp/e2e-verify.log
 
       - name: Run standard E2E tests
         if: steps.release.outputs.skip != 'true'
         run: |
           chmod +x ./apps/app/scripts/e2e-test.sh
-          ./apps/app/scripts/e2e-test.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}"
+          ./apps/app/scripts/e2e-test.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}" 2>&1 | tee /tmp/e2e-tests.log
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
 
@@ -505,7 +520,7 @@ jobs:
             bun run migrate 2>&1 && \
             sed -i 's|ExecStart=.*|ExecStart=/usr/bin/npm run start|' /etc/systemd/system/frost.service && \
             systemctl daemon-reload && \
-            systemctl start frost"
+            systemctl start frost" 2>&1 | tee /tmp/e2e-reset-ui.log
 
           echo "Waiting for Frost on port 3000..."
           for i in {1..24}; do
@@ -517,7 +532,7 @@ jobs:
             sleep 5
           done
           echo "Frost failed to start"
-          ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 50" || true
+          ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 100" || true
           exit 1
 
       - name: Test UI-triggered update flow
@@ -528,7 +543,7 @@ jobs:
             "${{ steps.server.outputs.ip }}" \
             "${{ steps.install.outputs.api_key }}" \
             "${{ github.head_ref || github.ref_name }}" \
-            "${{ github.repository }}"
+            "${{ github.repository }}" 2>&1 | tee /tmp/e2e-update-ui.log
 
       - name: Create broken branch for rollback test
         if: steps.release.outputs.skip != 'true'
@@ -578,7 +593,7 @@ jobs:
             bun run migrate 2>&1 && \
             sed -i 's|ExecStart=.*|ExecStart=/usr/bin/npm run start|' /etc/systemd/system/frost.service && \
             systemctl daemon-reload && \
-            systemctl start frost"
+            systemctl start frost" 2>&1 | tee /tmp/e2e-reset-rollback.log
 
           echo "Waiting for Frost on port 3000..."
           for i in {1..24}; do
@@ -590,7 +605,7 @@ jobs:
             sleep 5
           done
           echo "Frost failed to start"
-          ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 50" || true
+          ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 100" || true
           exit 1
 
       - name: Test rollback on build failure
@@ -601,7 +616,7 @@ jobs:
             "${{ steps.server.outputs.ip }}" \
             "${{ steps.install.outputs.api_key }}" \
             "${{ steps.broken.outputs.branch }}" \
-            "${{ github.repository }}"
+            "${{ github.repository }}" 2>&1 | tee /tmp/e2e-rollback.log
 
       - name: Cleanup broken branch
         if: always() && steps.broken.outputs.branch
@@ -612,14 +627,41 @@ jobs:
       - name: Collect logs on failure
         if: failure() && steps.release.outputs.skip != 'true'
         run: |
+          echo "=========================================="
+          echo "=== LOCAL TEST SCRIPT OUTPUTS ==="
+          echo "=========================================="
+          for log in /tmp/e2e-*.log; do
+            if [ -f "$log" ]; then
+              echo ""
+              echo "=== $(basename $log) ==="
+              cat "$log"
+            fi
+          done
+
+          echo ""
+          echo "=========================================="
+          echo "=== REMOTE SERVER LOGS ==="
+          echo "=========================================="
+
+          echo ""
           echo "=== Frost logs (last 500 lines) ==="
           ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 500" || true
+
           echo ""
           echo "=== Caddy logs ==="
           ssh root@${{ steps.server.outputs.ip }} "journalctl -u caddy --no-pager -n 50" || true
+
           echo ""
-          echo "=== Docker ==="
+          echo "=== Docker containers ==="
           ssh root@${{ steps.server.outputs.ip }} "docker ps -a" || true
+
+          echo ""
+          echo "=== Update log (if exists) ==="
+          ssh root@${{ steps.server.outputs.ip }} "cat /opt/frost/data/.update-log 2>/dev/null" || echo "(no update log)"
+
+          echo ""
+          echo "=== Update result (if exists) ==="
+          ssh root@${{ steps.server.outputs.ip }} "cat /opt/frost/data/.update-result 2>/dev/null" || echo "(no update result)"
 
       - name: Delete server
         if: always() && steps.server.outputs.server_id

--- a/apps/app/scripts/e2e-update-rollback.sh
+++ b/apps/app/scripts/e2e-update-rollback.sh
@@ -35,9 +35,24 @@ echo "Broken branch: $BROKEN_BRANCH"
 api() {
   local RESPONSE
   local HTTP_CODE
-  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  local CURL_EXIT
+
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
+
+  if [ -n "$CURL_EXIT" ]; then
+    echo "CURL FAILED (exit $CURL_EXIT):"
+    echo "$RESPONSE"
+    return 1
+  fi
+
   HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
+    echo "INVALID HTTP CODE: '$HTTP_CODE'"
+    echo "Response: $RESPONSE"
+    return 1
+  fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
     echo "API ERROR (HTTP $HTTP_CODE):"

--- a/apps/app/scripts/e2e-update-rollback.sh
+++ b/apps/app/scripts/e2e-update-rollback.sh
@@ -40,8 +40,8 @@ api() {
   RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
 
   if [ -n "$CURL_EXIT" ]; then
-    echo "CURL FAILED (exit $CURL_EXIT):"
-    echo "$RESPONSE"
+    echo "CURL FAILED (exit $CURL_EXIT):" >&2
+    echo "$RESPONSE" >&2
     return 1
   fi
 
@@ -49,14 +49,14 @@ api() {
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
 
   if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
-    echo "INVALID HTTP CODE: '$HTTP_CODE'"
-    echo "Response: $RESPONSE"
+    echo "INVALID HTTP CODE: '$HTTP_CODE'" >&2
+    echo "Response: $RESPONSE" >&2
     return 1
   fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
-    echo "API ERROR (HTTP $HTTP_CODE):"
-    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    echo "API ERROR (HTTP $HTTP_CODE):" >&2
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE" >&2
     return 1
   fi
   echo "$RESPONSE"

--- a/apps/app/scripts/e2e-update-rollback.sh
+++ b/apps/app/scripts/e2e-update-rollback.sh
@@ -13,11 +13,38 @@ if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ] || [ -z "$BROKEN_BRANCH" ] || [ -z "
   exit 1
 fi
 
+error_handler() {
+  echo ""
+  echo "!!! ERROR at line $1 !!!"
+  echo "Last command exited with status $2"
+  echo ""
+  echo "=== Debug: Frost health ==="
+  curl -sS --max-time 5 "$BASE_URL/api/health" 2>&1 || echo "(health check failed)"
+  echo ""
+  echo "=== Debug: Recent Frost logs ==="
+  ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$SERVER_IP "journalctl -u frost --no-pager -n 50" 2>&1 || echo "(failed to get logs)"
+  echo ""
+  echo "=== Debug: Update log ==="
+  ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$SERVER_IP "cat /opt/frost/data/.update-log 2>/dev/null" || echo "(no update log)"
+}
+trap 'error_handler $LINENO $?' ERR
+
 echo "Testing update rollback on $BASE_URL"
 echo "Broken branch: $BROKEN_BRANCH"
 
 api() {
-  curl -sS --max-time 30 -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@"
+  local RESPONSE
+  local HTTP_CODE
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if [ "$HTTP_CODE" -ge 400 ]; then
+    echo "API ERROR (HTTP $HTTP_CODE):"
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    return 1
+  fi
+  echo "$RESPONSE"
 }
 
 remote() {

--- a/apps/app/scripts/e2e-update-ui.sh
+++ b/apps/app/scripts/e2e-update-ui.sh
@@ -35,9 +35,24 @@ echo "Target branch: $TARGET_BRANCH"
 api() {
   local RESPONSE
   local HTTP_CODE
-  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  local CURL_EXIT
+
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
+
+  if [ -n "$CURL_EXIT" ]; then
+    echo "CURL FAILED (exit $CURL_EXIT):"
+    echo "$RESPONSE"
+    return 1
+  fi
+
   HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
+    echo "INVALID HTTP CODE: '$HTTP_CODE'"
+    echo "Response: $RESPONSE"
+    return 1
+  fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
     echo "API ERROR (HTTP $HTTP_CODE):"

--- a/apps/app/scripts/e2e-update-ui.sh
+++ b/apps/app/scripts/e2e-update-ui.sh
@@ -40,8 +40,8 @@ api() {
   RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
 
   if [ -n "$CURL_EXIT" ]; then
-    echo "CURL FAILED (exit $CURL_EXIT):"
-    echo "$RESPONSE"
+    echo "CURL FAILED (exit $CURL_EXIT):" >&2
+    echo "$RESPONSE" >&2
     return 1
   fi
 
@@ -49,14 +49,14 @@ api() {
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
 
   if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
-    echo "INVALID HTTP CODE: '$HTTP_CODE'"
-    echo "Response: $RESPONSE"
+    echo "INVALID HTTP CODE: '$HTTP_CODE'" >&2
+    echo "Response: $RESPONSE" >&2
     return 1
   fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
-    echo "API ERROR (HTTP $HTTP_CODE):"
-    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    echo "API ERROR (HTTP $HTTP_CODE):" >&2
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE" >&2
     return 1
   fi
   echo "$RESPONSE"

--- a/apps/app/scripts/e2e-update-ui.sh
+++ b/apps/app/scripts/e2e-update-ui.sh
@@ -13,11 +13,38 @@ if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ] || [ -z "$TARGET_BRANCH" ] || [ -z "
   exit 1
 fi
 
+error_handler() {
+  echo ""
+  echo "!!! ERROR at line $1 !!!"
+  echo "Last command exited with status $2"
+  echo ""
+  echo "=== Debug: Frost health ==="
+  curl -sS --max-time 5 "$BASE_URL/api/health" 2>&1 || echo "(health check failed)"
+  echo ""
+  echo "=== Debug: Recent Frost logs ==="
+  ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$SERVER_IP "journalctl -u frost --no-pager -n 50" 2>&1 || echo "(failed to get logs)"
+  echo ""
+  echo "=== Debug: Update log ==="
+  ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$SERVER_IP "cat /opt/frost/data/.update-log 2>/dev/null" || echo "(no update log)"
+}
+trap 'error_handler $LINENO $?' ERR
+
 echo "Testing UI-triggered update flow on $BASE_URL"
 echo "Target branch: $TARGET_BRANCH"
 
 api() {
-  curl -sS --max-time 30 -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@"
+  local RESPONSE
+  local HTTP_CODE
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if [ "$HTTP_CODE" -ge 400 ]; then
+    echo "API ERROR (HTTP $HTTP_CODE):"
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    return 1
+  fi
+  echo "$RESPONSE"
 }
 
 remote() {

--- a/apps/app/scripts/e2e-upgrade-create.sh
+++ b/apps/app/scripts/e2e-upgrade-create.sh
@@ -3,7 +3,7 @@ set -e
 
 SERVER_IP=$1
 API_KEY=$2
-BASE_URL="http://$SERVER_IP"
+BASE_URL="http://$SERVER_IP:3000"
 
 if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ]; then
   echo "Usage: $0 <server-ip> <api-key>"

--- a/apps/app/scripts/e2e-upgrade-create.sh
+++ b/apps/app/scripts/e2e-upgrade-create.sh
@@ -33,8 +33,8 @@ api() {
   RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
 
   if [ -n "$CURL_EXIT" ]; then
-    echo "CURL FAILED (exit $CURL_EXIT):"
-    echo "$RESPONSE"
+    echo "CURL FAILED (exit $CURL_EXIT):" >&2
+    echo "$RESPONSE" >&2
     return 1
   fi
 
@@ -42,14 +42,14 @@ api() {
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
 
   if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
-    echo "INVALID HTTP CODE: '$HTTP_CODE'"
-    echo "Response: $RESPONSE"
+    echo "INVALID HTTP CODE: '$HTTP_CODE'" >&2
+    echo "Response: $RESPONSE" >&2
     return 1
   fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
-    echo "API ERROR (HTTP $HTTP_CODE):"
-    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    echo "API ERROR (HTTP $HTTP_CODE):" >&2
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE" >&2
     return 1
   fi
   echo "$RESPONSE"

--- a/apps/app/scripts/e2e-upgrade-create.sh
+++ b/apps/app/scripts/e2e-upgrade-create.sh
@@ -28,9 +28,24 @@ echo "Creating pre-upgrade test data on $BASE_URL"
 api() {
   local RESPONSE
   local HTTP_CODE
-  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  local CURL_EXIT
+
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
+
+  if [ -n "$CURL_EXIT" ]; then
+    echo "CURL FAILED (exit $CURL_EXIT):"
+    echo "$RESPONSE"
+    return 1
+  fi
+
   HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
+    echo "INVALID HTTP CODE: '$HTTP_CODE'"
+    echo "Response: $RESPONSE"
+    return 1
+  fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
     echo "API ERROR (HTTP $HTTP_CODE):"

--- a/apps/app/scripts/e2e-upgrade-create.sh
+++ b/apps/app/scripts/e2e-upgrade-create.sh
@@ -10,10 +10,34 @@ if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ]; then
   exit 1
 fi
 
+error_handler() {
+  echo ""
+  echo "!!! ERROR at line $1 !!!"
+  echo "Last command exited with status $2"
+  echo ""
+  echo "=== Debug: Frost health ==="
+  curl -sS --max-time 5 "$BASE_URL/api/health" 2>&1 || echo "(health check failed)"
+  echo ""
+  echo "=== Debug: Recent Frost logs ==="
+  ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$SERVER_IP "journalctl -u frost --no-pager -n 30" 2>&1 || echo "(failed to get logs)"
+}
+trap 'error_handler $LINENO $?' ERR
+
 echo "Creating pre-upgrade test data on $BASE_URL"
 
 api() {
-  curl -sS --max-time 30 -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@"
+  local RESPONSE
+  local HTTP_CODE
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if [ "$HTTP_CODE" -ge 400 ]; then
+    echo "API ERROR (HTTP $HTTP_CODE):"
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    return 1
+  fi
+  echo "$RESPONSE"
 }
 
 wait_for_deployment() {

--- a/apps/app/scripts/e2e-upgrade-verify.sh
+++ b/apps/app/scripts/e2e-upgrade-verify.sh
@@ -13,10 +13,37 @@ if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ] || [ -z "$PROJECT_ID" ] || [ -z "$SE
   exit 1
 fi
 
+error_handler() {
+  echo ""
+  echo "!!! ERROR at line $1 !!!"
+  echo "Last command exited with status $2"
+  echo ""
+  echo "=== Debug: Frost health ==="
+  curl -sS --max-time 5 "$BASE_URL/api/health" 2>&1 || echo "(health check failed)"
+  echo ""
+  echo "=== Debug: Recent Frost logs ==="
+  ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$SERVER_IP "journalctl -u frost --no-pager -n 30" 2>&1 || echo "(failed to get logs)"
+}
+trap 'error_handler $LINENO $?' ERR
+
 echo "Verifying pre-upgrade data survived on $BASE_URL"
+echo "  PROJECT_ID=$PROJECT_ID"
+echo "  SERVICE_ID=$SERVICE_ID"
+echo "  DEPLOYMENT_ID=$DEPLOYMENT_ID"
 
 api() {
-  curl -sS --max-time 30 -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@"
+  local RESPONSE
+  local HTTP_CODE
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if [ "$HTTP_CODE" -ge 400 ]; then
+    echo "API ERROR (HTTP $HTTP_CODE):"
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    return 1
+  fi
+  echo "$RESPONSE"
 }
 
 FAILED=0

--- a/apps/app/scripts/e2e-upgrade-verify.sh
+++ b/apps/app/scripts/e2e-upgrade-verify.sh
@@ -6,7 +6,7 @@ API_KEY=$2
 PROJECT_ID=$3
 SERVICE_ID=$4
 DEPLOYMENT_ID=$5
-BASE_URL="http://$SERVER_IP"
+BASE_URL="http://$SERVER_IP:3000"
 
 if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ] || [ -z "$PROJECT_ID" ] || [ -z "$SERVICE_ID" ] || [ -z "$DEPLOYMENT_ID" ]; then
   echo "Usage: $0 <server-ip> <api-key> <project-id> <service-id> <deployment-id>"

--- a/apps/app/scripts/e2e-upgrade-verify.sh
+++ b/apps/app/scripts/e2e-upgrade-verify.sh
@@ -34,9 +34,24 @@ echo "  DEPLOYMENT_ID=$DEPLOYMENT_ID"
 api() {
   local RESPONSE
   local HTTP_CODE
-  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@")
+  local CURL_EXIT
+
+  RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
+
+  if [ -n "$CURL_EXIT" ]; then
+    echo "CURL FAILED (exit $CURL_EXIT):"
+    echo "$RESPONSE"
+    return 1
+  fi
+
   HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
+    echo "INVALID HTTP CODE: '$HTTP_CODE'"
+    echo "Response: $RESPONSE"
+    return 1
+  fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
     echo "API ERROR (HTTP $HTTP_CODE):"

--- a/apps/app/scripts/e2e-upgrade-verify.sh
+++ b/apps/app/scripts/e2e-upgrade-verify.sh
@@ -39,8 +39,8 @@ api() {
   RESPONSE=$(curl -sS --max-time 30 -w "\n%{http_code}" -H "X-Frost-Token: $API_KEY" -H "Content-Type: application/json" "$@" 2>&1) || CURL_EXIT=$?
 
   if [ -n "$CURL_EXIT" ]; then
-    echo "CURL FAILED (exit $CURL_EXIT):"
-    echo "$RESPONSE"
+    echo "CURL FAILED (exit $CURL_EXIT):" >&2
+    echo "$RESPONSE" >&2
     return 1
   fi
 
@@ -48,14 +48,14 @@ api() {
   RESPONSE=$(echo "$RESPONSE" | sed '$d')
 
   if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
-    echo "INVALID HTTP CODE: '$HTTP_CODE'"
-    echo "Response: $RESPONSE"
+    echo "INVALID HTTP CODE: '$HTTP_CODE'" >&2
+    echo "Response: $RESPONSE" >&2
     return 1
   fi
 
   if [ "$HTTP_CODE" -ge 400 ]; then
-    echo "API ERROR (HTTP $HTTP_CODE):"
-    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+    echo "API ERROR (HTTP $HTTP_CODE):" >&2
+    echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE" >&2
     return 1
   fi
   echo "$RESPONSE"

--- a/install.sh
+++ b/install.sh
@@ -162,8 +162,8 @@ else
   timer "Caddy DNS modules present"
 fi
 
-# Get server IP for HTTPS setup
-SERVER_IP=$(curl -s ifconfig.me 2>/dev/null || curl -s api.ipify.org 2>/dev/null || echo "YOUR_SERVER_IP")
+# Get server IP for HTTPS setup (force IPv4)
+SERVER_IP=$(curl -4 -s ifconfig.me 2>/dev/null || curl -4 -s api.ipify.org 2>/dev/null || echo "YOUR_SERVER_IP")
 
 # Configure Caddy with self-signed HTTPS
 timer "Configuring Caddy..."

--- a/install.sh
+++ b/install.sh
@@ -162,10 +162,18 @@ else
   timer "Caddy DNS modules present"
 fi
 
-# Configure Caddy to proxy to Frost
+# Get server IP for HTTPS setup
+SERVER_IP=$(curl -s ifconfig.me 2>/dev/null || curl -s api.ipify.org 2>/dev/null || echo "YOUR_SERVER_IP")
+
+# Configure Caddy with self-signed HTTPS
 timer "Configuring Caddy..."
-cat > /etc/caddy/Caddyfile << 'EOF'
+cat > /etc/caddy/Caddyfile << EOF
 :80 {
+  redir https://$SERVER_IP{uri} permanent
+}
+
+$SERVER_IP {
+  tls internal
   reverse_proxy localhost:3000
 }
 EOF
@@ -323,14 +331,12 @@ else
   echo -e "${YELLOW}Warning: Could not reach Frost. Check: journalctl -u frost -f${NC}"
 fi
 
-# Get server IP
-SERVER_IP=$(curl -s ifconfig.me 2>/dev/null || curl -s api.ipify.org 2>/dev/null || echo "YOUR_SERVER_IP")
-
 TOTAL_TIME=$(($(date +%s) - START_TIME))
 echo ""
 echo -e "${GREEN}Installation complete! (${TOTAL_TIME}s total)${NC}"
 echo ""
-echo -e "Frost is running at: ${GREEN}http://$SERVER_IP${NC}"
+echo -e "Frost is running at: ${GREEN}https://$SERVER_IP${NC}"
+echo -e "${YELLOW}Note: Browser will show certificate warning (self-signed). Click through to proceed.${NC}"
 
 if [ "$CREATE_API_KEY" = true ]; then
   echo ""
@@ -346,7 +352,7 @@ fi
 
 echo ""
 echo "Next steps:"
-echo "  1. Open http://$SERVER_IP to complete setup"
+echo "  1. Open https://$SERVER_IP to complete setup"
 echo "  2. Point your domain to $SERVER_IP"
 echo "  3. Go to Settings in Frost to configure SSL"
 echo ""


### PR DESCRIPTION
## Summary
- Fresh installs now serve over HTTPS using Caddy's `tls internal` for self-signed certs
- HTTP requests redirect to HTTPS permanently
- Users see browser cert warning but can click through to reach setup page

## How it works
- IP detection moved earlier in install.sh (before Caddyfile generation)
- Caddyfile uses `tls internal` which auto-generates self-signed cert
- When user configures real domain + SSL, `syncCaddyConfig()` replaces this via Caddy admin API

## Test plan
- [ ] Fresh install on test VPS: `ssh root@65.21.180.49 "curl -fsSL https://raw.githubusercontent.com/elitan/frost/main/install.sh | sudo bash"`
- [ ] Access `https://65.21.180.49` - should show browser cert warning
- [ ] Click through warning - should reach Frost setup page
- [ ] Verify HTTP redirects: `curl -I http://65.21.180.49` - should return 301 to HTTPS

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)