### PR TITLE
fix: marketing site Dockerfile for Frost deployment

### DIFF
--- a/apps/marketing/Dockerfile
+++ b/apps/marketing/Dockerfile
@@ -3,17 +3,22 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
+COPY apps/app/package.json ./apps/app/
+COPY apps/marketing/package.json ./apps/marketing/
+RUN bun install --frozen-lockfile --filter @frost/marketing
 
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+COPY apps/marketing ./apps/marketing
+WORKDIR /app/apps/marketing
 RUN bun run build
 
 FROM base AS runner
 ENV NODE_ENV=production
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+COPY --from=builder /app/apps/marketing/.next/standalone ./
+COPY --from=builder /app/apps/marketing/.next/static ./apps/marketing/.next/static
+COPY --from=builder /app/apps/marketing/public ./apps/marketing/public
 EXPOSE 3000
-CMD ["bun", "run", "server.js"]
+CMD ["bun", "run", "apps/marketing/server.js"]

--- a/apps/marketing/README.md
+++ b/apps/marketing/README.md
@@ -1,0 +1,26 @@
+# Frost Marketing Site
+
+## Deploy with Frost
+
+**Service Settings:**
+
+| Setting | Value |
+|---------|-------|
+| Deploy type | Repository |
+| Dockerfile path | `apps/marketing/Dockerfile` |
+| Build context | `.` (repo root) |
+| Container port | `3000` |
+
+**Steps:**
+1. Create project in Frost
+2. Add service with above settings
+3. Set repo URL to `https://github.com/elitan/frost`
+4. Add domain (e.g. `frost.build`)
+5. Deploy
+
+## Local Build
+
+```bash
+docker build -f apps/marketing/Dockerfile -t frost-marketing .
+docker run -p 3000:3000 frost-marketing
+```


### PR DESCRIPTION
## Summary
- Add `HOSTNAME=0.0.0.0` so Next.js accepts external connections in Docker
- Add `PORT=3000` env var for Frost routing
- Fix monorepo build context (copy workspace package.jsons, use `--filter`)
- Fix static files path to match Next.js standalone output structure
- Add README with Frost deployment instructions

## Test plan
- [x] Build locally: `docker build -f apps/marketing/Dockerfile -t frost-marketing .`
- [x] Run: `docker run -p 3000:3000 frost-marketing`
- [x] Verify CSS/JS loads correctly at http://localhost:3000
- [ ] Deploy to test VPS via Frost

🤖 Generated with [Claude Code](https://claude.com/claude-code)