### PR TITLE
feat: add docker build cache cleanup and real scheduler

### DIFF
--- a/apps/app/src/app/settings/cleanup/_components/run-cleanup-card.tsx
+++ b/apps/app/src/app/settings/cleanup/_components/run-cleanup-card.tsx
@@ -74,6 +74,13 @@ export function RunCleanupCard({
                 {settings.lastResult.deletedImages.length} images •{" "}
                 {settings.lastResult.prunedContainers} containers •{" "}
                 {settings.lastResult.deletedNetworks.length} networks
+                {settings.lastResult.prunedBuildCacheBytes > 0 && (
+                  <>
+                    {" "}
+                    • {formatBytes(settings.lastResult.prunedBuildCacheBytes)}{" "}
+                    build cache
+                  </>
+                )}
               </p>
               {settings.lastResult.errors.length > 0 && (
                 <p className="mt-1 text-red-400">

--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -11,6 +11,10 @@ export async function register() {
     startMetricsCollector();
     console.log("[startup] metrics collector: started");
 
+    const { startCleanupScheduler } = await import("./lib/cleanup-scheduler");
+    startCleanupScheduler();
+    console.log("[startup] cleanup scheduler: started");
+
     const { syncCaddyConfig } = await import("./lib/domains");
     try {
       const synced = await syncCaddyConfig();

--- a/apps/app/src/lib/cleanup-scheduler.ts
+++ b/apps/app/src/lib/cleanup-scheduler.ts
@@ -1,0 +1,40 @@
+import { getCleanupSettings, startCleanupJob } from "./cleanup";
+
+const CHECK_INTERVAL_MS = 60 * 1000;
+const CLEANUP_HOUR = 3;
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let lastCleanupDate: string | null = null;
+
+async function checkAndRun(): Promise<void> {
+  try {
+    const settings = await getCleanupSettings();
+    if (!settings.enabled) return;
+
+    const now = new Date();
+    const today = now.toISOString().split("T")[0];
+
+    if (now.getHours() === CLEANUP_HOUR && lastCleanupDate !== today) {
+      lastCleanupDate = today;
+      await startCleanupJob();
+      console.log("[cleanup-scheduler] Started daily cleanup");
+    }
+  } catch (err) {
+    console.error("[cleanup-scheduler] Error:", err);
+  }
+}
+
+export function startCleanupScheduler(): void {
+  if (intervalId) return;
+  intervalId = setInterval(checkAndRun, CHECK_INTERVAL_MS);
+  console.log(
+    "[cleanup-scheduler] Started (checks every minute, runs at 3 AM)",
+  );
+}
+
+export function stopCleanupScheduler(): void {
+  if (!intervalId) return;
+  clearInterval(intervalId);
+  intervalId = null;
+  console.log("[cleanup-scheduler] Stopped");
+}


### PR DESCRIPTION
## Summary
- Add `docker builder prune -f --keep-storage 10GB` to cleanup job (keeps 10GB for fast builds)
- Add real server-side scheduler that runs cleanup daily at 3 AM
- Show build cache bytes freed in cleanup result UI

Closes #241

## Test plan
- [ ] Run `bun run dev` and go to Settings > Cleanup
- [ ] Run manual cleanup and verify build cache bytes shown in result
- [ ] Verify scheduler starts on server startup (check console logs)
- [ ] Run `docker system df` before/after cleanup to confirm cache cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)