### PR TITLE
feat: add frost.yaml config file support

### DIFF
--- a/apps/app/frost.schema.json
+++ b/apps/app/frost.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Frost Configuration",
+  "description": "Configuration file for Frost service deployments",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "dockerfile": {
+      "type": "string",
+      "description": "Path to Dockerfile (relative to repo root)"
+    },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "Container port the app listens on"
+    },
+    "health_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Health check configuration",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "HTTP health check endpoint (e.g., /health)"
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300,
+          "description": "Startup timeout in seconds"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Resource limits",
+      "properties": {
+        "memory": {
+          "type": "string",
+          "pattern": "^\\d+[kmgKMG]$",
+          "description": "Memory limit (e.g., 256m, 1g)"
+        },
+        "cpu": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 64,
+          "description": "CPU limit (e.g., 0.5, 2)"
+        }
+      }
+    }
+  }
+}

--- a/apps/app/schema/005-frost-file-path.sql
+++ b/apps/app/schema/005-frost-file-path.sql
@@ -1,0 +1,1 @@
+ALTER TABLE services ADD COLUMN frost_file_path TEXT DEFAULT 'frost.yaml';

--- a/apps/app/src/app/docs/_components/docs-nav.tsx
+++ b/apps/app/src/app/docs/_components/docs-nav.tsx
@@ -37,6 +37,7 @@ const navigation: NavSection[] = [
     items: [
       { title: "Environment Variables", href: "/docs/guides/env-vars" },
       { title: "Custom Domains", href: "/docs/guides/custom-domains" },
+      { title: "Config File", href: "/docs/guides/config-file" },
     ],
   },
   {

--- a/apps/app/src/app/docs/guides/config-file/page.mdx
+++ b/apps/app/src/app/docs/guides/config-file/page.mdx
@@ -1,0 +1,49 @@
+# Config File (frost.yaml)
+
+Configure service builds and deployments with a `frost.yaml` file in your repo.
+
+## Location
+
+Set **Config File Path** in service settings (defaults to `frost.yaml` at repo root).
+
+For monorepos, point to your service's config:
+
+- Service A: `services/api/frost.yaml`
+- Service B: `services/web/frost.yaml`
+
+## Format
+
+```yaml
+# frost.yaml
+dockerfile: Dockerfile
+port: 3000
+health_check:
+  path: /health
+  timeout: 30
+resources:
+  memory: 512m
+  cpu: 0.5
+```
+
+## Fields
+
+| Field | Description |
+|-------|-------------|
+| `dockerfile` | Path to Dockerfile (relative to repo root) |
+| `port` | Container port the app listens on |
+| `health_check.path` | HTTP health check endpoint |
+| `health_check.timeout` | Startup timeout in seconds |
+| `resources.memory` | Memory limit (e.g., `256m`, `1g`) |
+| `resources.cpu` | CPU limit (e.g., `0.5`, `2`) |
+
+## Override Behavior
+
+Config file overrides UI settings at deploy time. UI settings remain unchanged.
+
+## IDE Support
+
+Add schema for autocomplete:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/elitan/frost/main/apps/app/frost.schema.json
+```

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/build-config-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/build-config-card.tsx
@@ -16,46 +16,64 @@ interface BuildConfigCardProps {
   serviceId: string;
 }
 
+interface FormValues {
+  branch: string;
+  dockerfilePath: string;
+  buildContext: string;
+  frostFilePath: string;
+}
+
+const DEFAULT_VALUES: FormValues = {
+  branch: "",
+  dockerfilePath: "",
+  buildContext: "",
+  frostFilePath: "",
+};
+
 export function BuildConfigCard({ serviceId }: BuildConfigCardProps) {
   const { data: service } = useService(serviceId);
   const envId = service?.environmentId ?? "";
   const updateMutation = useUpdateService(serviceId, envId);
   const deployMutation = useDeployService(serviceId, envId);
 
-  const [branch, setBranch] = useState("");
-  const [dockerfilePath, setDockerfilePath] = useState("");
-  const [buildContext, setBuildContext] = useState("");
-  const initialValues = useRef({
-    branch: "",
-    dockerfilePath: "",
-    buildContext: "",
-  });
+  const [values, setValues] = useState<FormValues>(DEFAULT_VALUES);
+  const initialValues = useRef<FormValues>(DEFAULT_VALUES);
 
   useEffect(() => {
     if (service) {
-      const b = service.branch ?? "main";
-      const d = service.dockerfilePath ?? "Dockerfile";
-      const c = service.buildContext ?? "";
-      setBranch(b);
-      setDockerfilePath(d);
-      setBuildContext(c);
-      initialValues.current = { branch: b, dockerfilePath: d, buildContext: c };
+      const newValues: FormValues = {
+        branch: service.branch ?? "main",
+        dockerfilePath: service.dockerfilePath ?? "Dockerfile",
+        buildContext: service.buildContext ?? "",
+        frostFilePath: service.frostFilePath ?? "",
+      };
+      setValues(newValues);
+      initialValues.current = newValues;
     }
   }, [service]);
 
   const hasChanges =
-    branch !== initialValues.current.branch ||
-    dockerfilePath !== initialValues.current.dockerfilePath ||
-    buildContext !== initialValues.current.buildContext;
+    values.branch !== initialValues.current.branch ||
+    values.dockerfilePath !== initialValues.current.dockerfilePath ||
+    values.buildContext !== initialValues.current.buildContext ||
+    values.frostFilePath !== initialValues.current.frostFilePath;
 
-  async function handleSave() {
+  function updateField<K extends keyof FormValues>(
+    field: K,
+    value: FormValues[K],
+  ): void {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSave(): Promise<void> {
     try {
       await updateMutation.mutateAsync({
-        branch: branch.trim() || "main",
-        dockerfilePath: dockerfilePath.trim() || "Dockerfile",
-        buildContext: buildContext.trim() || null,
+        branch: values.branch.trim() || "main",
+        dockerfilePath: values.dockerfilePath.trim() || "Dockerfile",
+        buildContext: values.buildContext.trim() || null,
+        frostFilePath: values.frostFilePath.trim() || null,
       });
-      initialValues.current = { branch, dockerfilePath, buildContext };
+      initialValues.current = values;
       toast.success("Build configuration saved", {
         description: "Redeploy required for changes to take effect",
         duration: 10000,
@@ -93,8 +111,8 @@ export function BuildConfigCard({ serviceId }: BuildConfigCardProps) {
         <div>
           <span className="mb-2 block text-sm text-neutral-400">Branch</span>
           <Input
-            value={branch}
-            onChange={(e) => setBranch(e.target.value)}
+            value={values.branch}
+            onChange={(e) => updateField("branch", e.target.value)}
             placeholder="main"
             className="max-w-sm font-mono"
           />
@@ -104,8 +122,8 @@ export function BuildConfigCard({ serviceId }: BuildConfigCardProps) {
             Dockerfile Path
           </span>
           <Input
-            value={dockerfilePath}
-            onChange={(e) => setDockerfilePath(e.target.value)}
+            value={values.dockerfilePath}
+            onChange={(e) => updateField("dockerfilePath", e.target.value)}
             placeholder="Dockerfile"
             className="max-w-sm font-mono"
           />
@@ -115,13 +133,28 @@ export function BuildConfigCard({ serviceId }: BuildConfigCardProps) {
             Build Context
           </span>
           <Input
-            value={buildContext}
-            onChange={(e) => setBuildContext(e.target.value)}
+            value={values.buildContext}
+            onChange={(e) => updateField("buildContext", e.target.value)}
             placeholder=". (repo root)"
             className="max-w-sm font-mono"
           />
           <p className="mt-1 text-xs text-neutral-500">
             Leave empty for repo root.
+          </p>
+        </div>
+        <div>
+          <span className="mb-2 block text-sm text-neutral-400">
+            Config File Path
+          </span>
+          <Input
+            value={values.frostFilePath}
+            onChange={(e) => updateField("frostFilePath", e.target.value)}
+            placeholder="frost.yaml"
+            className="max-w-sm font-mono"
+          />
+          <p className="mt-1 text-xs text-neutral-500">
+            Override settings at deploy time. Leave empty for frost.yaml at repo
+            root.
           </p>
         </div>
       </div>

--- a/apps/app/src/contracts/services.ts
+++ b/apps/app/src/contracts/services.ts
@@ -53,6 +53,7 @@ export const servicesContract = {
         cpuLimit: z.number().min(0.1).max(64).optional(),
         shutdownTimeout: z.number().min(1).max(300).optional(),
         registryId: z.string().optional(),
+        frostFilePath: z.string().optional(),
       }),
     )
     .output(servicesSchema),
@@ -88,6 +89,7 @@ export const servicesContract = {
         volumes: z.array(volumeConfigSchema).optional(),
         registryId: z.string().nullable().optional(),
         command: z.string().nullable().optional(),
+        frostFilePath: z.string().nullable().optional(),
       }),
     )
     .output(servicesSchema),

--- a/apps/app/src/lib/db-schemas.ts
+++ b/apps/app/src/lib/db-schemas.ts
@@ -433,6 +433,7 @@ export const servicesSchema = z.object({
   icon: z.string().nullable(),
   hostname: z.string().nullable(),
   currentDeploymentId: z.string().nullable(),
+  frostFilePath: z.string().nullable(),
   createdAt: z.number(),
 });
 
@@ -463,6 +464,7 @@ export const newServicesSchema = z.object({
   icon: z.string().nullable(),
   hostname: z.string().nullable(),
   currentDeploymentId: z.string().nullable(),
+  frostFilePath: z.string().nullable().optional(),
   createdAt: z.number(),
 });
 
@@ -493,6 +495,7 @@ export const servicesUpdateSchema = z.object({
   icon: z.string().nullable().optional(),
   hostname: z.string().nullable().optional(),
   currentDeploymentId: z.string().nullable().optional(),
+  frostFilePath: z.string().nullable().optional(),
   createdAt: z.number().optional(),
 });
 

--- a/apps/app/src/lib/db-types.ts
+++ b/apps/app/src/lib/db-types.ts
@@ -81,9 +81,9 @@ export interface Environments {
   'type': Generated<'production' | 'preview' | 'manual'>;
   prNumber: number | null;
   prBranch: string | null;
-  prCommentId: number | null;
   isEphemeral: Generated<boolean | null>;
   createdAt: number;
+  prCommentId: number | null;
 }
 
 export interface GithubInstallations {
@@ -153,9 +153,10 @@ export interface Services {
   shutdownTimeout: number | null;
   requestTimeout: number | null;
   command: string | null;
-  icon: string | null;
   currentDeploymentId: string | null;
   createdAt: number;
+  icon: string | null;
+  frostFilePath: Generated<string | null>;
 }
 
 export interface Settings {

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -26,6 +26,7 @@ import {
   waitForHealthy,
 } from "./docker";
 import { syncCaddyConfig } from "./domains";
+import { loadFrostConfig, mergeConfigWithService } from "./frost-config";
 import {
   createCommitStatus,
   generateInstallationToken,
@@ -389,6 +390,7 @@ async function runServiceDeployment(
 
   try {
     let imageName: string;
+    let effectiveService = service;
 
     if (service.deployType === "image") {
       if (!service.imageUrl) {
@@ -487,9 +489,26 @@ async function runServiceDeployment(
       );
       await appendLog(deploymentId, cloneResult || "Cloned successfully\n");
 
+      const frostConfigResult = loadFrostConfig(
+        repoPath,
+        service.frostFilePath ?? "frost.yaml",
+      );
+
+      if (frostConfigResult.error) {
+        throw new Error(`frost.yaml: ${frostConfigResult.error}`);
+      }
+
+      if (frostConfigResult.config) {
+        await appendLog(deploymentId, `Using ${frostConfigResult.filename}\n`);
+        effectiveService = mergeConfigWithService(
+          service,
+          frostConfigResult.config,
+        );
+      }
+
       const detectedIcon = detectIcon(
         repoPath,
-        service.dockerfilePath ?? undefined,
+        effectiveService.dockerfilePath ?? undefined,
       );
       if (detectedIcon && !service.icon) {
         await db
@@ -541,7 +560,7 @@ async function runServiceDeployment(
       const buildResult = await buildImage({
         repoPath,
         imageName,
-        dockerfilePath: service.dockerfilePath,
+        dockerfilePath: effectiveService.dockerfilePath ?? undefined,
         buildContext: service.buildContext ?? undefined,
         envVars,
         labels: baseLabels,
@@ -634,9 +653,9 @@ async function runServiceDeployment(
       .updateTable("deployments")
       .set({
         envVarsSnapshot: JSON.stringify(envVarsList),
-        containerPort: service.containerPort,
-        healthCheckPath: service.healthCheckPath,
-        healthCheckTimeout: service.healthCheckTimeout,
+        containerPort: effectiveService.containerPort,
+        healthCheckPath: effectiveService.healthCheckPath,
+        healthCheckTimeout: effectiveService.healthCheckTimeout,
         volumes: service.volumes,
       })
       .where("id", "=", deploymentId)
@@ -668,7 +687,7 @@ async function runServiceDeployment(
     const { containerId, hostPort } = await runContainerWithPortRetry(
       {
         imageName,
-        containerPort: service.containerPort ?? undefined,
+        containerPort: effectiveService.containerPort ?? undefined,
         name: containerName,
         envVars: runtimeEnvVars,
         network: networkName,
@@ -681,8 +700,8 @@ async function runServiceDeployment(
         volumes,
         fileMounts,
         command,
-        memoryLimit: service.memoryLimit ?? undefined,
-        cpuLimit: service.cpuLimit ?? undefined,
+        memoryLimit: effectiveService.memoryLimit ?? undefined,
+        cpuLimit: effectiveService.cpuLimit ?? undefined,
         shutdownTimeout: service.shutdownTimeout ?? undefined,
       },
       async (port, attempt) => {
@@ -697,8 +716,8 @@ async function runServiceDeployment(
       deploymentId,
       `Container started: ${containerId.substring(0, 12)}\n`,
     );
-    const healthCheckType = service.healthCheckPath
-      ? `HTTP ${service.healthCheckPath}`
+    const healthCheckType = effectiveService.healthCheckPath
+      ? `HTTP ${effectiveService.healthCheckPath}`
       : "TCP";
     await appendLog(
       deploymentId,
@@ -708,8 +727,8 @@ async function runServiceDeployment(
     const isHealthy = await waitForHealthy({
       containerId,
       port: hostPort,
-      path: service.healthCheckPath,
-      timeoutSeconds: service.healthCheckTimeout ?? 60,
+      path: effectiveService.healthCheckPath,
+      timeoutSeconds: effectiveService.healthCheckTimeout ?? 60,
     });
     if (!isHealthy) {
       const containerStatus = await getContainerStatus(containerId);

--- a/apps/app/src/lib/frost-config.ts
+++ b/apps/app/src/lib/frost-config.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Selectable } from "kysely";
+import { parse } from "yaml";
+import { z } from "zod";
+import type { Services } from "./db-types";
+
+export const frostConfigSchema = z
+  .object({
+    dockerfile: z.string().optional(),
+    port: z.number().min(1).max(65535).optional(),
+    health_check: z
+      .object({
+        path: z.string().optional(),
+        timeout: z.number().min(1).max(300).optional(),
+      })
+      .optional(),
+    resources: z
+      .object({
+        memory: z
+          .string()
+          .regex(/^\d+[kmg]$/i)
+          .optional(),
+        cpu: z.number().min(0.1).max(64).optional(),
+      })
+      .optional(),
+  })
+  .strict();
+
+export type FrostConfig = z.infer<typeof frostConfigSchema>;
+
+export type FrostConfigResult =
+  | {
+      found: false;
+      error?: undefined;
+      config?: undefined;
+      filename?: undefined;
+    }
+  | { found: true; error: string; config?: undefined; filename?: undefined }
+  | { found: true; error?: undefined; config: FrostConfig; filename: string };
+
+export function loadFrostConfig(
+  repoPath: string,
+  frostFilePath: string,
+): FrostConfigResult {
+  const basePath = frostFilePath.replace(/\.(yaml|yml)$/, "");
+  const yamlPath = join(repoPath, `${basePath}.yaml`);
+  const ymlPath = join(repoPath, `${basePath}.yml`);
+
+  const yamlExists = existsSync(yamlPath);
+  const ymlExists = existsSync(ymlPath);
+
+  if (yamlExists && ymlExists) {
+    return {
+      found: true,
+      error: `Both ${basePath}.yaml and ${basePath}.yml exist. Remove one.`,
+    };
+  }
+
+  if (!yamlExists && !ymlExists) {
+    return { found: false };
+  }
+
+  const filePath = yamlExists ? yamlPath : ymlPath;
+  const filename = yamlExists ? `${basePath}.yaml` : `${basePath}.yml`;
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (err: any) {
+    return { found: true, error: `Failed to read config: ${err.message}` };
+  }
+
+  if (!content.trim()) {
+    return { found: false };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parse(content);
+  } catch (err: any) {
+    return { found: true, error: `Invalid YAML: ${err.message}` };
+  }
+
+  if (parsed === null || parsed === undefined) {
+    return { found: false };
+  }
+
+  const result = frostConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    return { found: true, error: issues };
+  }
+
+  return { found: true, config: result.data, filename };
+}
+
+type EffectiveService = Pick<
+  Selectable<Services>,
+  | "dockerfilePath"
+  | "containerPort"
+  | "healthCheckPath"
+  | "healthCheckTimeout"
+  | "memoryLimit"
+  | "cpuLimit"
+>;
+
+export function mergeConfigWithService<T extends EffectiveService>(
+  service: T,
+  config: FrostConfig,
+): T {
+  return {
+    ...service,
+    dockerfilePath: config.dockerfile ?? service.dockerfilePath,
+    containerPort: config.port ?? service.containerPort,
+    healthCheckPath: config.health_check?.path ?? service.healthCheckPath,
+    healthCheckTimeout:
+      config.health_check?.timeout ?? service.healthCheckTimeout,
+    memoryLimit: config.resources?.memory ?? service.memoryLimit,
+    cpuLimit: config.resources?.cpu ?? service.cpuLimit,
+  };
+}

--- a/apps/app/src/server/services.ts
+++ b/apps/app/src/server/services.ts
@@ -206,6 +206,8 @@ export const services = {
           shutdownTimeout: input.shutdownTimeout ?? null,
           registryId:
             input.deployType === "image" ? (input.registryId ?? null) : null,
+          frostFilePath:
+            input.deployType === "repo" ? (input.frostFilePath ?? null) : null,
           createdAt: now,
         })
         .execute();
@@ -306,6 +308,9 @@ export const services = {
       updates.volumes = JSON.stringify(input.volumes);
     if (input.registryId !== undefined) updates.registryId = input.registryId;
     if (input.command !== undefined) updates.command = input.command;
+    if (service.deployType === "repo" && input.frostFilePath !== undefined) {
+      updates.frostFilePath = input.frostFilePath;
+    }
 
     if (Object.keys(updates).length > 0) {
       await db


### PR DESCRIPTION
## Summary

- Add `frost.yaml` config file support for per-service build/deploy settings
- Config file overrides UI settings at deploy time (like Railway's `railway.toml`)
- New `frostFilePath` service setting to specify config location

## Changes

- **Migration**: Add `frost_file_path` column to services table
- **Config parser**: Zod schema with strict validation, YAML parsing
- **Deployer**: Load config after clone, merge with service settings
- **UI**: Config file path input in Build Configuration section
- **Docs**: New guide page for config file usage
- **Schema**: JSON schema for IDE autocomplete

## frost.yaml Format

```yaml
dockerfile: Dockerfile
port: 3000
health_check:
  path: /health
  timeout: 30
resources:
  memory: 512m
  cpu: 0.5
```

## Test plan

- [ ] Set `frostFilePath` in UI, deploy, verify config loaded from build log
- [ ] Test override: set port=8080 in UI, port=3000 in frost.yaml, verify 3000 used
- [ ] Test error cases: invalid YAML, unknown fields, both .yaml and .yml exist
- [ ] Test missing file uses UI settings only
- [ ] Verify typecheck and lint pass

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)