### PR TITLE
fix: prevent duplicate service hostnames in Docker network

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,26 @@ Dev deploy (push local changes to test VPS):
 bun run dev          # start dev server
 bun run build        # production build
 bun run db:gen       # regenerate db types (run after schema changes)
-./scripts/e2e-test.sh <ip> <api-key>  # run e2e tests - extend when adding features (runs automatically via GitHub Actions on PRs)
 ```
 
-## Testing
-Create a PR to trigger e2e tests via GitHub Actions. Watch CI checks in the PR to verify tests pass.
+## E2E Tests
+
+Run locally (start `bun run dev` first):
+```bash
+./apps/app/scripts/e2e-local.sh <api-key>           # run all tests
+./apps/app/scripts/e2e-local.sh <api-key> 2         # batch size 2 (fewer parallel tests)
+
+# run single test
+SERVER_IP=localhost API_KEY=<key> E2E_LOCAL=1 FROST_DATA_DIR=./apps/app/data \
+  ./apps/app/scripts/e2e/group-01-basic.sh
+```
+
+Run against remote VPS:
+```bash
+./apps/app/scripts/e2e-test.sh <ip> <api-key>
+```
+
+E2E tests run automatically via GitHub Actions on PRs.
 
 ## Test locally
 ```bash

--- a/apps/app/schema/002-hostname-unique.sql
+++ b/apps/app/schema/002-hostname-unique.sql
@@ -1,0 +1,18 @@
+-- Auto-fix duplicate hostnames by adding numeric suffix
+UPDATE services
+SET hostname = hostname || '-' || (
+  SELECT COUNT(*)
+  FROM services s2
+  WHERE s2.environment_id = services.environment_id
+    AND s2.hostname = services.hostname
+    AND s2.rowid < services.rowid
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM services s2
+  WHERE s2.environment_id = services.environment_id
+    AND s2.hostname = services.hostname
+    AND s2.id != services.id
+);
+
+CREATE UNIQUE INDEX idx_services_environment_hostname ON services(environment_id, hostname);

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+E2E_DIR="$SCRIPT_DIR/e2e"
+
+BATCH_SIZE=${2:-4}
+PORT=${FROST_PORT:-3000}
+
+echo "========================================"
+echo "Local E2E Tests"
+echo "========================================"
+echo ""
+
+cd "$APP_DIR"
+
+if ! curl -sf "http://localhost:$PORT/api/health" > /dev/null 2>&1; then
+  echo "Error: Frost not running on localhost:$PORT"
+  echo "Start with: bun run dev"
+  exit 1
+fi
+echo "✓ Frost running on port $PORT"
+
+API_KEY="${1:-${FROST_API_KEY:-}}"
+if [ -z "$API_KEY" ]; then
+  echo "Usage: $0 <api-key>"
+  echo "Or set FROST_API_KEY environment variable"
+  exit 1
+fi
+echo "✓ API key provided"
+
+for dir in "$APP_DIR/test/fixtures"/*/; do
+  if [ -d "$dir" ] && [ ! -d "$dir/.git" ]; then
+    echo "Initializing git in $(basename "$dir")..."
+    (cd "$dir" && git init -b main && git add -A && git commit -m "init" --allow-empty) > /dev/null 2>&1
+  fi
+done
+echo "✓ Test fixtures ready"
+
+echo "Cleaning up Docker resources from previous runs..."
+docker rm -f $(docker ps -aq --filter "label=frost.managed=true") 2>/dev/null || true
+docker network prune -f > /dev/null 2>&1
+echo "✓ Docker cleanup done"
+
+export SERVER_IP="localhost"
+export API_KEY
+export E2E_LOCAL=1
+export FROST_DATA_DIR="$APP_DIR/data"
+
+chmod +x "$E2E_DIR"/*.sh
+
+FAILED=0
+ALL_GROUPS=("$E2E_DIR"/group-*.sh)
+TOTAL=${#ALL_GROUPS[@]}
+BATCH=0
+
+echo ""
+echo "Running $TOTAL test groups (batch size: $BATCH_SIZE)"
+echo ""
+
+for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
+  BATCH=$((BATCH+1))
+  PIDS=()
+  GROUP_NAMES=()
+
+  END=$((i + BATCH_SIZE))
+  [ $END -gt $TOTAL ] && END=$TOTAL
+
+  echo "--- Batch $BATCH: groups $((i+1))-$END ---"
+
+  for ((j=i; j<END; j++)); do
+    group="${ALL_GROUPS[$j]}"
+    GROUP_NAME=$(basename "$group" .sh)
+    GROUP_NAMES+=("$GROUP_NAME")
+    "$group" &
+    PIDS+=($!)
+    sleep 2
+  done
+
+  for k in "${!PIDS[@]}"; do
+    PID=${PIDS[$k]}
+    GROUP=${GROUP_NAMES[$k]}
+    if wait "$PID"; then
+      echo "✓ $GROUP passed"
+    else
+      echo "✗ $GROUP FAILED"
+      FAILED=1
+    fi
+  done
+  echo ""
+done
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "========================================"
+  echo "All E2E tests passed!"
+  echo "========================================"
+  exit 0
+else
+  echo "========================================"
+  echo "Some E2E tests FAILED"
+  echo "========================================"
+  exit 1
+fi

--- a/apps/app/scripts/e2e/group-06-webhook.sh
+++ b/apps/app/scripts/e2e/group-06-webhook.sh
@@ -38,8 +38,10 @@ api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
 
 log "Testing webhook triggers deployment..."
 TEST_WEBHOOK_SECRET="e2e-test-webhook-secret-$(date +%s)"
-remote "which sqlite3 || (apt-get update && apt-get install -y sqlite3)"
-remote "sqlite3 /opt/frost/data/frost.db \"
+if [ "${E2E_LOCAL:-}" != "1" ]; then
+  remote "which sqlite3 || (apt-get update && apt-get install -y sqlite3)"
+fi
+remote "sqlite3 $FROST_DATA_DIR/frost.db \"
 INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_id', 'test-app-id');
 INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_slug', 'test-app');
 INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_name', 'Test App');
@@ -49,7 +51,7 @@ INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_client_id', 'te
 INSERT OR REPLACE INTO settings (key, value) VALUES ('github_app_client_secret', 'test-client-secret');
 \"" || fail "Failed to insert GitHub app settings"
 
-SETTING_CHECK=$(remote "sqlite3 /opt/frost/data/frost.db \"SELECT COUNT(*) FROM settings WHERE key = 'github_app_webhook_secret';\"")
+SETTING_CHECK=$(remote "sqlite3 $FROST_DATA_DIR/frost.db \"SELECT COUNT(*) FROM settings WHERE key = 'github_app_webhook_secret';\"")
 [ "$SETTING_CHECK" != "1" ] && fail "Webhook secret not written to database"
 
 PROJECT2=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-webhook-deploy"}')
@@ -97,6 +99,6 @@ log "Webhook-deployed service responds correctly"
 
 log "Cleanup..."
 api -X DELETE "$BASE_URL/api/projects/$PROJECT2_ID" > /dev/null
-remote "sqlite3 /opt/frost/data/frost.db \"DELETE FROM settings WHERE key LIKE 'github_app_%';\"" || log "Warning: cleanup of settings failed"
+remote "sqlite3 $FROST_DATA_DIR/frost.db \"DELETE FROM settings WHERE key LIKE 'github_app_%';\"" || log "Warning: cleanup of settings failed"
 
 pass

--- a/apps/app/scripts/e2e/group-07-database.sh
+++ b/apps/app/scripts/e2e/group-07-database.sh
@@ -41,8 +41,8 @@ POSTGRES_PASSWORD=$(echo "$SERVICE_ENVVARS" | jq -r '.[] | select(.key == "POSTG
 log "Credentials auto-generated (pw length: ${#POSTGRES_PASSWORD})"
 
 log "Verifying SSL cert generated..."
-SSL_CERT_EXISTS=$(remote "test -f /opt/frost/data/ssl/$SERVICE_ID/server.crt && echo 'exists'" 2>&1)
-SSL_KEY_EXISTS=$(remote "test -f /opt/frost/data/ssl/$SERVICE_ID/server.key && echo 'exists'" 2>&1)
+SSL_CERT_EXISTS=$(remote "test -f $FROST_DATA_DIR/ssl/$SERVICE_ID/server.crt && echo 'exists'" 2>&1)
+SSL_KEY_EXISTS=$(remote "test -f $FROST_DATA_DIR/ssl/$SERVICE_ID/server.key && echo 'exists'" 2>&1)
 [ "$SSL_CERT_EXISTS" != "exists" ] || [ "$SSL_KEY_EXISTS" != "exists" ] && fail "SSL cert/key not generated"
 log "SSL certificate generated"
 
@@ -77,7 +77,7 @@ VOLUME_AFTER=$(remote "docker volume ls --filter name=$EXPECTED_VOLUME --format 
 echo "$VOLUME_AFTER" | grep -q "$EXPECTED_VOLUME" && fail "Volume should have been deleted"
 log "Volume deleted"
 
-SSL_CERT_AFTER=$(remote "test -f /opt/frost/data/ssl/$SERVICE_ID/server.crt && echo 'exists' || echo 'deleted'" 2>&1)
+SSL_CERT_AFTER=$(remote "test -f $FROST_DATA_DIR/ssl/$SERVICE_ID/server.crt && echo 'exists' || echo 'deleted'" 2>&1)
 [ "$SSL_CERT_AFTER" = "exists" ] && fail "SSL cert should have been deleted"
 log "SSL cert deleted"
 

--- a/apps/app/scripts/e2e/group-21-hostname.sh
+++ b/apps/app/scripts/e2e/group-21-hostname.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log "=== Hostname uniqueness ==="
+
+log "Creating project..."
+PROJECT=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-hostname"}')
+PROJECT_ID=$(require_field "$PROJECT" '.id' "create project") || fail "Failed to create project: $PROJECT"
+log "Created project: $PROJECT_ID"
+
+ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environment"
+log "Using environment: $ENV_ID"
+
+log "Creating first service 'My App'..."
+SERVICE1=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
+  -d '{"name":"My App","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
+SERVICE1_ID=$(require_field "$SERVICE1" '.id' "create service1") || fail "Failed to create service1: $SERVICE1"
+SERVICE1_HOSTNAME=$(require_field "$SERVICE1" '.hostname' "get hostname1") || fail "No hostname: $SERVICE1"
+log "Created service1: $SERVICE1_ID (hostname: $SERVICE1_HOSTNAME)"
+
+[ "$SERVICE1_HOSTNAME" = "my-app" ] || fail "Expected hostname 'my-app', got '$SERVICE1_HOSTNAME'"
+
+log "Creating second service with conflicting name 'my-app' (should fail)..."
+SERVICE2=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
+  -d '{"name":"my-app","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}' 2>&1)
+if echo "$SERVICE2" | grep -qi "conflict\|already exists"; then
+  log "Correctly rejected conflicting hostname"
+else
+  fail "Should have rejected conflicting hostname: $SERVICE2"
+fi
+
+log "Creating service with explicit hostname..."
+SERVICE3=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
+  -d '{"name":"my-app","hostname":"my-app-2","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
+SERVICE3_ID=$(require_field "$SERVICE3" '.id' "create service3") || fail "Failed to create service3: $SERVICE3"
+SERVICE3_HOSTNAME=$(require_field "$SERVICE3" '.hostname' "get hostname3") || fail "No hostname: $SERVICE3"
+log "Created service3: $SERVICE3_ID (hostname: $SERVICE3_HOSTNAME)"
+
+[ "$SERVICE3_HOSTNAME" = "my-app-2" ] || fail "Expected hostname 'my-app-2', got '$SERVICE3_HOSTNAME'"
+
+log "Updating service3 hostname to conflict (should fail)..."
+UPDATE=$(api -X PATCH "$BASE_URL/api/services/$SERVICE3_ID" \
+  -d '{"hostname":"my-app"}' 2>&1)
+if echo "$UPDATE" | grep -qi "conflict\|already exists"; then
+  log "Correctly rejected conflicting hostname update"
+else
+  fail "Should have rejected conflicting hostname update: $UPDATE"
+fi
+
+log "Waiting for deployments..."
+sleep 1
+DEPLOYS1=$(api "$BASE_URL/api/services/$SERVICE1_ID/deployments")
+DEPLOY1_ID=$(require_field "$DEPLOYS1" '.[0].id' "get deploy1") || fail "No deployment: $DEPLOYS1"
+DEPLOYS3=$(api "$BASE_URL/api/services/$SERVICE3_ID/deployments")
+DEPLOY3_ID=$(require_field "$DEPLOYS3" '.[0].id' "get deploy3") || fail "No deployment: $DEPLOYS3"
+wait_for_deployment "$DEPLOY1_ID" || fail "Deployment 1 failed"
+wait_for_deployment "$DEPLOY3_ID" || fail "Deployment 3 failed"
+
+log "Verifying inter-service communication with both hostnames..."
+NETWORK_NAME=$(sanitize_name "frost-net-$PROJECT_ID-$ENV_ID")
+CURL1=$(remote "docker run --rm --network $NETWORK_NAME curlimages/curl -sf http://my-app:80")
+echo "$CURL1" | grep -q "nginx" || fail "Cannot reach my-app"
+CURL2=$(remote "docker run --rm --network $NETWORK_NAME curlimages/curl -sf http://my-app-2:80")
+echo "$CURL2" | grep -q "nginx" || fail "Cannot reach my-app-2"
+log "Both hostnames resolve correctly"
+
+log "Cleanup..."
+api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
+
+pass

--- a/apps/app/src/contracts/services.ts
+++ b/apps/app/src/contracts/services.ts
@@ -30,6 +30,10 @@ export const servicesContract = {
       z.object({
         environmentId: z.string(),
         name: z.string().min(1),
+        hostname: z
+          .string()
+          .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/)
+          .optional(),
         deployType: z.enum(["repo", "image", "database"]).default("repo"),
         repoUrl: z.string().optional(),
         branch: z.string().default("main"),
@@ -58,6 +62,10 @@ export const servicesContract = {
       z.object({
         id: z.string(),
         name: z.string().optional(),
+        hostname: z
+          .string()
+          .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/)
+          .optional(),
         envVars: z.array(envVarSchema).optional(),
         containerPort: z.number().min(1).max(65535).optional(),
         branch: z.string().optional(),

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -33,6 +33,7 @@ import {
   injectTokenIntoUrl,
   isGitHubRepo,
 } from "./github";
+import { slugify } from "./slugify";
 import { generateSelfSignedCert, getSSLPaths, sslCertsExist } from "./ssl";
 import type { EnvVar } from "./types";
 import { buildVolumeName, createVolume } from "./volumes";
@@ -648,8 +649,8 @@ async function runServiceDeployment(
         name: containerName,
         envVars: runtimeEnvVars,
         network: networkName,
-        hostname: service.hostname ?? service.name,
-        networkAlias: service.name,
+        hostname: service.hostname ?? slugify(service.name),
+        networkAlias: service.hostname ?? slugify(service.name),
         labels: {
           ...baseLabels,
           "frost.deployment.id": deploymentId,
@@ -996,8 +997,8 @@ async function runRollbackDeployment(
         name: containerName,
         envVars: runtimeEnvVars,
         network: networkName,
-        hostname: service.hostname ?? service.name,
-        networkAlias: service.name,
+        hostname: service.hostname ?? slugify(service.name),
+        networkAlias: service.hostname ?? slugify(service.name),
         labels: {
           ...baseLabels,
           "frost.deployment.id": deploymentId,


### PR DESCRIPTION
## Summary
- Add unique constraint on (environment_id, hostname) with auto-fix migration for existing duplicates
- Validate hostname uniqueness on service create and update
- Allow custom hostname parameter (falls back to slugified name)
- Make hostname card editable with redeploy prompt
- Add e2e test for hostname uniqueness validation

Fixes #180

## Test plan
- [ ] Create two services with names that slugify to same hostname → should fail
- [ ] Create service with explicit hostname → should work
- [ ] Update hostname to conflict → should fail
- [ ] Verify inter-service communication works with both hostnames
- [ ] e2e test `group-21-hostname.sh` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)