### PR TITLE
fix: use correct URLs in PR comments and GitHub checks

### DIFF
--- a/apps/app/public/static/status/building.svg
+++ b/apps/app/public/static/status/building.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="20" viewBox="0 0 64 20">
+  <rect width="64" height="20" rx="10" fill="#f59e0b"/>
+  <text x="32" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="11" font-weight="500" fill="white" text-anchor="middle">Building</text>
+</svg>

--- a/apps/app/public/static/status/failed.svg
+++ b/apps/app/public/static/status/failed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20" viewBox="0 0 50 20">
+  <rect width="50" height="20" rx="10" fill="#ef4444"/>
+  <text x="25" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="11" font-weight="500" fill="white" text-anchor="middle">Failed</text>
+</svg>

--- a/apps/app/public/static/status/ready.svg
+++ b/apps/app/public/static/status/ready.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="52" height="20" viewBox="0 0 52 20">
+  <rect width="52" height="20" rx="10" fill="#10b981"/>
+  <text x="26" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="11" font-weight="500" fill="white" text-anchor="middle">Ready</text>
+</svg>

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import type { Selectable } from "kysely";
 import { nanoid } from "nanoid";
+import { getSetting } from "./auth";
 import { decrypt } from "./crypto";
 import { db } from "./db";
 import type { Environments, Projects, Registries, Services } from "./db-types";
@@ -220,12 +221,17 @@ async function updateCommitStatusIfGitHub(
   if (commitSha === "HEAD" || commitSha.length < 7) return;
 
   try {
+    const frostDomain = await getSetting("domain");
+    const targetUrl = frostDomain
+      ? `https://${frostDomain}/deployments/${deploymentId}`
+      : undefined;
+
     await createCommitStatus({
       repoUrl,
       commitSha,
       state,
       description,
-      targetUrl: `/deployments/${deploymentId}`,
+      targetUrl,
     });
   } catch (err) {
     console.warn("Failed to update commit status:", err);


### PR DESCRIPTION
## Summary
- PR comment preview URLs now use actual domains from domains table via `getPreferredDomain()`
- GitHub check "Details" links use absolute URLs (`https://{frostDomain}/deployments/{id}`) instead of broken relative paths
- Updated PR comment format to Vercel-style table with status badges and service links

## Test plan
- [ ] Create PR on connected repo
- [ ] Verify GitHub PR shows "Frost" check with clickable link to deployment page
- [ ] Verify PR comment has working preview URLs pointing to actual domains

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)