### PR TITLE
fix: use MemAvailable for accurate memory monitoring on Linux

### DIFF
--- a/apps/app/src/app/projects/[id]/services/[serviceId]/_components/service-metrics-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/_components/service-metrics-card.tsx
@@ -136,7 +136,7 @@ export function ServiceMetricsCard({ serviceId }: ServiceMetricsCardProps) {
                         fontSize: "11px",
                       }}
                       labelStyle={{ color: "#a3a3a3" }}
-                      labelFormatter={formatTime}
+                      labelFormatter={(label) => formatTime(label as number)}
                       formatter={(value) => [
                         `${Number(value).toFixed(1)}%`,
                         "CPU",
@@ -214,7 +214,7 @@ export function ServiceMetricsCard({ serviceId }: ServiceMetricsCardProps) {
                         fontSize: "11px",
                       }}
                       labelStyle={{ color: "#a3a3a3" }}
-                      labelFormatter={formatTime}
+                      labelFormatter={(label) => formatTime(label as number)}
                       formatter={(value, _name, props) => {
                         const percent = `${Number(value).toFixed(1)}%`;
                         const bytes = props.payload?.bytes;

--- a/apps/app/src/app/settings/monitoring/_components/metric-chart.tsx
+++ b/apps/app/src/app/settings/monitoring/_components/metric-chart.tsx
@@ -88,7 +88,7 @@ export function MetricChart({
               fontSize: "12px",
             }}
             labelStyle={{ color: "#a3a3a3" }}
-            labelFormatter={formatTime}
+            labelFormatter={(label) => formatTime(label as number)}
             formatter={(value) => [`${Number(value).toFixed(1)}${unit}`, label]}
           />
           <Area

--- a/apps/marketing/Dockerfile
+++ b/apps/marketing/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json bun.lock ./
+COPY apps/app/package.json ./apps/app/
 COPY apps/marketing/package.json ./apps/marketing/
 RUN bun install --frozen-lockfile
 

--- a/apps/marketing/Dockerfile
+++ b/apps/marketing/Dockerfile
@@ -10,8 +10,7 @@ RUN bun install --frozen-lockfile --filter @frost/marketing
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/marketing ./apps/marketing
-WORKDIR /app/apps/marketing
-RUN bun run build
+RUN bun run --cwd apps/marketing build
 
 FROM base AS runner
 ENV NODE_ENV=production

--- a/apps/marketing/Dockerfile
+++ b/apps/marketing/Dockerfile
@@ -3,12 +3,12 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json bun.lock ./
-COPY apps/app/package.json ./apps/app/
 COPY apps/marketing/package.json ./apps/marketing/
-RUN bun install --frozen-lockfile
+RUN bun install --filter @frost/marketing
 
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/marketing/node_modules ./apps/marketing/node_modules
 COPY apps/marketing ./apps/marketing
 WORKDIR /app/apps/marketing
 RUN bun run build

--- a/apps/marketing/Dockerfile
+++ b/apps/marketing/Dockerfile
@@ -3,14 +3,14 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json bun.lock ./
-COPY apps/app/package.json ./apps/app/
 COPY apps/marketing/package.json ./apps/marketing/
-RUN bun install --frozen-lockfile --filter @frost/marketing
+RUN bun install --frozen-lockfile
 
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/marketing ./apps/marketing
-RUN bun run --cwd apps/marketing build
+WORKDIR /app/apps/marketing
+RUN bun run build
 
 FROM base AS runner
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
● Fix memory monitoring showing inflated usage (~91% vs actual ~38%)
● Read `/proc/meminfo` MemAvailable on Linux instead of `os.freemem()`
● Fall back to `os.freemem()` on non-Linux platforms

## Problem
`os.freemem()` returns only completely unallocated memory, not accounting for Linux buffer/cache that can be reclaimed.

```
Actual:     used: 2.9GB, buff/cache: 4.6GB, available: 4.7GB
Reported:   used: 6.9GB (total - free, includes buff/cache)
```

## Test plan
- [ ] Deploy to test server
- [ ] Compare `free -h` output with Frost monitoring
- [ ] `available` column should roughly match `memoryTotal - memoryUsed` in Frost

🤖 Generated with [Claude Code](https://claude.com/claude-code)