### PR TITLE
feat: improve deployment list with logs drawer

### DIFF
--- a/apps/app/schema/006-deployment-trigger.sql
+++ b/apps/app/schema/006-deployment-trigger.sql
@@ -1,0 +1,3 @@
+ALTER TABLE deployments ADD COLUMN trigger TEXT DEFAULT 'manual';
+ALTER TABLE deployments ADD COLUMN triggered_by_username TEXT;
+ALTER TABLE deployments ADD COLUMN triggered_by_avatar_url TEXT;

--- a/apps/app/src/app/projects/[id]/_components/deployment-logs-drawer.tsx
+++ b/apps/app/src/app/projects/[id]/_components/deployment-logs-drawer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useMemo } from "react";
+import { LogViewer } from "@/components/log-viewer";
+import { SideDrawer } from "@/components/side-drawer";
+import { StatusDot } from "@/components/status-dot";
+import { Button } from "@/components/ui/button";
+import type { Deployment } from "@/lib/api";
+
+interface DeploymentLogsDrawerProps {
+  deployment: Deployment | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function DeploymentLogsDrawer({
+  deployment,
+  isOpen,
+  onClose,
+}: DeploymentLogsDrawerProps) {
+  const buildLogLines = useMemo(() => {
+    if (!deployment?.buildLog) return [];
+    return deployment.buildLog.split("\n");
+  }, [deployment?.buildLog]);
+
+  return (
+    <SideDrawer
+      isOpen={isOpen}
+      onClose={onClose}
+      width="60vw"
+      zIndex={40}
+      fadeIn
+    >
+      {deployment && (
+        <>
+          <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
+            <div className="flex items-center gap-3">
+              <span className="text-lg font-semibold text-neutral-200">
+                Deployment Logs
+              </span>
+              <div className="flex items-center gap-2 text-sm text-neutral-500">
+                <StatusDot status={deployment.status} />
+                <span className="font-mono">
+                  {deployment.commitSha?.slice(0, 7) ||
+                    deployment.id.slice(0, 7)}
+                </span>
+              </div>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onClose}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex h-[calc(100%-57px)] flex-col">
+            {deployment.errorMessage && (
+              <div className="mx-4 mt-4 rounded border border-red-900 bg-red-950/50 p-3 text-sm text-red-400">
+                {deployment.errorMessage}
+              </div>
+            )}
+            <LogViewer logs={buildLogLines} emptyMessage="No logs yet..." />
+          </div>
+        </>
+      )}
+    </SideDrawer>
+  );
+}

--- a/apps/app/src/app/projects/[id]/_components/service-sidebar.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-sidebar.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+import { SideDrawer } from "@/components/side-drawer";
 import { StateTabs } from "@/components/state-tabs";
 import { Button } from "@/components/ui/button";
 import { useService } from "@/hooks/use-services";
 import { FALLBACK_ICON, getServiceIcon } from "@/lib/service-logo";
-import { cn } from "@/lib/utils";
 import { SidebarDeployments } from "./sidebar-deployments";
 import { SidebarLogs } from "./sidebar-logs";
 import { SidebarOverview } from "./sidebar-overview";
