### PR TITLE
fix: include icon field in project list services

### DIFF
--- a/apps/app/src/contracts/projects.ts
+++ b/apps/app/src/contracts/projects.ts
@@ -17,6 +17,7 @@ const latestDeploymentSchema = z.object({
 const projectListServiceSchema = z.object({
   id: z.string(),
   name: z.string(),
+  icon: z.string().nullable(),
   imageUrl: z.string().nullable(),
   deployType: z.string(),
   status: z.string().nullable(),

--- a/apps/app/src/server/projects.ts
+++ b/apps/app/src/server/projects.ts
@@ -102,6 +102,7 @@ export const projects = {
           services: services.map((s) => ({
             id: s.id,
             name: s.name,
+            icon: s.icon,
             imageUrl: s.imageUrl,
             deployType: s.deployType,
             status: latestDeploymentByService[s.id]?.status ?? null,


### PR DESCRIPTION
## Summary
- Add `icon` field to project list service schema
- Include `icon` in project list API response

Mini canvas was showing fallback letter (e.g., "W") instead of service icon because the `icon` field was missing from the project list API.

## Test plan
- [ ] Deploy a service with a detected icon (e.g., WordPress)
- [ ] Verify icon shows in both main canvas and mini canvas on projects overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)