### PR TITLE
feat: add Clawdbot template

### DIFF
--- a/apps/app/templates/services/clawdbot.yaml
+++ b/apps/app/templates/services/clawdbot.yaml
@@ -1,0 +1,21 @@
+name: Clawdbot
+description: Personal AI assistant with multi-channel support
+category: ai
+docs: https://docs.clawd.bot/
+
+services:
+  clawdbot:
+    image: clawdbot/clawdbot:v2026.1.23
+    port: 18789
+    icon: clawdbot
+    command: node dist/index.js gateway --bind 0.0.0.0 --port 18789
+    environment:
+      HOME: /home/node
+      TERM: xterm-256color
+      CLAWDBOT_GATEWAY_TOKEN:
+        generated: password
+    volumes:
+      - config:/home/node/.clawdbot
+      - workspace:/home/node/clawd
+    health_check:
+      timeout: 60


### PR DESCRIPTION
## Summary
- Add Clawdbot one-click template (personal AI assistant)
- Multi-channel support: Telegram, Slack, Discord, WhatsApp web, etc.

## Test plan
- [ ] Deploy template on test VPS
- [ ] Verify gateway starts and is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)