@@ -27,25 +27,19 @@ export function ServiceSidebar({
   const [activeTab, setActiveTab] = useState<
     "overview" | "deployments" | "logs" | "settings"
   >("overview");
+  const [hasNestedDrawer, setHasNestedDrawer] = useState(false);
 
-  const isOpen = !!serviceId;
-
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && isOpen) {
-        onClose();
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
+  const handleNestedDrawerChange = useCallback((hasDrawer: boolean) => {
+    setHasNestedDrawer(hasDrawer);
+  }, []);
 
   return (
-    <div
-      className={cn(
-        "fixed bottom-0 right-0 top-[120px] z-30 w-[60vw] rounded-tl-xl border-l border-t border-neutral-800 bg-neutral-900 transition-transform duration-300 ease-in-out",
-        isOpen ? "translate-x-0" : "translate-x-full",
-      )}
+    <SideDrawer
+      isOpen={!!serviceId}
+      onClose={onClose}
+      width="60vw"
+      zIndex={30}
+      hasNestedDrawer={hasNestedDrawer}
     >
       {service && (
         <>
@@ -90,7 +84,10 @@ export function ServiceSidebar({
                 <SidebarOverview service={service} />
               )}
               {activeTab === "deployments" && (
-                <SidebarDeployments service={service} />
+                <SidebarDeployments
+                  service={service}
+                  onNestedDrawerChange={handleNestedDrawerChange}
+                />
               )}
               {activeTab === "logs" && <SidebarLogs service={service} />}
               {activeTab === "settings" && (
@@ -100,6 +97,6 @@ export function ServiceSidebar({
           </div>
         </>
       )}
-    </div>
+    </SideDrawer>
   );
 }

--- a/apps/app/src/app/projects/[id]/_components/sidebar-deployments.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-deployments.tsx
@@ -2,28 +2,32 @@
 
 import { useMutation } from "@tanstack/react-query";
 import { Loader2, RotateCw } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EmptyState } from "@/components/empty-state";
-import { LogViewer } from "@/components/log-viewer";
-import { StatusDot } from "@/components/status-dot";
 import { Button } from "@/components/ui/button";
 import { useDeployments, useDeployService } from "@/hooks/use-services";
 import type { Deployment, Service } from "@/lib/api";
 import { orpc } from "@/lib/orpc-client";
 import { DeploymentRow } from "../services/[serviceId]/_components/deployment-row";
+import { DeploymentLogsDrawer } from "./deployment-logs-drawer";
 
 interface SidebarDeploymentsProps {
   service: Service;
+  onNestedDrawerChange?: (hasDrawer: boolean) => void;
 }
 
-export function SidebarDeployments({ service }: SidebarDeploymentsProps) {
+export function SidebarDeployments({
+  service,
+  onNestedDrawerChange,
+}: SidebarDeploymentsProps) {
   const { data: deployments = [] } = useDeployments(service.id);
   const deployMutation = useDeployService(service.id, service.environmentId);
 
   const [selectedDeployment, setSelectedDeployment] =
     useState<Deployment | null>(null);
   const selectedDeploymentRef = useRef<string | null>(null);
+  const [logsOpen, setLogsOpen] = useState(false);
 
   const rollbackMutation = useMutation({
     mutationFn: (deploymentId: string) =>
@@ -55,27 +59,30 @@ export function SidebarDeployments({ service }: SidebarDeploymentsProps) {
   function handleSelectDeployment(d: Deployment) {
     setSelectedDeployment(d);
     selectedDeploymentRef.current = d.id;
+    setLogsOpen(true);
   }
 
-  const buildLogLines = useMemo(() => {
-    if (!selectedDeployment?.buildLog) return [];
-    return selectedDeployment.buildLog.split("\n");
-  }, [selectedDeployment?.buildLog]);
+  function handleCloseLogs() {
+    setLogsOpen(false);
+  }
+
+  useEffect(() => {
+    onNestedDrawerChange?.(logsOpen);
+  }, [logsOpen, onNestedDrawerChange]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
-      <div className="rounded-lg border border-neutral-700 bg-neutral-800">
-        <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-neutral-700 bg-neutral-800">
+        <div className="flex shrink-0 items-center justify-between border-b border-neutral-700 px-4 py-3">
           <span className="text-sm font-medium text-neutral-300">
             Deployments
           </span>
           <Button
             size="sm"
             variant="outline"
-            onClick={() => {
-              deployMutation.mutateAsync().then(() => {
-                toast.success("Deployment started");
-              });
+            onClick={async () => {
+              await deployMutation.mutateAsync();
+              toast.success("Deployment started");
             }}
             disabled={deployMutation.isPending}
           >
@@ -100,7 +107,7 @@ export function SidebarDeployments({ service }: SidebarDeploymentsProps) {
             />
           </div>
         ) : (
-          <div className="max-h-48 divide-y divide-neutral-700 overflow-auto">
+          <div className="min-h-0 flex-1 divide-y divide-neutral-700 overflow-auto">
             {deployments.map((d) => {
               const hasVolumes = service.volumes && service.volumes !== "[]";
               const canRollback =
@@ -135,32 +142,11 @@ export function SidebarDeployments({ service }: SidebarDeploymentsProps) {
         )}
       </div>
 
-      {selectedDeployment && (
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-neutral-700 bg-neutral-800">
-          <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">
-            <div className="flex items-center gap-3">
-              <span className="text-sm font-medium text-neutral-300">
-                Deployment Logs
-              </span>
-              <div className="flex items-center gap-2 text-xs text-neutral-500">
-                <StatusDot status={selectedDeployment.status} />
-                <span className="font-mono">
-                  {selectedDeployment.commitSha?.slice(0, 7) ||
-                    selectedDeployment.id.slice(0, 7)}
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="flex min-h-0 flex-1 flex-col">
-            {selectedDeployment.errorMessage && (
-              <div className="mx-4 mt-4 rounded border border-red-900 bg-red-950/50 p-3 text-sm text-red-400">
-                {selectedDeployment.errorMessage}
-              </div>
-            )}
-            <LogViewer logs={buildLogLines} emptyMessage="No logs yet..." />
-          </div>
-        </div>
-      )}
+      <DeploymentLogsDrawer
+        deployment={selectedDeployment}
+        isOpen={logsOpen}
+        onClose={handleCloseLogs}
+      />
     </div>
   );
 }

--- a/apps/app/src/app/projects/[id]/_components/sidebar-deployments.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-deployments.tsx
@@ -102,17 +102,20 @@ export function SidebarDeployments({ service }: SidebarDeploymentsProps) {
         ) : (
           <div className="max-h-48 divide-y divide-neutral-700 overflow-auto">
             {deployments.map((d) => {
-              const hasVolumes = service?.volumes && service.volumes !== "[]";
+              const hasVolumes = service.volumes && service.volumes !== "[]";
               const canRollback =
                 !hasVolumes && !!d.imageName && d.rollbackEligible === true;
               const isCurrent = d.id === service.currentDeploymentId;
               return (
                 <DeploymentRow
                   key={d.id}
-                  id={d.id}
                   commitSha={d.commitSha}
+                  commitMessage={d.commitMessage}
+                  gitBranch={d.gitBranch}
                   status={d.status}
                   createdAt={d.createdAt}
+                  finishedAt={d.finishedAt}
+                  trigger={d.trigger}
                   selected={selectedDeployment?.id === d.id}
                   onClick={() => handleSelectDeployment(d)}
                   canRollback={canRollback}
@@ -123,7 +126,6 @@ export function SidebarDeployments({ service }: SidebarDeploymentsProps) {
                     rollbackMutation.variables === d.id
                   }
                   isCurrent={isCurrent}
-                  imageName={d.imageName}
                 />
               );
             })}

--- a/apps/app/src/app/projects/[id]/_components/sidebar-deployments.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-deployments.tsx
@@ -116,6 +116,8 @@ export function SidebarDeployments({ service }: SidebarDeploymentsProps) {
                   createdAt={d.createdAt}
                   finishedAt={d.finishedAt}
                   trigger={d.trigger}
+                  triggeredByUsername={d.triggeredByUsername}
+                  triggeredByAvatarUrl={d.triggeredByAvatarUrl}
                   selected={selectedDeployment?.id === d.id}
                   onClick={() => handleSelectDeployment(d)}
                   canRollback={canRollback}

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
@@ -11,6 +11,8 @@ interface DeploymentRowProps {
   createdAt: number;
   finishedAt?: number | null;
   trigger?: string | null;
+  triggeredByUsername?: string | null;
+  triggeredByAvatarUrl?: string | null;
   selected: boolean;
   onClick: () => void;
   canRollback?: boolean;
@@ -50,6 +52,8 @@ export function DeploymentRow({
   createdAt,
   finishedAt,
   trigger,
+  triggeredByUsername,
+  triggeredByAvatarUrl,
   selected,
   onClick,
   canRollback,
@@ -118,12 +122,21 @@ export function DeploymentRow({
               <Check className="h-3 w-3" />
             </span>
           )}
-          <span
-            className="flex items-center gap-1 text-xs text-neutral-500"
-            title={getTriggerLabel(trigger)}
-          >
-            {getTriggerIcon(trigger)}
-          </span>
+          {triggeredByAvatarUrl ? (
+            <img
+              src={triggeredByAvatarUrl}
+              alt={triggeredByUsername || ""}
+              title={triggeredByUsername || getTriggerLabel(trigger)}
+              className="h-5 w-5 rounded-full"
+            />
+          ) : (
+            <span
+              className="flex items-center gap-1 text-xs text-neutral-500"
+              title={getTriggerLabel(trigger)}
+            >
+              {getTriggerIcon(trigger)}
+            </span>
+          )}
           {duration && (
             <span className="text-xs text-neutral-500 w-12 text-right">
               {duration}

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
@@ -1,13 +1,16 @@
-import { Check, RotateCcw } from "lucide-react";
+import { Check, GitBranch, GitCommit, Play, RotateCcw } from "lucide-react";
 import { StatusDot } from "@/components/status-dot";
-import { getTimeAgo } from "@/lib/time";
+import { formatDuration, getTimeAgo } from "@/lib/time";
 import { cn } from "@/lib/utils";
 
 interface DeploymentRowProps {
-  id: string;
   commitSha: string;
+  commitMessage?: string | null;
+  gitBranch?: string | null;
   status: string;
   createdAt: number;
+  finishedAt?: number | null;
+  trigger?: string | null;
   selected: boolean;
   onClick: () => void;
   canRollback?: boolean;
@@ -15,17 +18,38 @@ interface DeploymentRowProps {
   onRollback?: () => void;
   isRollingBack?: boolean;
   isCurrent?: boolean;
-  imageName?: string | null;
 }
 
-function getDisplayStatus(status: string): string {
-  return status;
+function getTriggerIcon(trigger: string | null | undefined) {
+  switch (trigger) {
+    case "git":
+      return <GitCommit className="h-3 w-3" />;
+    case "rollback":
+      return <RotateCcw className="h-3 w-3" />;
+    default:
+      return <Play className="h-3 w-3" />;
+  }
+}
+
+function getTriggerLabel(trigger: string | null | undefined): string {
+  switch (trigger) {
+    case "git":
+      return "push";
+    case "rollback":
+      return "rollback";
+    default:
+      return "manual";
+  }
 }
 
 export function DeploymentRow({
   commitSha,
+  commitMessage,
+  gitBranch,
   status,
   createdAt,
+  finishedAt,
+  trigger,
   selected,
   onClick,
   canRollback,
@@ -33,11 +57,15 @@ export function DeploymentRow({
   onRollback,
   isRollingBack,
   isCurrent,
-  imageName,
 }: DeploymentRowProps) {
   const date = new Date(createdAt);
   const timeAgo = getTimeAgo(date);
-  const displayStatus = getDisplayStatus(status);
+  const duration =
+    finishedAt && createdAt ? formatDuration(createdAt, finishedAt) : null;
+  const truncatedMessage = commitMessage
+    ? commitMessage.split("\n")[0].slice(0, 50) +
+      (commitMessage.length > 50 ? "..." : "")
+    : null;
 
   function handleRollback(e: React.MouseEvent) {
     e.stopPropagation();
@@ -59,24 +87,51 @@ export function DeploymentRow({
       onClick={onClick}
       onKeyDown={handleKeyDown}
       className={cn(
-        "group w-full px-4 py-3 text-left transition-colors hover:bg-neutral-800/50 cursor-pointer",
+        "group w-full px-4 py-2.5 text-left transition-colors hover:bg-neutral-800/50 cursor-pointer",
         selected && "bg-neutral-800",
       )}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <StatusDot status={displayStatus} />
-          <span className="font-mono text-sm text-neutral-300">
-            {commitSha}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <StatusDot status={status} />
+          <span className="text-xs capitalize text-neutral-300 w-16 shrink-0">
+            {status}
           </span>
-          {isCurrent && (
-            <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-xs text-blue-400">
-              <Check className="h-3 w-3" />
-              Current
+          {gitBranch && (
+            <span className="flex items-center gap-1 text-xs text-neutral-500 shrink-0">
+              <GitBranch className="h-3 w-3" />
+              <span className="max-w-20 truncate">{gitBranch}</span>
+            </span>
+          )}
+          <span className="font-mono text-xs text-neutral-400 shrink-0">
+            {commitSha.slice(0, 7)}
+          </span>
+          {truncatedMessage && (
+            <span className="min-w-0 truncate text-xs text-neutral-500">
+              {truncatedMessage}
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
+          {isCurrent && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/30 bg-blue-500/10 px-1.5 py-0.5 text-xs text-blue-400">
+              <Check className="h-3 w-3" />
+            </span>
+          )}
+          <span
+            className="flex items-center gap-1 text-xs text-neutral-500"
+            title={getTriggerLabel(trigger)}
+          >
+            {getTriggerIcon(trigger)}
+          </span>
+          {duration && (
+            <span className="text-xs text-neutral-500 w-12 text-right">
+              {duration}
+            </span>
+          )}
+          <span className="text-xs text-neutral-500 w-14 text-right">
+            {timeAgo}
+          </span>
           <span className="w-6 flex justify-center">
             {canRollback && !isRunning && (
               <button
@@ -91,9 +146,6 @@ export function DeploymentRow({
                 />
               </button>
             )}
-          </span>
-          <span className="text-xs text-neutral-500 w-14 text-right">
-            {timeAgo}
           </span>
         </div>
       </div>

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
@@ -28,6 +28,34 @@ function isInProgress(status: string): boolean {
   );
 }
 
+interface TriggerLabelProps {
+  trigger?: string | null;
+  gitBranch?: string | null;
+}
+
+function TriggerLabel({
+  trigger,
+  gitBranch,
+}: TriggerLabelProps): React.ReactNode {
+  if (trigger === "rollback") {
+    return (
+      <>
+        <RotateCcw className="h-3.5 w-3.5 text-neutral-500" />
+        <span>Rollback</span>
+      </>
+    );
+  }
+  if (gitBranch) {
+    return (
+      <>
+        <GitBranch className="h-3.5 w-3.5 text-neutral-500" />
+        <span className="truncate max-w-32">{gitBranch}</span>
+      </>
+    );
+  }
+  return <span className="text-neutral-500">Manual deploy</span>;
+}
+
 export function DeploymentRow({
   commitSha,
   commitMessage,
@@ -88,19 +116,7 @@ export function DeploymentRow({
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 text-sm text-neutral-300">
-            {trigger === "rollback" ? (
-              <>
-                <RotateCcw className="h-3.5 w-3.5 text-neutral-500" />
-                <span>Rollback</span>
-              </>
-            ) : gitBranch ? (
-              <>
-                <GitBranch className="h-3.5 w-3.5 text-neutral-500" />
-                <span className="truncate max-w-32">{gitBranch}</span>
-              </>
-            ) : (
-              <span className="text-neutral-500">Manual deploy</span>
-            )}
+            <TriggerLabel trigger={trigger} gitBranch={gitBranch} />
           </div>
           <div className="flex items-center gap-1.5 text-xs text-neutral-500 mt-0.5">
             <GitCommit className="h-3 w-3" />

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/_components/deployment-row.tsx
@@ -1,4 +1,4 @@
-import { Check, GitBranch, GitCommit, Play, RotateCcw } from "lucide-react";
+import { GitBranch, GitCommit, RotateCcw } from "lucide-react";
 import { StatusDot } from "@/components/status-dot";
 import { formatDuration, getTimeAgo } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -22,26 +22,10 @@ interface DeploymentRowProps {
   isCurrent?: boolean;
 }
 
-function getTriggerIcon(trigger: string | null | undefined) {
-  switch (trigger) {
-    case "git":
-      return <GitCommit className="h-3 w-3" />;
-    case "rollback":
-      return <RotateCcw className="h-3 w-3" />;
-    default:
-      return <Play className="h-3 w-3" />;
-  }
-}
-
-function getTriggerLabel(trigger: string | null | undefined): string {
-  switch (trigger) {
-    case "git":
-      return "push";
-    case "rollback":
-      return "rollback";
-    default:
-      return "manual";
-  }
+function isInProgress(status: string): boolean {
+  return ["pending", "cloning", "pulling", "building", "deploying"].includes(
+    status,
+  );
 }
 
 export function DeploymentRow({
@@ -62,14 +46,11 @@ export function DeploymentRow({
   isRollingBack,
   isCurrent,
 }: DeploymentRowProps) {
-  const date = new Date(createdAt);
-  const timeAgo = getTimeAgo(date);
+  const timeAgo = getTimeAgo(new Date(createdAt));
   const duration =
     finishedAt && createdAt ? formatDuration(createdAt, finishedAt) : null;
-  const truncatedMessage = commitMessage
-    ? commitMessage.split("\n")[0].slice(0, 50) +
-      (commitMessage.length > 50 ? "..." : "")
-    : null;
+  const inProgress = isInProgress(status);
+  const elapsed = inProgress ? formatDuration(createdAt, Date.now()) : null;
 
   function handleRollback(e: React.MouseEvent) {
     e.stopPropagation();
@@ -95,56 +76,60 @@ export function DeploymentRow({
         selected && "bg-neutral-800",
       )}
     >
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <StatusDot status={status} />
-          <span className="text-xs capitalize text-neutral-300 w-16 shrink-0">
-            {status}
-          </span>
-          {gitBranch && (
-            <span className="flex items-center gap-1 text-xs text-neutral-500 shrink-0">
-              <GitBranch className="h-3 w-3" />
-              <span className="max-w-20 truncate">{gitBranch}</span>
-            </span>
-          )}
-          <span className="font-mono text-xs text-neutral-400 shrink-0">
-            {commitSha.slice(0, 7)}
-          </span>
-          {truncatedMessage && (
-            <span className="min-w-0 truncate text-xs text-neutral-500">
-              {truncatedMessage}
-            </span>
-          )}
+      <div className="flex items-center gap-4">
+        <div className="w-20 shrink-0">
+          <div className="flex items-center gap-2">
+            <StatusDot status={status} showLabel />
+          </div>
+          <div className="text-xs text-neutral-500 mt-0.5">
+            {inProgress ? elapsed : duration}
+          </div>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5 text-sm text-neutral-300">
+            {trigger === "rollback" ? (
+              <>
+                <RotateCcw className="h-3.5 w-3.5 text-neutral-500" />
+                <span>Rollback</span>
+              </>
+            ) : gitBranch ? (
+              <>
+                <GitBranch className="h-3.5 w-3.5 text-neutral-500" />
+                <span className="truncate max-w-32">{gitBranch}</span>
+              </>
+            ) : (
+              <span className="text-neutral-500">Manual deploy</span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5 text-xs text-neutral-500 mt-0.5">
+            <GitCommit className="h-3 w-3" />
+            <span className="font-mono">{commitSha.slice(0, 7)}</span>
+            {commitMessage && (
+              <span className="truncate">{commitMessage.split("\n")[0]}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-3">
           {isCurrent && (
-            <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/30 bg-blue-500/10 px-1.5 py-0.5 text-xs text-blue-400">
-              <Check className="h-3 w-3" />
+            <span className="rounded-full bg-blue-500 px-2 py-0.5 text-xs font-medium text-white">
+              Current
             </span>
           )}
-          {triggeredByAvatarUrl ? (
-            <img
-              src={triggeredByAvatarUrl}
-              alt={triggeredByUsername || ""}
-              title={triggeredByUsername || getTriggerLabel(trigger)}
-              className="h-5 w-5 rounded-full"
-            />
-          ) : (
-            <span
-              className="flex items-center gap-1 text-xs text-neutral-500"
-              title={getTriggerLabel(trigger)}
-            >
-              {getTriggerIcon(trigger)}
+          <div className="flex items-center gap-2 text-xs text-neutral-500">
+            <span>
+              {timeAgo}
+              {triggeredByUsername && ` by ${triggeredByUsername}`}
             </span>
-          )}
-          {duration && (
-            <span className="text-xs text-neutral-500 w-12 text-right">
-              {duration}
-            </span>
-          )}
-          <span className="text-xs text-neutral-500 w-14 text-right">
-            {timeAgo}
-          </span>
+            {triggeredByAvatarUrl && (
+              <img
+                src={triggeredByAvatarUrl}
+                alt={triggeredByUsername || ""}
+                className="h-5 w-5 rounded-full"
+              />
+            )}
+          </div>
           <span className="w-6 flex justify-center">
             {canRollback && !isRunning && (
               <button

--- a/apps/app/src/components/side-drawer.tsx
+++ b/apps/app/src/components/side-drawer.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+const STACK_OFFSET = 30;
+
+const FADE_OFFSET = 20;
+
+function getTransform(
+  isOpen: boolean,
+  hasNestedDrawer: boolean,
+  fadeIn: boolean,
+): string {
+  if (!isOpen) {
+    if (fadeIn) return `translate(${FADE_OFFSET}px, ${-FADE_OFFSET}px)`;
+    return "translateX(100%)";
+  }
+  if (hasNestedDrawer)
+    return `translate(${-STACK_OFFSET}px, ${STACK_OFFSET}px)`;
+  return "translate(0, 0)";
+}
+
+interface SideDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  width: string;
+  zIndex: number;
+  hasNestedDrawer?: boolean;
+  fadeIn?: boolean;
+  children: React.ReactNode;
+}
+
+export function SideDrawer({
+  isOpen,
+  onClose,
+  width,
+  zIndex,
+  hasNestedDrawer = false,
+  fadeIn = false,
+  children,
+}: SideDrawerProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && isOpen && !hasNestedDrawer) {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [isOpen, hasNestedDrawer, onClose]);
+
+  const drawer = (
+    <div
+      className={cn(
+        "fixed bottom-0 right-0 top-[120px] rounded-tl-xl border-l border-t border-neutral-800 bg-neutral-900 transition-all duration-300 ease-in-out",
+        !isOpen && "pointer-events-none opacity-0",
+      )}
+      style={{
+        width,
+        zIndex,
+        transform: getTransform(isOpen, hasNestedDrawer, fadeIn),
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  if (!mounted) return null;
+
+  return createPortal(drawer, document.body);
+}

--- a/apps/app/src/components/status-dot.tsx
+++ b/apps/app/src/components/status-dot.tsx
@@ -1,23 +1,34 @@
 import { cn } from "@/lib/utils";
 
-type Status =
-  | "pending"
-  | "cloning"
-  | "pulling"
-  | "building"
-  | "deploying"
-  | "running"
-  | "failed";
+type StatusColor = "yellow" | "red" | "green";
 
-const statusConfig: Record<Status, { color: string; pulse: boolean }> = {
-  pending: { color: "bg-neutral-500", pulse: false },
-  cloning: { color: "bg-yellow-500", pulse: true },
-  pulling: { color: "bg-yellow-500", pulse: true },
-  building: { color: "bg-yellow-500", pulse: true },
-  deploying: { color: "bg-yellow-500", pulse: true },
-  running: { color: "bg-green-500", pulse: false },
-  failed: { color: "bg-red-500", pulse: false },
+interface StatusConfig {
+  color: string;
+  pulse: boolean;
+  label: string;
+}
+
+const colorConfig: Record<StatusColor, StatusConfig> = {
+  yellow: { color: "bg-yellow-500", pulse: true, label: "pending" },
+  red: { color: "bg-red-500", pulse: false, label: "failed" },
+  green: { color: "bg-green-500", pulse: false, label: "ok" },
 };
+
+function getStatusColor(status: string): StatusColor {
+  switch (status) {
+    case "pending":
+    case "cloning":
+    case "pulling":
+    case "building":
+    case "deploying":
+      return "yellow";
+    case "failed":
+    case "cancelled":
+      return "red";
+    default:
+      return "green";
+  }
+}
 
 interface StatusDotProps {
   status: string;
@@ -30,7 +41,8 @@ export function StatusDot({
   className,
   showLabel = false,
 }: StatusDotProps) {
-  const config = statusConfig[status as Status] ?? statusConfig.pending;
+  const statusColor = getStatusColor(status);
+  const config = colorConfig[statusColor];
 
   return (
     <span className={cn("inline-flex items-center gap-2", className)}>
@@ -42,8 +54,10 @@ export function StatusDot({
         )}
       />
       {showLabel && (
-        <span className="text-xs text-neutral-400 capitalize">{status}</span>
+        <span className="text-xs text-neutral-400">{config.label}</span>
       )}
     </span>
   );
 }
+
+export { getStatusColor, colorConfig };

--- a/apps/app/src/lib/db-schemas.ts
+++ b/apps/app/src/lib/db-schemas.ts
@@ -135,6 +135,9 @@ export const deploymentsSchema = z.object({
   rollbackSourceId: z.string().nullable(),
   gitCommitSha: z.string().nullable(),
   gitBranch: z.string().nullable(),
+  trigger: z.string().nullable(),
+  triggeredByUsername: z.string().nullable(),
+  triggeredByAvatarUrl: z.string().nullable(),
 });
 
 export const newDeploymentsSchema = z.object({
@@ -160,6 +163,9 @@ export const newDeploymentsSchema = z.object({
   rollbackSourceId: z.string().nullable(),
   gitCommitSha: z.string().nullable(),
   gitBranch: z.string().nullable(),
+  trigger: z.string().nullable().optional(),
+  triggeredByUsername: z.string().nullable().optional(),
+  triggeredByAvatarUrl: z.string().nullable().optional(),
 });
 
 export const deploymentsUpdateSchema = z.object({
@@ -185,6 +191,9 @@ export const deploymentsUpdateSchema = z.object({
   rollbackSourceId: z.string().nullable().optional(),
   gitCommitSha: z.string().nullable().optional(),
   gitBranch: z.string().nullable().optional(),
+  trigger: z.string().nullable().optional(),
+  triggeredByUsername: z.string().nullable().optional(),
+  triggeredByAvatarUrl: z.string().nullable().optional(),
 });
 
 export type Deployments = z.infer<typeof deploymentsSchema>;

--- a/apps/app/src/lib/db-types.ts
+++ b/apps/app/src/lib/db-types.ts
@@ -58,6 +58,9 @@ export interface Deployments {
   gitBranch: string | null;
   createdAt: number;
   finishedAt: number | null;
+  trigger: Generated<string | null>;
+  triggeredByUsername: string | null;
+  triggeredByAvatarUrl: string | null;
 }
 
 export interface Domains {

--- a/apps/app/src/lib/time.ts
+++ b/apps/app/src/lib/time.ts
@@ -8,3 +8,11 @@ export function getTimeAgo(date: Date): string {
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
 }
+
+export function formatDuration(startMs: number, endMs: number): string {
+  const totalSeconds = Math.floor((endMs - startMs) / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}


### PR DESCRIPTION
## Summary
- Add `trigger` column to track deployment source (manual/git/rollback)
- Store GitHub sender info (username, avatar) for git-triggered deploys
- Redesign deployment rows with branch, commit message, duration, trigger icons
- Add deployment logs drawer that opens when clicking a deployment row
- Create reusable `SideDrawer` component with stacking animation
- Parent drawer shifts down-left when nested drawer opens (Railway-inspired)

## Test plan
- [ ] Manual deploy → verify trigger='manual'
- [ ] Push to repo with webhook → verify trigger='git' and sender info
- [ ] Rollback deployment → verify trigger='rollback'
- [ ] UI shows branch, commit message (truncated), duration, trigger icon
- [ ] Click deployment row → logs drawer opens with fade-in animation
- [ ] Parent sidebar shifts when logs drawer is open
- [ ] Escape key closes topmost drawer first

🤖 Generated with [Claude Code](https://claude.com/claude-code)