### PR TITLE
fix: truncate long branch names on service cards

### DIFF
--- a/apps/app/src/app/_components/project-card.tsx
+++ b/apps/app/src/app/_components/project-card.tsx
@@ -73,9 +73,9 @@ export function ProjectCard({
             {latestDeployment.branch && (
               <>
                 <span>on</span>
-                <span className="inline-flex items-center gap-1">
-                  <GitBranch className="h-3 w-3" />
-                  {latestDeployment.branch}
+                <span className="inline-flex items-center gap-1 min-w-0 max-w-[150px]">
+                  <GitBranch className="h-3 w-3 shrink-0" />
+                  <span className="truncate">{latestDeployment.branch}</span>
                 </span>
               </>
             )}

--- a/apps/app/src/app/projects/[id]/_components/service-content.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-content.tsx
@@ -70,13 +70,15 @@ export function ServiceContent({
       )}
 
       {deployment && (
-        <div className="flex items-center gap-1 text-xs text-neutral-500 mt-auto">
-          <span>{getTimeAgo(new Date(deployment.createdAt))}</span>
+        <div className="flex items-center gap-1 text-xs text-neutral-500 mt-auto min-w-0">
+          <span className="shrink-0">
+            {getTimeAgo(new Date(deployment.createdAt))}
+          </span>
           {service.deployType === "repo" && (
             <>
-              <span>on</span>
-              <GitBranch className="h-3 w-3" />
-              <span>{service.branch || "main"}</span>
+              <span className="shrink-0">on</span>
+              <GitBranch className="h-3 w-3 shrink-0" />
+              <span className="truncate">{service.branch || "main"}</span>
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Prevents double-line wrapping when branch names are long (e.g., `fix/memory-monitoring-inflated-usage`)
- Adds `shrink-0` to time/icon elements to prevent them from shrinking
- Branch name truncates with ellipsis to fill remaining space

## Test plan
- [ ] View project list with services that have long branch names
- [ ] View service cards with long branch names
- [ ] Confirm single-line display with ellipsis truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)