### PR TITLE
fix: update PR comment after deployment completes

### DIFF
--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -807,8 +807,8 @@ async function runServiceDeployment(
 
     try {
       await updateEnvironmentPRComment(environment.id, service.repoUrl);
-    } catch (prErr) {
-      console.warn("Failed to update PR comment:", prErr);
+    } catch (err) {
+      console.warn("Failed to update PR comment:", err);
     }
   }
 }

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -38,6 +38,7 @@ import { slugify } from "./slugify";
 import { generateSelfSignedCert, getSSLPaths, sslCertsExist } from "./ssl";
 import type { EnvVar } from "./types";
 import { buildVolumeName, createVolume } from "./volumes";
+import { updateEnvironmentPRComment } from "./webhook";
 
 const execAsync = promisify(exec);
 
@@ -750,6 +751,12 @@ async function runServiceDeployment(
       deploymentId,
     );
 
+    try {
+      await updateEnvironmentPRComment(environment.id, service.repoUrl);
+    } catch (err) {
+      console.warn("Failed to update PR comment:", err);
+    }
+
     await updateRollbackEligible(service.id);
 
     const previousDeployments = await db
@@ -797,6 +804,12 @@ async function runServiceDeployment(
       "Deployment failed",
       deploymentId,
     );
+
+    try {
+      await updateEnvironmentPRComment(environment.id, service.repoUrl);
+    } catch (prErr) {
+      console.warn("Failed to update PR comment:", prErr);
+    }
   }
 }
 

--- a/apps/app/src/lib/webhook.ts
+++ b/apps/app/src/lib/webhook.ts
@@ -2,7 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { nanoid } from "nanoid";
 import { db } from "./db";
 import { removeNetwork, stopContainer } from "./docker";
-import { normalizeGitHubUrl } from "./github";
+import { normalizeGitHubUrl, updatePRComment } from "./github";
 import { createService } from "./services";
 import { slugify } from "./slugify";
 
@@ -372,4 +372,38 @@ export async function getEnvironmentServiceStatuses(
   }
 
   return statuses;
+}
+
+export async function updateEnvironmentPRComment(
+  environmentId: string,
+  repoUrl: string | null,
+): Promise<void> {
+  if (!repoUrl) return;
+
+  const env = await db
+    .selectFrom("environments")
+    .select(["prCommentId", "prBranch", "projectId"])
+    .where("id", "=", environmentId)
+    .executeTakeFirst();
+
+  if (!env?.prCommentId || !env.prBranch) return;
+
+  const latestDeployment = await db
+    .selectFrom("deployments")
+    .select("commitSha")
+    .where("environmentId", "=", environmentId)
+    .orderBy("createdAt", "desc")
+    .executeTakeFirst();
+
+  const statuses = await getEnvironmentServiceStatuses(
+    environmentId,
+    env.projectId,
+  );
+  const body = buildPRCommentBody(
+    statuses,
+    env.prBranch,
+    latestDeployment?.commitSha ?? "HEAD",
+  );
+
+  await updatePRComment(repoUrl, env.prCommentId, body);
 }

--- a/apps/app/src/lib/webhook.ts
+++ b/apps/app/src/lib/webhook.ts
@@ -388,17 +388,16 @@ export async function updateEnvironmentPRComment(
 
   if (!env?.prCommentId || !env.prBranch) return;
 
-  const latestDeployment = await db
-    .selectFrom("deployments")
-    .select("commitSha")
-    .where("environmentId", "=", environmentId)
-    .orderBy("createdAt", "desc")
-    .executeTakeFirst();
+  const [latestDeployment, statuses] = await Promise.all([
+    db
+      .selectFrom("deployments")
+      .select("commitSha")
+      .where("environmentId", "=", environmentId)
+      .orderBy("createdAt", "desc")
+      .executeTakeFirst(),
+    getEnvironmentServiceStatuses(environmentId, env.projectId),
+  ]);
 
-  const statuses = await getEnvironmentServiceStatuses(
-    environmentId,
-    env.projectId,
-  );
   const body = buildPRCommentBody(
     statuses,
     env.prBranch,


### PR DESCRIPTION
## Summary
- PR comment now updates to ✅ running or ❌ failed when deployment finishes
- Previously only updated on new pushes or PR close

## Test plan
- [ ] Create a PR on a repo connected to Frost
- [ ] Verify initial comment shows "🔄 deploying"
- [ ] Wait for deployment to complete
- [ ] Verify comment updates to "✅ running" with URL or "❌ failed"
- [ ] Test failure case by deploying a broken Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)