### PR TITLE
feat: scan for frost.yaml when adding repo service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,7 @@ yarn-error.log*
 **/data/
 /repos/
 
-# test fixtures
-/test/
+# test fixtures - ignore nested .git dirs from cloned repos
 **/test/fixtures/*/.git/
 
 # bun

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ yarn-error.log*
 **/data/
 /repos/
 
-# test fixtures - ignore nested .git dirs from cloned repos
+# e2e cloned repos (root test/ is for local e2e testing, real fixtures in apps/app/test/)
+/test/
 **/test/fixtures/*/.git/
 
 # bun

--- a/apps/app/src/app/projects/[id]/_components/create-service-modal.tsx
+++ b/apps/app/src/app/projects/[id]/_components/create-service-modal.tsx
@@ -257,6 +257,11 @@ export function CreateServiceModal({
         buildContext: df.buildContext,
         containerPort: df.detectedPort ?? 8080,
         enabled: true,
+        frostFilePath: df.frostConfig?.frostFilePath,
+        healthCheckPath: df.frostConfig?.healthCheckPath,
+        healthCheckTimeout: df.frostConfig?.healthCheckTimeout,
+        memoryLimit: df.frostConfig?.memoryLimit,
+        cpuLimit: df.frostConfig?.cpuLimit,
       }));
 
       setStagedServices(staged);
@@ -284,6 +289,10 @@ export function CreateServiceModal({
           dockerfilePath: s.dockerfilePath,
           buildContext: s.buildContext,
           containerPort: s.containerPort,
+          healthCheckPath: s.healthCheckPath,
+          healthCheckTimeout: s.healthCheckTimeout,
+          memoryLimit: s.memoryLimit,
+          cpuLimit: s.cpuLimit,
         })),
       });
 

--- a/apps/app/src/app/projects/[id]/_components/staged-services-list.tsx
+++ b/apps/app/src/app/projects/[id]/_components/staged-services-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { File, Loader2, Minus, Plus, X } from "lucide-react";
+import { File, Loader2, Minus, Plus, Snowflake, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -12,6 +12,11 @@ export interface StagedService {
   buildContext: string;
   containerPort: number;
   enabled: boolean;
+  frostFilePath?: string;
+  healthCheckPath?: string;
+  healthCheckTimeout?: number;
+  memoryLimit?: string;
+  cpuLimit?: number;
 }
 
 interface StagedServicesListProps {
@@ -124,9 +129,22 @@ export function StagedServicesList({
                     />
                   </div>
 
-                  <div className="flex items-center gap-1.5 text-xs text-neutral-500">
-                    <File className="h-3 w-3" />
-                    <span className="font-mono">{service.dockerfilePath}</span>
+                  <div className="flex items-center gap-2 text-xs text-neutral-500">
+                    <div className="flex items-center gap-1.5">
+                      <File className="h-3 w-3" />
+                      <span className="font-mono">
+                        {service.dockerfilePath}
+                      </span>
+                    </div>
+                    {service.frostFilePath && (
+                      <div
+                        className="flex items-center gap-1 rounded bg-blue-500/20 px-1.5 py-0.5 text-blue-400"
+                        title={`Config from ${service.frostFilePath}`}
+                      >
+                        <Snowflake className="h-3 w-3" />
+                        <span>frost.yaml</span>
+                      </div>
+                    )}
                   </div>
 
                   {isDuplicate && (

--- a/apps/app/src/contracts/github.ts
+++ b/apps/app/src/contracts/github.ts
@@ -20,11 +20,20 @@ const repoSchema = z.object({
   }),
 });
 
+const frostConfigInfoSchema = z.object({
+  frostFilePath: z.string(),
+  healthCheckPath: z.string().optional(),
+  healthCheckTimeout: z.number().optional(),
+  memoryLimit: z.string().optional(),
+  cpuLimit: z.number().optional(),
+});
+
 const dockerfileInfoSchema = z.object({
   path: z.string(),
   suggestedName: z.string(),
   buildContext: z.string(),
   detectedPort: z.number().nullable(),
+  frostConfig: frostConfigInfoSchema.optional(),
 });
 
 export const githubContract = {

--- a/apps/app/src/contracts/services.ts
+++ b/apps/app/src/contracts/services.ts
@@ -128,6 +128,13 @@ export const servicesContract = {
             dockerfilePath: z.string(),
             buildContext: z.string(),
             containerPort: z.number().min(1).max(65535).optional(),
+            healthCheckPath: z.string().optional(),
+            healthCheckTimeout: z.number().optional(),
+            memoryLimit: z
+              .string()
+              .regex(/^\d+[kmg]$/i)
+              .optional(),
+            cpuLimit: z.number().min(0.1).max(64).optional(),
           }),
         ),
       }),

--- a/apps/app/src/lib/frost-config.test.ts
+++ b/apps/app/src/lib/frost-config.test.ts
@@ -102,15 +102,11 @@ resources:
   });
 
   test("throws on invalid timeout - too low", () => {
-    expect(() =>
-      parseFrostConfig("health_check:\n  timeout: 0"),
-    ).toThrow();
+    expect(() => parseFrostConfig("health_check:\n  timeout: 0")).toThrow();
   });
 
   test("throws on invalid timeout - too high", () => {
-    expect(() =>
-      parseFrostConfig("health_check:\n  timeout: 500"),
-    ).toThrow();
+    expect(() => parseFrostConfig("health_check:\n  timeout: 500")).toThrow();
   });
 
   test("throws on unknown keys (strict mode)", () => {

--- a/apps/app/src/lib/frost-config.test.ts
+++ b/apps/app/src/lib/frost-config.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { parseFrostConfig } from "./frost-config";
+
+describe("parseFrostConfig", () => {
+  test("parses minimal config", () => {
+    const config = parseFrostConfig("port: 3000");
+    expect(config.port).toBe(3000);
+  });
+
+  test("parses full config", () => {
+    const yaml = `
+port: 4000
+dockerfile: Dockerfile.prod
+health_check:
+  path: /health
+  timeout: 30
+resources:
+  memory: 512m
+  cpu: 0.5
+`;
+    const config = parseFrostConfig(yaml);
+    expect(config.port).toBe(4000);
+    expect(config.dockerfile).toBe("Dockerfile.prod");
+    expect(config.health_check?.path).toBe("/health");
+    expect(config.health_check?.timeout).toBe(30);
+    expect(config.resources?.memory).toBe("512m");
+    expect(config.resources?.cpu).toBe(0.5);
+  });
+
+  test("parses config with only health_check", () => {
+    const yaml = `
+health_check:
+  path: /api/health
+`;
+    const config = parseFrostConfig(yaml);
+    expect(config.health_check?.path).toBe("/api/health");
+    expect(config.health_check?.timeout).toBeUndefined();
+    expect(config.port).toBeUndefined();
+  });
+
+  test("parses config with only resources", () => {
+    const yaml = `
+resources:
+  memory: 1g
+  cpu: 2
+`;
+    const config = parseFrostConfig(yaml);
+    expect(config.resources?.memory).toBe("1g");
+    expect(config.resources?.cpu).toBe(2);
+  });
+
+  test("parses empty config", () => {
+    const config = parseFrostConfig("{}");
+    expect(config.port).toBeUndefined();
+    expect(config.dockerfile).toBeUndefined();
+  });
+
+  test("throws on invalid port - too low", () => {
+    expect(() => parseFrostConfig("port: 0")).toThrow();
+  });
+
+  test("throws on invalid port - too high", () => {
+    expect(() => parseFrostConfig("port: 70000")).toThrow();
+  });
+
+  test("throws on invalid memory format", () => {
+    expect(() => parseFrostConfig("resources:\n  memory: 512mb")).toThrow();
+  });
+
+  test("throws on invalid cpu - too low", () => {
+    expect(() => parseFrostConfig("resources:\n  cpu: 0.05")).toThrow();
+  });
+
+  test("throws on invalid cpu - too high", () => {
+    expect(() => parseFrostConfig("resources:\n  cpu: 100")).toThrow();
+  });
+
+  test("accepts valid memory formats", () => {
+    expect(
+      parseFrostConfig("resources:\n  memory: 256k").resources?.memory,
+    ).toBe("256k");
+    expect(
+      parseFrostConfig("resources:\n  memory: 512m").resources?.memory,
+    ).toBe("512m");
+    expect(parseFrostConfig("resources:\n  memory: 2g").resources?.memory).toBe(
+      "2g",
+    );
+    expect(
+      parseFrostConfig("resources:\n  memory: 256K").resources?.memory,
+    ).toBe("256K");
+    expect(
+      parseFrostConfig("resources:\n  memory: 512M").resources?.memory,
+    ).toBe("512M");
+    expect(parseFrostConfig("resources:\n  memory: 2G").resources?.memory).toBe(
+      "2G",
+    );
+  });
+
+  test("accepts dockerfile path", () => {
+    const config = parseFrostConfig("dockerfile: build/Dockerfile.prod");
+    expect(config.dockerfile).toBe("build/Dockerfile.prod");
+  });
+});

--- a/apps/app/src/lib/frost-config.ts
+++ b/apps/app/src/lib/frost-config.ts
@@ -1,0 +1,29 @@
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+
+export const frostConfigSchema = z.object({
+  dockerfile: z.string().optional(),
+  port: z.number().min(1).max(65535).optional(),
+  health_check: z
+    .object({
+      path: z.string().optional(),
+      timeout: z.number().optional(),
+    })
+    .optional(),
+  resources: z
+    .object({
+      memory: z
+        .string()
+        .regex(/^\d+[kmg]$/i)
+        .optional(),
+      cpu: z.number().min(0.1).max(64).optional(),
+    })
+    .optional(),
+});
+
+export type FrostConfig = z.infer<typeof frostConfigSchema>;
+
+export function parseFrostConfig(content: string): FrostConfig {
+  const parsed = parseYaml(content);
+  return frostConfigSchema.parse(parsed);
+}

--- a/apps/app/src/server/services.ts
+++ b/apps/app/src/server/services.ts
@@ -450,6 +450,10 @@ export const services = {
           dockerfilePath: svc.dockerfilePath,
           buildContext: svc.buildContext === "." ? null : svc.buildContext,
           containerPort: svc.containerPort,
+          healthCheckPath: svc.healthCheckPath,
+          healthCheckTimeout: svc.healthCheckTimeout,
+          memoryLimit: svc.memoryLimit,
+          cpuLimit: svc.cpuLimit,
           autoDeploy: true,
           wildcardDomain: { projectHostname, environmentName: envName },
         });

--- a/apps/app/test/fixtures/frost-yaml-test/Dockerfile
+++ b/apps/app/test/fixtures/frost-yaml-test/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/apps/app/test/fixtures/frost-yaml-test/frost.yaml
+++ b/apps/app/test/fixtures/frost-yaml-test/frost.yaml
@@ -1,0 +1,7 @@
+port: 4000
+health_check:
+  path: /health
+  timeout: 30
+resources:
+  memory: 512m
+  cpu: 0.5

--- a/apps/app/test/fixtures/frost-yaml-test/index.js
+++ b/apps/app/test/fixtures/frost-yaml-test/index.js
@@ -1,0 +1,12 @@
+const http = require("node:http");
+const PORT = process.env.PORT || 3000;
+const server = http.createServer((req, res) => {
+  if (req.url === "/health") {
+    res.writeHead(200);
+    res.end("OK");
+    return;
+  }
+  res.writeHead(200);
+  res.end("Hello from frost-yaml-test");
+});
+server.listen(PORT, () => console.log(`Listening on port ${PORT}`));


### PR DESCRIPTION
## Summary

- Add frost.yaml detection when scanning repos for Dockerfiles
- Pre-populate service settings (health check, resource limits, port) from frost.yaml
- Show frost.yaml badge on staged services in UI
- Add tests for frost-config parsing and findFrostFiles

## Changes

| File | Change |
|------|--------|
| `src/lib/frost-config.ts` | NEW: Zod schema + parser for frost.yaml |
| `src/lib/frost-config.test.ts` | NEW: 14 tests for config parsing |
| `src/lib/github.ts` | Add `findFrostFiles()`, update `scanLocalDirectory()` |
| `src/lib/github.test.ts` | Add 6 tests for `findFrostFiles()` |
| `src/server/github.ts` | Update scan handler to check frost.yaml first |
| `src/contracts/github.ts` | Extend `dockerfileInfoSchema` with `frostConfig` |
| `src/contracts/services.ts` | Extend `createBatch` input with health/resource fields |
| `src/server/services.ts` | Pass frost config fields to `createService()` |
| `staged-services-list.tsx` | Add frost config fields + badge indicator |
| `create-service-modal.tsx` | Map frost config to staged services |

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes  
- [x] All 297 tests pass (including 20 new tests)
- [ ] Manual: scan repo with frost.yaml, verify config pre-populated
- [ ] Manual: verify frost.yaml badge shows in staged services UI

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)