### PR TITLE
fix: sync Caddy config after stopping previous deployments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Types in `src/lib/db-types.ts` are auto-generated. Never modify manually.
 6. Stop previous deployment
 
 ## Conventions
+- Use static imports (not dynamic `await import`) - we run on VPS only, no edge runtime
 - When planning features, consider if docs need updating
 - New service settings must work across API, UI, and frost.yaml config file
 - Never use non-null assertions (`!`). Handle undefined properly or throw explicit errors.

--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -2,11 +2,23 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const { runMigrations } = await import("./lib/migrate");
     runMigrations();
+    console.log("[startup] migrations: ok");
 
     const { persistUpdateResult } = await import("./lib/updater");
     await persistUpdateResult();
 
     const { startMetricsCollector } = await import("./lib/metrics-collector");
     startMetricsCollector();
+    console.log("[startup] metrics collector: started");
+
+    const { syncCaddyConfig } = await import("./lib/domains");
+    try {
+      const synced = await syncCaddyConfig();
+      console.log(
+        `[startup] caddy sync: ${synced ? "ok" : "skipped (no domains)"}`,
+      );
+    } catch (err) {
+      console.error("[startup] caddy sync: failed", err);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Move `syncCaddyConfig()` to after stopping previous deployments to prevent 502 errors
- Use "stopped" status instead of "failed" for stopped deployments

Fixes #223

## Problem
`syncCaddyConfig()` was called BEFORE stopping previous deployments:
1. New deployment marked "running" on port A
2. Old deployment still marked "running" on port B
3. Caddy config created with routes for BOTH ports
4. Old deployment stopped but Caddy not reloaded
5. Caddy routes to stale port → 502

## Test plan
- [ ] Run typecheck: `bun run typecheck`
- [ ] Run E2E tests
- [ ] Manual test: deploy, redeploy, verify no 502 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)