### PR TITLE
fix: use wildcard cert for subdomains

### DIFF
--- a/apps/app/src/lib/domains.ts
+++ b/apps/app/src/lib/domains.ts
@@ -350,7 +350,7 @@ function buildCaddyConfig(
 
   if (wildcardConfig && wildcardDomains.length > 0) {
     policies.push({
-      subjects: [`*.${wildcardConfig.domain}`],
+      subjects: [`*.${wildcardConfig.domain}`, ...wildcardDomains],
       issuers: [dnsAcmeIssuer(email, wildcardConfig.dnsConfig, staging)],
     });
   }


### PR DESCRIPTION
## Summary
- Fix SSL delay (~5s ERR_SSL_PROTOCOL_ERROR) after deploying new services
- Caddy was requesting individual certs for each subdomain instead of using the existing wildcard cert
- Include specific subdomains in the wildcard policy subjects so Caddy matches them correctly

## Root cause
When building Caddy TLS policies, only `*.apps.j4labs.se` was in subjects. New subdomains like `myapp.apps.j4labs.se` didn't match this policy, causing Caddy to fall back to requesting individual certs via HTTP-01.

## Test plan
- [ ] Deploy a new service with wildcard domain configured
- [ ] Verify HTTPS works immediately (no SSL error)
- [ ] Check Caddy config includes specific subdomains in wildcard policy subjects

🤖 Generated with [Claude Code](https://claude.com/claude-code)