### PR TITLE
feat: add repo scanner wizard for batch service creation

### DIFF
--- a/apps/app/src/app/projects/[id]/_components/sidebar-settings.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-settings.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { Loader2, Pencil } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EnvVarEditor } from "@/components/env-var-editor";
@@ -12,6 +13,7 @@ import type { EnvVar, Service } from "@/lib/api";
 import { api } from "@/lib/api";
 import { DomainsSection } from "../services/[serviceId]/_components/domains-section";
 import { BuildConfigCard } from "../services/[serviceId]/settings/_components/build-config-card";
+import { ContainerPortCard } from "../services/[serviceId]/settings/_components/container-port-card";
 import { CpuLimitCard } from "../services/[serviceId]/settings/_components/cpu-limit-card";
 import { DangerZoneCard } from "../services/[serviceId]/settings/_components/danger-zone-card";
 import { HealthCheckCard } from "../services/[serviceId]/settings/_components/health-check-card";
@@ -36,16 +38,27 @@ type SettingsTab =
   | "runtime"
   | "danger";
 
-function VariablesTab({ service }: { service: Service }) {
+function parseEnvVars(service: Service): EnvVar[] {
+  const allVars: EnvVar[] = service.envVars ? JSON.parse(service.envVars) : [];
+  return allVars.filter((v) => v.key !== "PORT");
+}
+
+interface VariablesTabProps {
+  service: Service;
+  runtimeSettingsUrl: string;
+}
+
+function VariablesTab({ service, runtimeSettingsUrl }: VariablesTabProps) {
   const updateMutation = useUpdateService(service.id, service.environmentId);
   const deployMutation = useDeployService(service.id, service.environmentId);
 
   const [editing, setEditing] = useState(false);
   const [envVars, setEnvVars] = useState<EnvVar[]>([]);
+  const [hasValidationErrors, setHasValidationErrors] = useState(false);
   const initialEnvVars = useRef<EnvVar[]>([]);
 
   function handleEdit() {
-    const vars = service.envVars ? JSON.parse(service.envVars) : [];
+    const vars = parseEnvVars(service);
     setEnvVars(vars);
     initialEnvVars.current = vars;
     setEditing(true);
@@ -73,7 +86,7 @@ function VariablesTab({ service }: { service: Service }) {
     }
   }
 
-  const vars: EnvVar[] = service.envVars ? JSON.parse(service.envVars) : [];
+  const vars = parseEnvVars(service);
 
   return (
     <Card className="bg-neutral-800 border-neutral-700">
@@ -91,16 +104,24 @@ function VariablesTab({ service }: { service: Service }) {
       <CardContent>
         <p className="mb-4 text-xs text-neutral-500">
           These are specific to this service (in addition to project-level
-          vars).
+          vars). The <code className="text-neutral-400">PORT</code> variable is
+          managed by the Container Port setting in Runtime.
         </p>
         {editing ? (
           <div className="space-y-4">
-            <EnvVarEditor value={envVars} onChange={setEnvVars} />
+            <EnvVarEditor
+              value={envVars}
+              onChange={setEnvVars}
+              onValidationChange={setHasValidationErrors}
+              managedKeySettingsUrl={runtimeSettingsUrl}
+            />
             <div className="flex gap-2">
               <Button
                 size="sm"
                 onClick={handleSave}
-                disabled={updateMutation.isPending || !hasChanges}
+                disabled={
+                  updateMutation.isPending || !hasChanges || hasValidationErrors
+                }
               >
                 {updateMutation.isPending ? (
                   <>
@@ -174,7 +195,30 @@ const NAV_ITEMS: { id: SettingsTab; label: string }[] = [
 ];
 
 export function SidebarSettings({ service, projectId }: SidebarSettingsProps) {
-  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const tabParam = searchParams.get("tab");
+  const activeTab: SettingsTab =
+    tabParam && NAV_ITEMS.some((item) => item.id === tabParam)
+      ? (tabParam as SettingsTab)
+      : "general";
+
+  function buildTabUrl(tab: SettingsTab): string {
+    const params = new URLSearchParams(searchParams.toString());
+    if (tab === "general") {
+      params.delete("tab");
+    } else {
+      params.set("tab", tab);
+    }
+    const query = params.toString();
+    return query ? `${pathname}?${query}` : pathname;
+  }
+
+  function setActiveTab(tab: SettingsTab) {
+    router.push(buildTabUrl(tab), { scroll: false });
+  }
 
   return (
     <div className="flex gap-6">
@@ -216,7 +260,12 @@ export function SidebarSettings({ service, projectId }: SidebarSettingsProps) {
           </>
         )}
 
-        {activeTab === "variables" && <VariablesTab service={service} />}
+        {activeTab === "variables" && (
+          <VariablesTab
+            service={service}
+            runtimeSettingsUrl={buildTabUrl("runtime")}
+          />
+        )}
 
         {activeTab === "domains" && <DomainsTab service={service} />}
 
@@ -224,6 +273,7 @@ export function SidebarSettings({ service, projectId }: SidebarSettingsProps) {
 
         {activeTab === "runtime" && (
           <>
+            <ContainerPortCard serviceId={service.id} />
             <HealthCheckCard serviceId={service.id} />
             <RequestTimeoutCard serviceId={service.id} />
             <ShutdownTimeoutCard serviceId={service.id} />

--- a/apps/app/src/app/projects/[id]/_components/staged-services-list.tsx
+++ b/apps/app/src/app/projects/[id]/_components/staged-services-list.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { File, Loader2, Minus, Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+
+export interface StagedService {
+  id: string;
+  name: string;
+  dockerfilePath: string;
+  buildContext: string;
+  containerPort: number;
+  enabled: boolean;
+}
+
+interface StagedServicesListProps {
+  services: StagedService[];
+  onChange: (services: StagedService[]) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  isLoading?: boolean;
+}
+
+export function StagedServicesList({
+  services,
+  onChange,
+  onCancel,
+  onSubmit,
+  isLoading,
+}: StagedServicesListProps): React.ReactElement {
+  const enabledCount = services.filter((s) => s.enabled).length;
+
+  function updateService(id: string, updates: Partial<StagedService>): void {
+    onChange(services.map((s) => (s.id === id ? { ...s, ...updates } : s)));
+  }
+
+  function toggleAll(enabled: boolean): void {
+    onChange(services.map((s) => ({ ...s, enabled })));
+  }
+
+  const duplicates = new Set(
+    services
+      .filter((s) => s.enabled)
+      .map((s) => s.name)
+      .filter((name, i, arr) => arr.indexOf(name) !== i),
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-neutral-400">
+          {services.length} Dockerfile{services.length !== 1 ? "s" : ""} found
+        </p>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => toggleAll(false)}
+            disabled={enabledCount === 0}
+            className="text-neutral-400 hover:text-neutral-200"
+          >
+            <Minus className="mr-1 h-3 w-3" />
+            None
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => toggleAll(true)}
+            disabled={enabledCount === services.length}
+            className="text-neutral-400 hover:text-neutral-200"
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            All
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {services.map((service) => {
+          const isDuplicate = service.enabled && duplicates.has(service.name);
+          return (
+            <div
+              key={service.id}
+              className={`rounded-lg border p-3 transition-colors ${
+                service.enabled
+                  ? "border-neutral-700 bg-neutral-800"
+                  : "border-neutral-800 bg-neutral-900 opacity-60"
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <Switch
+                  checked={service.enabled}
+                  onCheckedChange={(enabled) =>
+                    updateService(service.id, { enabled })
+                  }
+                  className="mt-1"
+                />
+
+                <div className="flex-1 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={service.name}
+                      onChange={(e) =>
+                        updateService(service.id, { name: e.target.value })
+                      }
+                      disabled={!service.enabled}
+                      className={`h-8 border-neutral-700 bg-neutral-900 text-sm ${
+                        isDuplicate ? "border-red-500" : ""
+                      }`}
+                      placeholder="Service name"
+                    />
+                    <Input
+                      type="number"
+                      value={service.containerPort}
+                      onChange={(e) =>
+                        updateService(service.id, {
+                          containerPort: parseInt(e.target.value, 10) || 8080,
+                        })
+                      }
+                      disabled={!service.enabled}
+                      className="h-8 w-20 border-neutral-700 bg-neutral-900 text-sm"
+                      placeholder="Port"
+                    />
+                  </div>
+
+                  <div className="flex items-center gap-1.5 text-xs text-neutral-500">
+                    <File className="h-3 w-3" />
+                    <span className="font-mono">{service.dockerfilePath}</span>
+                  </div>
+
+                  {isDuplicate && (
+                    <p className="text-xs text-red-400">
+                      Duplicate name - will be auto-suffixed
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex gap-2 pt-2">
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          className="flex-1 border-neutral-700 bg-transparent text-neutral-300 hover:bg-neutral-800 hover:text-neutral-100"
+        >
+          <X className="mr-1.5 h-4 w-4" />
+          Cancel
+        </Button>
+        <Button
+          onClick={onSubmit}
+          disabled={enabledCount === 0 || isLoading}
+          className="flex-1"
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              Creating...
+            </>
+          ) : (
+            `Create ${enabledCount} Service${enabledCount !== 1 ? "s" : ""}`
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/container-port-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/container-port-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { SettingCard } from "@/components/setting-card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  useDeployService,
+  useService,
+  useUpdateService,
+} from "@/hooks/use-services";
+import type { EnvVar } from "@/lib/api";
+
+interface ContainerPortCardProps {
+  serviceId: string;
+}
+
+export function ContainerPortCard({ serviceId }: ContainerPortCardProps) {
+  const { data: service } = useService(serviceId);
+  const envId = service?.environmentId ?? "";
+  const updateMutation = useUpdateService(serviceId, envId);
+  const deployMutation = useDeployService(serviceId, envId);
+
+  const [port, setPort] = useState("");
+  const initialPort = useRef("");
+
+  useEffect(() => {
+    if (service) {
+      const p = service.containerPort?.toString() ?? "8080";
+      setPort(p);
+      initialPort.current = p;
+    }
+  }, [service]);
+
+  const hasChanges = port !== initialPort.current;
+
+  async function handleSave() {
+    const portNum = parseInt(port, 10);
+    if (Number.isNaN(portNum) || portNum < 1 || portNum > 65535) {
+      toast.error("Port must be between 1 and 65535");
+      return;
+    }
+
+    const currentEnvVars: EnvVar[] = service?.envVars
+      ? JSON.parse(service.envVars)
+      : [];
+    const envVarsWithoutPort = currentEnvVars.filter((v) => v.key !== "PORT");
+    const newEnvVars = [...envVarsWithoutPort, { key: "PORT", value: port }];
+
+    try {
+      await updateMutation.mutateAsync({
+        containerPort: portNum,
+        envVars: newEnvVars,
+      });
+      initialPort.current = port;
+      toast.success("Container port saved", {
+        description: "Redeploy required for changes to take effect",
+        duration: 10000,
+        action: {
+          label: "Redeploy",
+          onClick: () => deployMutation.mutateAsync(),
+        },
+      });
+    } catch {
+      toast.error("Failed to save");
+    }
+  }
+
+  if (!service) return null;
+
+  return (
+    <SettingCard
+      title="Container Port"
+      description="The port your application listens on inside the container."
+      footerLeft={
+        <span className="text-xs text-neutral-500">
+          Also sets the PORT env var so your app knows which port to bind to.
+        </span>
+      }
+      footerRight={
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={updateMutation.isPending || !hasChanges}
+        >
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            "Save"
+          )}
+        </Button>
+      }
+    >
+      <Input
+        type="number"
+        value={port}
+        onChange={(e) => setPort(e.target.value)}
+        placeholder="8080"
+        className="w-32 font-mono"
+        min={1}
+        max={65535}
+      />
+    </SettingCard>
+  );
+}

--- a/apps/app/src/contracts/github.ts
+++ b/apps/app/src/contracts/github.ts
@@ -20,6 +20,13 @@ const repoSchema = z.object({
   }),
 });
 
+const dockerfileInfoSchema = z.object({
+  path: z.string(),
+  suggestedName: z.string(),
+  buildContext: z.string(),
+  detectedPort: z.number().nullable(),
+});
+
 export const githubContract = {
   repos: oc
     .route({ method: "GET", path: "/github/repos" })
@@ -28,6 +35,21 @@ export const githubContract = {
       z.object({
         owners: z.array(ownerSchema),
         repos: z.array(repoSchema),
+      }),
+    ),
+
+  scan: oc
+    .route({ method: "POST", path: "/github/scan" })
+    .input(
+      z.object({
+        repoUrl: z.string(),
+        branch: z.string(),
+        repoName: z.string(),
+      }),
+    )
+    .output(
+      z.object({
+        dockerfiles: z.array(dockerfileInfoSchema),
       }),
     ),
 };

--- a/apps/app/src/contracts/services.ts
+++ b/apps/app/src/contracts/services.ts
@@ -111,4 +111,36 @@ export const servicesContract = {
     .route({ method: "GET", path: "/services/{id}/volumes" })
     .input(z.object({ id: z.string() }))
     .output(z.array(volumeInfoSchema)),
+
+  createBatch: oc
+    .route({
+      method: "POST",
+      path: "/environments/{environmentId}/services/batch",
+    })
+    .input(
+      z.object({
+        environmentId: z.string(),
+        repoUrl: z.string(),
+        branch: z.string(),
+        services: z.array(
+          z.object({
+            name: z.string().min(1),
+            dockerfilePath: z.string(),
+            buildContext: z.string(),
+            containerPort: z.number().min(1).max(65535).optional(),
+          }),
+        ),
+      }),
+    )
+    .output(
+      z.object({
+        created: z.array(servicesSchema),
+        errors: z.array(
+          z.object({
+            name: z.string(),
+            error: z.string(),
+          }),
+        ),
+      }),
+    ),
 };

--- a/apps/app/src/lib/service-logo.ts
+++ b/apps/app/src/lib/service-logo.ts
@@ -25,7 +25,7 @@ const KEYWORD_ICONS: Array<{ keywords: string[]; icon: string }> = [
   { keywords: ["n8n"], icon: "n8n" },
   { keywords: ["hasura"], icon: "hasura" },
   { keywords: ["umami"], icon: "umami" },
-  { keywords: ["plausible"], icon: "plausible" },
+  { keywords: ["plausible"], icon: "plausibleanalytics" },
   { keywords: ["clickhouse"], icon: "clickhouse" },
 ];
 

--- a/apps/app/test/fixtures/monorepo/apps/web/Dockerfile
+++ b/apps/app/test/fixtures/monorepo/apps/web/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY apps/app/test/fixtures/monorepo/package.json /root-package.json
+COPY apps/app/test/fixtures/monorepo/apps/web/package.json .
+COPY apps/app/test/fixtures/monorepo/apps/web/index.js .
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/apps/app/test/fixtures/monorepo/apps/web/index.js
+++ b/apps/app/test/fixtures/monorepo/apps/web/index.js
@@ -1,0 +1,12 @@
+const http = require("node:http");
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("Hello from web!");
+});
+
+server.listen(port, () => {
+  console.log(`Web server running on port ${port}`);
+});

--- a/apps/app/test/fixtures/monorepo/apps/web/package.json
+++ b/apps/app/test/fixtures/monorepo/apps/web/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "main": "index.js"
+}


### PR DESCRIPTION
## Summary

- Auto-scan repos for Dockerfiles when user selects a repo in create service modal
- Show staged services UI (Railway-style) for reviewing/editing before batch creation
- Detect ports from Dockerfiles (EXPOSE/ENV PORT directives)
- Add batch create endpoint that handles partial failures gracefully
- Add Container Port setting card with Cloud Run-style PORT env var management
- PORT is now a reserved env var managed by Container Port setting
- Settings tabs use URL state (?tab=runtime) for shareable/bookmarkable URLs

## Test plan

- [ ] Select a repo with multiple Dockerfiles → see staged services list
- [ ] Edit service names/ports inline → verify changes persist
- [ ] Toggle services on/off → verify only enabled services are created
- [ ] Test batch create with mock data (monorepo-example)
- [ ] Try adding PORT env var → see validation error with link to Container Port setting
- [ ] Change Container Port → verify PORT env var is synced
- [ ] Verify settings tab URLs are shareable (?tab=runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)