### PR TITLE
feat: add architecture view for projects page

### DIFF
--- a/apps/app/src/app/_components/project-architecture-card.tsx
+++ b/apps/app/src/app/_components/project-architecture-card.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { Background, BackgroundVariant, ReactFlow } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import Link from "next/link";
+import { useMemo } from "react";
+import { StatusDot } from "@/components/status-dot";
+import type { ProjectListItem } from "@/lib/api";
+import { getKnownServiceLogo } from "@/lib/service-logo";
+import { cn } from "@/lib/utils";
+import { ProjectAvatar } from "./project-avatar";
+
+type CanvasPositions = Record<string, { x: number; y: number }>;
+
+interface MiniServiceNodeProps {
+  service: ProjectListItem["services"][number];
+}
+
+const POSITION_SCALE = 3;
+
+function MiniServiceNode({ service }: MiniServiceNodeProps) {
+  const logo = getKnownServiceLogo(service);
+
+  return (
+    <div
+      className="flex h-11 w-11 items-center justify-center rounded-lg bg-neutral-800 border border-neutral-700"
+      title={service.name}
+    >
+      {logo ? (
+        <img src={logo} alt="" className="h-6 w-6 object-contain" />
+      ) : (
+        <span className="text-base font-semibold text-neutral-300">
+          {service.name.charAt(0).toUpperCase()}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface ProjectArchitectureCardProps {
+  project: ProjectListItem;
+}
+
+export function ProjectArchitectureCard({
+  project,
+}: ProjectArchitectureCardProps) {
+  const runningCount = project.services.filter(
+    (s) => s.status === "running",
+  ).length;
+  const totalCount = project.services.length;
+
+  const nodes = useMemo(() => {
+    const positions: CanvasPositions = project.canvasPositions
+      ? (JSON.parse(project.canvasPositions) as CanvasPositions)
+      : {};
+
+    return project.services.map((service, index) => {
+      const realPos = positions[service.id] || { x: 60 + index * 140, y: 60 };
+      const scaledPos = {
+        x: realPos.x / POSITION_SCALE,
+        y: realPos.y / POSITION_SCALE,
+      };
+      return {
+        id: service.id,
+        position: scaledPos,
+        data: { service },
+        type: "miniService",
+      };
+    });
+  }, [project.services, project.canvasPositions]);
+
+  const nodeTypes = useMemo(
+    () => ({
+      miniService: ({
+        data,
+      }: {
+        data: { service: MiniServiceNodeProps["service"] };
+      }) => <MiniServiceNode service={data.service} />,
+    }),
+    [],
+  );
+
+  const hasDeployment =
+    runningCount > 0 || project.services.some((s) => s.status);
+
+  return (
+    <Link
+      href={`/projects/${project.id}`}
+      className="group block rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden transition-colors hover:border-neutral-700 hover:bg-neutral-800/50"
+    >
+      <div
+        className={cn(
+          "relative h-52 w-full",
+          totalCount === 0 && "flex items-center justify-center",
+        )}
+      >
+        {totalCount === 0 ? (
+          <span className="text-sm text-neutral-500">No services</span>
+        ) : (
+          <ReactFlow
+            nodes={nodes}
+            edges={[]}
+            nodeTypes={nodeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.15, maxZoom: 1.5 }}
+            panOnDrag={false}
+            zoomOnScroll={false}
+            zoomOnPinch={false}
+            zoomOnDoubleClick={false}
+            nodesDraggable={false}
+            nodesConnectable={false}
+            nodesFocusable={false}
+            elementsSelectable={false}
+            minZoom={0.1}
+            maxZoom={2}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background
+              variant={BackgroundVariant.Dots}
+              gap={20}
+              size={1}
+              color="#404040"
+            />
+          </ReactFlow>
+        )}
+      </div>
+      <div className="flex items-center gap-3 border-t border-neutral-800 p-3">
+        <ProjectAvatar name={project.name} size="sm" />
+        <div className="flex-1 min-w-0">
+          <h2 className="font-medium text-neutral-100 truncate">
+            {project.name}
+          </h2>
+        </div>
+        {hasDeployment && (
+          <div className="flex items-center gap-2 text-xs text-neutral-400">
+            <StatusDot status={runningCount > 0 ? "running" : "pending"} />
+            <span>
+              {runningCount}/{totalCount} online
+            </span>
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/apps/app/src/app/_components/project-list-item.tsx
+++ b/apps/app/src/app/_components/project-list-item.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { StatusDot } from "@/components/status-dot";
+import type { ProjectListItem as ProjectListItemType } from "@/lib/api";
+
+interface ProjectListRowProps {
+  project: ProjectListItemType;
+}
+
+export function ProjectListRow({ project }: ProjectListRowProps) {
+  const runningCount = project.services.filter(
+    (s) => s.status === "running",
+  ).length;
+  const totalCount = project.services.length;
+  const hasServices = totalCount > 0;
+
+  return (
+    <Link
+      href={`/projects/${project.id}`}
+      className="flex items-center justify-between rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3 transition-colors hover:border-neutral-700 hover:bg-neutral-800/50"
+    >
+      <span className="font-medium text-neutral-100">{project.name}</span>
+      {hasServices && (
+        <div className="flex items-center gap-2 text-sm text-neutral-400">
+          <StatusDot status={runningCount > 0 ? "running" : "pending"} />
+          <span>production</span>
+          <span className="text-neutral-500">·</span>
+          <span>
+            {runningCount}/{totalCount} services online
+          </span>
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/apps/app/src/app/_components/skeleton-card.tsx
+++ b/apps/app/src/app/_components/skeleton-card.tsx
@@ -1,21 +1,25 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-export function SkeletonCard() {
+export function SkeletonArchitectureCard() {
   return (
-    <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
-      <div className="flex items-start gap-3">
-        <Skeleton className="h-10 w-10 rounded-full" />
-        <div className="flex-1 space-y-2">
-          <Skeleton className="h-5 w-32" />
-          <Skeleton className="h-4 w-40" />
-        </div>
+    <div className="rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden">
+      <div className="h-52 bg-neutral-950" />
+      <div className="flex items-center gap-3 border-t border-neutral-800 p-3">
+        <Skeleton className="h-8 w-8 rounded-full" />
+        <Skeleton className="h-5 w-32" />
       </div>
-      <div className="mt-3">
-        <Skeleton className="h-5 w-28 rounded-full" />
-      </div>
-      <div className="mt-3 space-y-2">
-        <Skeleton className="h-4 w-48" />
-        <Skeleton className="h-3 w-24" />
+    </div>
+  );
+}
+
+export function SkeletonListItem() {
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
+      <Skeleton className="h-5 w-32" />
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-2 w-2 rounded-full" />
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-4 w-32" />
       </div>
     </div>
   );

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,20 +1,42 @@
 "use client";
 
-import { Plus, Rocket, Search } from "lucide-react";
+import { LayoutGrid, List, Plus, Rocket, Search } from "lucide-react";
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { BreadcrumbHeader } from "@/components/breadcrumb-header";
 import { EmptyState } from "@/components/empty-state";
 import { Header } from "@/components/header";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useProjects } from "@/hooks/use-projects";
-import { ProjectCard } from "./_components/project-card";
-import { SkeletonCard } from "./_components/skeleton-card";
+import { ProjectArchitectureCard } from "./_components/project-architecture-card";
+import { ProjectListRow } from "./_components/project-list-item";
+import {
+  SkeletonArchitectureCard,
+  SkeletonListItem,
+} from "./_components/skeleton-card";
+
+type ViewMode = "architecture" | "list";
+const VIEW_STORAGE_KEY = "frost-projects-view";
 
 export default function Home() {
   const { data: projects, isLoading } = useProjects();
   const [search, setSearch] = useState("");
+  const [view, setView] = useState<ViewMode>("architecture");
+
+  useEffect(() => {
+    const saved = localStorage.getItem(VIEW_STORAGE_KEY);
+    if (saved === "architecture" || saved === "list") {
+      setView(saved);
+    }
+  }, []);
+
+  function handleViewChange(value: string) {
+    const v = value as ViewMode;
+    setView(v);
+    localStorage.setItem(VIEW_STORAGE_KEY, v);
+  }
 
   const filteredProjects = useMemo(() => {
     if (!projects) return [];
@@ -25,11 +47,20 @@ export default function Home() {
 
   function renderContent() {
     if (isLoading) {
+      if (view === "list") {
+        return (
+          <div className="flex flex-col gap-2">
+            <SkeletonListItem />
+            <SkeletonListItem />
+            <SkeletonListItem />
+          </div>
+        );
+      }
       return (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <SkeletonCard />
-          <SkeletonCard />
-          <SkeletonCard />
+          <SkeletonArchitectureCard />
+          <SkeletonArchitectureCard />
+          <SkeletonArchitectureCard />
         </div>
       );
     }
@@ -55,17 +86,20 @@ export default function Home() {
       );
     }
 
+    if (view === "architecture") {
+      return (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredProjects.map((project) => (
+            <ProjectArchitectureCard key={project.id} project={project} />
+          ))}
+        </div>
+      );
+    }
+
     return (
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="flex flex-col gap-2">
         {filteredProjects.map((project) => (
-          <ProjectCard
-            key={project.id}
-            id={project.id}
-            name={project.name}
-            runningUrl={project.runningUrl}
-            repoUrl={project.repoUrl}
-            latestDeployment={project.latestDeployment}
-          />
+          <ProjectListRow key={project.id} project={project} />
         ))}
       </div>
     );
@@ -87,6 +121,18 @@ export default function Home() {
               className="pl-9"
             />
           </div>
+          <Tabs value={view} onValueChange={handleViewChange}>
+            <TabsList className="bg-neutral-800">
+              <TabsTrigger value="architecture" className="gap-1.5">
+                <LayoutGrid className="h-4 w-4" />
+                <span className="hidden sm:inline">Architecture</span>
+              </TabsTrigger>
+              <TabsTrigger value="list" className="gap-1.5">
+                <List className="h-4 w-4" />
+                <span className="hidden sm:inline">List</span>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
           <Button asChild>
             <Link href="/projects/new">
               <Plus className="mr-1.5 h-4 w-4" />

--- a/apps/app/src/app/projects/[id]/_components/service-card.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-card.tsx
@@ -1,62 +1,9 @@
 "use client";
 
-import { GitBranch, Github, Package } from "lucide-react";
 import Link from "next/link";
-import { StatusDot } from "@/components/status-dot";
 import { Card, CardContent } from "@/components/ui/card";
 import type { Service } from "@/lib/api";
-import { getTimeAgo } from "@/lib/time";
-
-function getGitHubRepoFromUrl(url: string | null): string | null {
-  if (!url) return null;
-  const match = url.match(/github\.com\/([^/]+\/[^/]+)/);
-  return match ? match[1] : null;
-}
-
-function getKnownServiceLogo(service: Service): string | null {
-  const imageUrl = service.imageUrl?.toLowerCase() || "";
-  const name = service.name.toLowerCase();
-
-  if (
-    imageUrl.includes("postgres") ||
-    name.includes("postgres") ||
-    name.includes("pg")
-  ) {
-    return "https://www.postgresql.org/media/img/about/press/elephant.png";
-  }
-  if (imageUrl.includes("redis") || name.includes("redis")) {
-    return "https://cdn.simpleicons.org/redis/DC382D";
-  }
-  if (imageUrl.includes("mysql") || name.includes("mysql")) {
-    return "https://cdn.simpleicons.org/mysql/4479A1";
-  }
-  if (imageUrl.includes("mongo") || name.includes("mongo")) {
-    return "https://cdn.simpleicons.org/mongodb/47A248";
-  }
-  if (imageUrl.includes("mariadb") || name.includes("mariadb")) {
-    return "https://cdn.simpleicons.org/mariadb/003545";
-  }
-  if (imageUrl.includes("nginx") || name.includes("nginx")) {
-    return "https://cdn.simpleicons.org/nginx/009639";
-  }
-  if (imageUrl.includes("node") || name.includes("node")) {
-    return "https://cdn.simpleicons.org/nodedotjs/339933";
-  }
-  if (imageUrl.includes("python") || name.includes("python")) {
-    return "https://cdn.simpleicons.org/python/3776AB";
-  }
-  if (imageUrl.includes("rabbitmq") || name.includes("rabbitmq")) {
-    return "https://cdn.simpleicons.org/rabbitmq/FF6600";
-  }
-  if (imageUrl.includes("elasticsearch") || name.includes("elastic")) {
-    return "https://cdn.simpleicons.org/elasticsearch/005571";
-  }
-  if (imageUrl.includes("minio") || name.includes("minio")) {
-    return "https://cdn.simpleicons.org/minio/C72E49";
-  }
-
-  return null;
-}
+import { ServiceContent } from "./service-content";
 
 interface ServiceCardProps {
   service: Service;
@@ -77,8 +24,6 @@ export function ServiceCard({
     (serverIp && deployment?.hostPort
       ? `${serverIp}:${deployment.hostPort}`
       : null);
-  const githubRepo = getGitHubRepoFromUrl(service.repoUrl);
-  const knownLogo = getKnownServiceLogo(service);
 
   return (
     <Link
@@ -87,65 +32,8 @@ export function ServiceCard({
     >
       <Card className="h-full cursor-pointer bg-neutral-900 border-neutral-800 transition-colors hover:border-neutral-700">
         <CardContent className="flex h-full flex-col p-4">
-          <div className="flex items-start gap-3 mb-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-800 text-neutral-400">
-              {knownLogo ? (
-                <img
-                  src={knownLogo}
-                  alt=""
-                  className="h-5 w-5 object-contain"
-                />
-              ) : (
-                <span className="text-sm font-semibold text-neutral-300">
-                  {service.name.charAt(0).toUpperCase()}
-                </span>
-              )}
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center justify-between">
-                <p className="font-medium text-neutral-200">{service.name}</p>
-                <StatusDot status={deployment?.status || "pending"} />
-              </div>
-              {url && service.serviceType !== "database" && (
-                <p className="text-xs text-neutral-500 truncate">{url}</p>
-              )}
-            </div>
-          </div>
-
-          {service.deployType === "repo" && githubRepo && (
-            <span className="inline-flex items-center gap-1.5 self-start rounded-full bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400 mb-2">
-              <Github className="h-3 w-3" />
-              {githubRepo}
-            </span>
-          )}
-
-          {service.deployType === "image" && (
-            <span className="inline-flex items-center gap-1.5 self-start rounded-full bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400 mb-2">
-              <Package className="h-3 w-3" />
-              {service.imageUrl}
-            </span>
-          )}
-
-          {deployment?.commitMessage && (
-            <p className="text-sm text-neutral-400 line-clamp-1 mb-2">
-              {deployment.commitMessage}
-            </p>
-          )}
-
+          <ServiceContent service={service} url={url} />
           <div className="flex-grow" />
-
-          {deployment && (
-            <div className="flex items-center gap-1 text-xs text-neutral-500">
-              <span>{getTimeAgo(new Date(deployment.createdAt))}</span>
-              {service.deployType === "repo" && (
-                <>
-                  <span>on</span>
-                  <GitBranch className="h-3 w-3" />
-                  <span>{service.branch || "main"}</span>
-                </>
-              )}
-            </div>
-          )}
         </CardContent>
       </Card>
     </Link>

--- a/apps/app/src/app/projects/[id]/_components/service-content.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-content.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { GitBranch, Github, Package } from "lucide-react";
+import { StatusDot } from "@/components/status-dot";
+import type { Service } from "@/lib/api";
+import { getKnownServiceLogo } from "@/lib/service-logo";
+import { getGitHubRepoFromUrl } from "@/lib/service-url";
+import { getTimeAgo } from "@/lib/time";
+
+interface ServiceContentProps {
+  service: Service;
+  url: string | null;
+  truncateImage?: boolean;
+}
+
+export function ServiceContent({
+  service,
+  url,
+  truncateImage,
+}: ServiceContentProps) {
+  const deployment = service.latestDeployment;
+  const githubRepo = getGitHubRepoFromUrl(service.repoUrl);
+  const knownLogo = getKnownServiceLogo(service);
+
+  return (
+    <>
+      <div className="flex items-start gap-3 mb-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-800 text-neutral-400">
+          {knownLogo ? (
+            <img src={knownLogo} alt="" className="h-5 w-5 object-contain" />
+          ) : (
+            <span className="text-sm font-semibold text-neutral-300">
+              {service.name.charAt(0).toUpperCase()}
+            </span>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between">
+            <p className="font-medium text-neutral-200">{service.name}</p>
+            <StatusDot status={deployment?.status || "pending"} />
+          </div>
+          {url && service.serviceType !== "database" && (
+            <p className="text-xs text-neutral-500 truncate">{url}</p>
+          )}
+        </div>
+      </div>
+
+      {service.deployType === "repo" && githubRepo && (
+        <span className="inline-flex items-center gap-1.5 self-start rounded-full bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400 mb-2">
+          <Github className="h-3 w-3" />
+          {githubRepo}
+        </span>
+      )}
+
+      {service.deployType === "image" && (
+        <span className="inline-flex items-center gap-1.5 self-start rounded-full bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400 mb-2">
+          <Package className="h-3 w-3" />
+          {truncateImage ? (
+            <span className="truncate max-w-[180px]">{service.imageUrl}</span>
+          ) : (
+            service.imageUrl
+          )}
+        </span>
+      )}
+
+      {deployment?.commitMessage && (
+        <p className="text-sm text-neutral-400 line-clamp-1 mb-2">
+          {deployment.commitMessage}
+        </p>
+      )}
+
+      {deployment && (
+        <div className="flex items-center gap-1 text-xs text-neutral-500 mt-auto">
+          <span>{getTimeAgo(new Date(deployment.createdAt))}</span>
+          {service.deployType === "repo" && (
+            <>
+              <span>on</span>
+              <GitBranch className="h-3 w-3" />
+              <span>{service.branch || "main"}</span>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/app/src/app/projects/[id]/_components/service-node.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-node.tsx
@@ -2,63 +2,10 @@
 
 import type { Node, NodeProps } from "@xyflow/react";
 import { Handle, Position } from "@xyflow/react";
-import { GitBranch, Github, Package } from "lucide-react";
-import { StatusDot } from "@/components/status-dot";
 import { Card, CardContent } from "@/components/ui/card";
 import type { Service } from "@/lib/api";
-import { getTimeAgo } from "@/lib/time";
 import { cn } from "@/lib/utils";
-
-function getGitHubRepoFromUrl(url: string | null): string | null {
-  if (!url) return null;
-  const match = url.match(/github\.com\/([^/]+\/[^/]+)/);
-  return match ? match[1] : null;
-}
-
-function getKnownServiceLogo(service: Service): string | null {
-  const imageUrl = service.imageUrl?.toLowerCase() || "";
-  const name = service.name.toLowerCase();
-
-  if (
-    imageUrl.includes("postgres") ||
-    name.includes("postgres") ||
-    name.includes("pg")
-  ) {
-    return "https://www.postgresql.org/media/img/about/press/elephant.png";
-  }
-  if (imageUrl.includes("redis") || name.includes("redis")) {
-    return "https://cdn.simpleicons.org/redis/DC382D";
-  }
-  if (imageUrl.includes("mysql") || name.includes("mysql")) {
-    return "https://cdn.simpleicons.org/mysql/4479A1";
-  }
-  if (imageUrl.includes("mongo") || name.includes("mongo")) {
-    return "https://cdn.simpleicons.org/mongodb/47A248";
-  }
-  if (imageUrl.includes("mariadb") || name.includes("mariadb")) {
-    return "https://cdn.simpleicons.org/mariadb/003545";
-  }
-  if (imageUrl.includes("nginx") || name.includes("nginx")) {
-    return "https://cdn.simpleicons.org/nginx/009639";
-  }
-  if (imageUrl.includes("node") || name.includes("node")) {
-    return "https://cdn.simpleicons.org/nodedotjs/339933";
-  }
-  if (imageUrl.includes("python") || name.includes("python")) {
-    return "https://cdn.simpleicons.org/python/3776AB";
-  }
-  if (imageUrl.includes("rabbitmq") || name.includes("rabbitmq")) {
-    return "https://cdn.simpleicons.org/rabbitmq/FF6600";
-  }
-  if (imageUrl.includes("elasticsearch") || name.includes("elastic")) {
-    return "https://cdn.simpleicons.org/elasticsearch/005571";
-  }
-  if (imageUrl.includes("minio") || name.includes("minio")) {
-    return "https://cdn.simpleicons.org/minio/C72E49";
-  }
-
-  return null;
-}
+import { ServiceContent } from "./service-content";
 
 export type ServiceNodeData = {
   service: Service;
@@ -78,8 +25,6 @@ export function ServiceNode({ data }: NodeProps<ServiceNodeType>) {
     (serverIp && deployment?.hostPort
       ? `${serverIp}:${deployment.hostPort}`
       : null);
-  const githubRepo = getGitHubRepoFromUrl(service.repoUrl);
-  const knownLogo = getKnownServiceLogo(service);
 
   return (
     <>
@@ -93,63 +38,7 @@ export function ServiceNode({ data }: NodeProps<ServiceNodeType>) {
         )}
       >
         <CardContent className="flex flex-col p-4">
-          <div className="flex items-start gap-3 mb-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-800 text-neutral-400">
-              {knownLogo ? (
-                <img
-                  src={knownLogo}
-                  alt=""
-                  className="h-5 w-5 object-contain"
-                />
-              ) : (
-                <span className="text-sm font-semibold text-neutral-300">
-                  {service.name.charAt(0).toUpperCase()}
-                </span>
-              )}
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center justify-between">
-                <p className="font-medium text-neutral-200">{service.name}</p>
-                <StatusDot status={deployment?.status || "pending"} />
-              </div>
-              {url && service.serviceType !== "database" && (
-                <p className="text-xs text-neutral-500 truncate">{url}</p>
-              )}
-            </div>
-          </div>
-
-          {service.deployType === "repo" && githubRepo && (
-            <span className="inline-flex items-center gap-1.5 self-start rounded-full bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400 mb-2">
-              <Github className="h-3 w-3" />
-              {githubRepo}
-            </span>
-          )}
-
-          {service.deployType === "image" && (
-            <span className="inline-flex items-center gap-1.5 self-start rounded-full bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400 mb-2">
-              <Package className="h-3 w-3" />
-              <span className="truncate max-w-[180px]">{service.imageUrl}</span>
-            </span>
-          )}
-
-          {deployment?.commitMessage && (
-            <p className="text-sm text-neutral-400 line-clamp-1 mb-2">
-              {deployment.commitMessage}
-            </p>
-          )}
-
-          {deployment && (
-            <div className="flex items-center gap-1 text-xs text-neutral-500 mt-auto">
-              <span>{getTimeAgo(new Date(deployment.createdAt))}</span>
-              {service.deployType === "repo" && (
-                <>
-                  <span>on</span>
-                  <GitBranch className="h-3 w-3" />
-                  <span>{service.branch || "main"}</span>
-                </>
-              )}
-            </div>
-          )}
+          <ServiceContent service={service} url={url} truncateImage />
         </CardContent>
       </Card>
       <Handle type="source" position={Position.Right} className="invisible" />

--- a/apps/app/src/app/projects/[id]/environments/[envId]/page.tsx
+++ b/apps/app/src/app/projects/[id]/environments/[envId]/page.tsx
@@ -28,6 +28,10 @@ export default function EnvironmentDetailPage() {
     orpc.environments.get.queryOptions({ input: { id: envId } }),
   );
 
+  const { data: project } = useQuery(
+    orpc.projects.get.queryOptions({ input: { id: projectId } }),
+  );
+
   const { data: settings } = useQuery({
     queryKey: ["settings"],
     queryFn: () => api.settings.get(),
@@ -89,7 +93,9 @@ export default function EnvironmentDetailPage() {
 
   if (!environment) return null;
 
-  const canvasPositions: CanvasPositions = {};
+  const canvasPositions: CanvasPositions = project?.canvasPositions
+    ? (JSON.parse(project.canvasPositions) as CanvasPositions)
+    : {};
 
   if (services.length === 0) {
     if (isMobile) {

--- a/apps/app/src/contracts/projects.ts
+++ b/apps/app/src/contracts/projects.ts
@@ -14,11 +14,20 @@ const latestDeploymentSchema = z.object({
   branch: z.string().nullable(),
 });
 
+const projectListServiceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  imageUrl: z.string().nullable(),
+  deployType: z.string(),
+  status: z.string().nullable(),
+});
+
 const projectListItemSchema = projectsSchema.extend({
   servicesCount: z.number(),
   latestDeployment: latestDeploymentSchema.nullable(),
   repoUrl: z.string().nullable(),
   runningUrl: z.string().nullable(),
+  services: z.array(projectListServiceSchema),
 });
 
 const serviceWithDeploymentSchema = servicesSchema.extend({

--- a/apps/app/src/lib/service-logo.ts
+++ b/apps/app/src/lib/service-logo.ts
@@ -1,0 +1,40 @@
+interface ServiceLike {
+  name: string;
+  imageUrl?: string | null;
+}
+
+const KNOWN_LOGOS: Array<{ keywords: string[]; logo: string }> = [
+  {
+    keywords: ["postgres", "pg"],
+    logo: "https://www.postgresql.org/media/img/about/press/elephant.png",
+  },
+  { keywords: ["redis"], logo: "https://cdn.simpleicons.org/redis/DC382D" },
+  { keywords: ["mysql"], logo: "https://cdn.simpleicons.org/mysql/4479A1" },
+  { keywords: ["mongo"], logo: "https://cdn.simpleicons.org/mongodb/47A248" },
+  { keywords: ["mariadb"], logo: "https://cdn.simpleicons.org/mariadb/003545" },
+  { keywords: ["nginx"], logo: "https://cdn.simpleicons.org/nginx/009639" },
+  { keywords: ["node"], logo: "https://cdn.simpleicons.org/nodedotjs/339933" },
+  { keywords: ["python"], logo: "https://cdn.simpleicons.org/python/3776AB" },
+  {
+    keywords: ["rabbitmq"],
+    logo: "https://cdn.simpleicons.org/rabbitmq/FF6600",
+  },
+  {
+    keywords: ["elasticsearch", "elastic"],
+    logo: "https://cdn.simpleicons.org/elasticsearch/005571",
+  },
+  { keywords: ["minio"], logo: "https://cdn.simpleicons.org/minio/C72E49" },
+];
+
+export function getKnownServiceLogo(service: ServiceLike): string | null {
+  const imageUrl = service.imageUrl?.toLowerCase() || "";
+  const name = service.name.toLowerCase();
+
+  for (const { keywords, logo } of KNOWN_LOGOS) {
+    if (keywords.some((kw) => imageUrl.includes(kw) || name.includes(kw))) {
+      return logo;
+    }
+  }
+
+  return null;
+}

--- a/apps/app/src/lib/service-url.ts
+++ b/apps/app/src/lib/service-url.ts
@@ -1,5 +1,11 @@
 import type { Domain } from "@/lib/api";
 
+export function getGitHubRepoFromUrl(url: string | null): string | null {
+  if (!url) return null;
+  const match = url.match(/github\.com\/([^/]+\/[^/]+)/);
+  return match ? match[1] : null;
+}
+
 export function getPreferredDomain(domains: Domain[]): Domain | null {
   const verified = domains.filter((d) => d.dnsVerified);
   return (


### PR DESCRIPTION
## Summary
- Add view toggle (Architecture/List) to projects page
- Architecture view shows mini canvas with service icons at scaled positions
- List view shows simple full-width rows with project name and status
- View preference persisted in localStorage

## Changes
- Extract service logo detection to shared `lib/service-logo.ts`
- Create shared `ServiceContent` component to reduce duplication
- Fix environment page to load saved canvas positions from project
- Extend API to return services array with deployment status

## Test plan
- [ ] Toggle between Architecture and List views
- [ ] Verify mini canvas shows correct service positions
- [ ] Verify view preference persists after page reload
- [ ] Verify canvas position changes in project page reflect in mini canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)