### PR TITLE
fix: serve status badges from frost.build

### DIFF
--- a/apps/app/src/lib/webhook.ts
+++ b/apps/app/src/lib/webhook.ts
@@ -323,20 +323,15 @@ export interface BuildPRCommentParams {
   frostDomain: string | null;
 }
 
-function getStatusBadge(status: string, frostDomain: string | null): string {
+function getStatusBadge(status: string): string {
+  const baseUrl = "https://frost.build/static/status";
   if (status === "running") {
-    return frostDomain
-      ? `![Ready](https://${frostDomain}/static/status/ready.svg)`
-      : "🟢 Ready";
+    return `![Ready](${baseUrl}/ready.svg)`;
   }
   if (status === "failed") {
-    return frostDomain
-      ? `![Failed](https://${frostDomain}/static/status/failed.svg)`
-      : "🔴 Failed";
+    return `![Failed](${baseUrl}/failed.svg)`;
   }
-  return frostDomain
-    ? `![Building](https://${frostDomain}/static/status/building.svg)`
-    : "🟡 Building";
+  return `![Building](${baseUrl}/building.svg)`;
 }
 
 export function buildPRCommentBody(params: BuildPRCommentParams): string {
@@ -345,7 +340,7 @@ export function buildPRCommentBody(params: BuildPRCommentParams): string {
 
   const rows = services
     .map((s) => {
-      const statusBadge = getStatusBadge(s.status, frostDomain);
+      const statusBadge = getStatusBadge(s.status);
       const serviceLink = frostDomain
         ? `[${s.name}](https://${frostDomain}/projects/${projectId}/environments/${environmentId}/services/${s.id})`
         : s.name;

--- a/apps/marketing/public/static/status/building.svg
+++ b/apps/marketing/public/static/status/building.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="20" viewBox="0 0 64 20">
+  <rect width="64" height="20" rx="10" fill="#f59e0b"/>
+  <text x="32" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="11" font-weight="500" fill="white" text-anchor="middle">Building</text>
+</svg>

--- a/apps/marketing/public/static/status/failed.svg
+++ b/apps/marketing/public/static/status/failed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20" viewBox="0 0 50 20">
+  <rect width="50" height="20" rx="10" fill="#ef4444"/>
+  <text x="25" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="11" font-weight="500" fill="white" text-anchor="middle">Failed</text>
+</svg>

--- a/apps/marketing/public/static/status/ready.svg
+++ b/apps/marketing/public/static/status/ready.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="52" height="20" viewBox="0 0 52 20">
+  <rect width="52" height="20" rx="10" fill="#10b981"/>
+  <text x="26" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="11" font-weight="500" fill="white" text-anchor="middle">Ready</text>
+</svg>


### PR DESCRIPTION
## Summary
- Serve SVG status badges from frost.build instead of the Frost app
- Badges blocked by auth middleware on app → use public marketing site instead

Fixes #263

## Test plan
- [ ] Deploy marketing site
- [ ] Verify badges accessible: `curl -I https://frost.build/static/status/ready.svg`
- [ ] Trigger PR deployment, check badge renders in GitHub comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)