### PR TITLE
feat: add startup logging for caddy sync details and SSL config

### DIFF
--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -17,10 +17,17 @@ export async function register() {
 
     const { syncCaddyConfig } = await import("./lib/domains");
     try {
-      const synced = await syncCaddyConfig();
-      console.log(
-        `[startup] caddy sync: ${synced ? "ok" : "skipped (no domains)"}`,
-      );
+      const result = await syncCaddyConfig();
+      if (!result.synced) {
+        console.log("[startup] caddy sync: skipped (no domains)");
+        return;
+      }
+      const parts = [
+        result.frostDomain,
+        result.serviceDomains > 0 && `${result.serviceDomains} service domains`,
+      ].filter(Boolean);
+      console.log(`[startup] caddy sync: ok (${parts.join(", ")})`);
+      if (result.staging) console.log("[startup] ssl: staging mode");
     } catch (err) {
       console.error("[startup] caddy sync: failed", err);
     }


### PR DESCRIPTION
## Summary
- Show frost domain and service domain count in caddy sync log
- Log SSL staging mode when enabled

Closes #226

## Test plan
- [ ] Run `bun run dev` and verify new log format
- [ ] Check log output with domains configured
- [ ] Check log output with SSL staging enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)