### PR TITLE
fix: expand Docker network pool limits

### DIFF
--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -4,6 +4,17 @@ export async function register() {
     runMigrations();
     console.log("[startup] migrations: ok");
 
+    const { ensureDockerNetworkConfig } = await import("./lib/docker-config");
+    const dockerRestarted = await ensureDockerNetworkConfig().catch((err) => {
+      console.error("[startup] docker: failed to configure network pools", err);
+      return false;
+    });
+    console.log(
+      dockerRestarted
+        ? "[startup] docker: configured network pools, restarted"
+        : "[startup] docker: network pools ok",
+    );
+
     const { persistUpdateResult } = await import("./lib/updater");
     await persistUpdateResult();
 

--- a/apps/app/src/lib/docker-config.ts
+++ b/apps/app/src/lib/docker-config.ts
@@ -1,0 +1,31 @@
+import { exec } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+const DAEMON_JSON = "/etc/docker/daemon.json";
+const DEFAULT_ADDRESS_POOLS = [
+  { base: "10.0.0.0/8", size: 24 },
+  { base: "172.17.0.0/12", size: 24 },
+  { base: "192.168.0.0/16", size: 24 },
+];
+
+function readDaemonConfig(): Record<string, unknown> {
+  if (!existsSync(DAEMON_JSON)) return {};
+  try {
+    return JSON.parse(readFileSync(DAEMON_JSON, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+export async function ensureDockerNetworkConfig(): Promise<boolean> {
+  const config = readDaemonConfig();
+  if (config["default-address-pools"]) return false;
+
+  config["default-address-pools"] = DEFAULT_ADDRESS_POOLS;
+  writeFileSync(DAEMON_JSON, JSON.stringify(config, null, 2));
+  await execAsync("systemctl restart docker");
+  return true;
+}

--- a/install.sh
+++ b/install.sh
@@ -72,11 +72,11 @@ echo ""
 timer "Installing dependencies..."
 
 # Install build tools if not present
-if ! command -v git &> /dev/null || ! command -v unzip &> /dev/null; then
+if ! command -v git &> /dev/null || ! command -v unzip &> /dev/null || ! command -v jq &> /dev/null; then
   timer "apt-get update..."
   apt-get update -qq
   timer "apt-get install build tools..."
-  apt-get install -y -qq git unzip build-essential > /dev/null
+  apt-get install -y -qq git unzip build-essential jq > /dev/null
 else
   timer "Build tools already installed"
 fi
@@ -89,6 +89,25 @@ if ! command -v docker &> /dev/null; then
   systemctl start docker
 else
   timer "Docker already installed"
+fi
+
+# Configure Docker network pools for more networks (~70k instead of ~31)
+DOCKER_POOLS='[{"base":"10.0.0.0/8","size":24},{"base":"172.17.0.0/12","size":24},{"base":"192.168.0.0/16","size":24}]'
+DAEMON_JSON="/etc/docker/daemon.json"
+
+if [ -f "$DAEMON_JSON" ] && grep -q "default-address-pools" "$DAEMON_JSON"; then
+  timer "Docker network pools already configured"
+else
+  if [ -f "$DAEMON_JSON" ]; then
+    timer "Updating Docker daemon config..."
+    jq --argjson pools "$DOCKER_POOLS" '. + {"default-address-pools": $pools}' "$DAEMON_JSON" > "$DAEMON_JSON.tmp"
+    mv "$DAEMON_JSON.tmp" "$DAEMON_JSON"
+  else
+    timer "Creating Docker daemon config..."
+    echo "{\"default-address-pools\": $DOCKER_POOLS}" | jq '.' > "$DAEMON_JSON"
+  fi
+  timer "Restarting Docker to apply network config..."
+  systemctl restart docker
 fi
 
 # Install Go if not present (needed for xcaddy)


### PR DESCRIPTION
## Summary
- Configure Docker daemon to use `/24` subnets from all private ranges
- Supports ~70k networks (vs ~31 default) with 254 IPs per network
- Fresh installs: configured via `install.sh`
- Existing installs: configured via `update.sh` or on Frost restart

Fixes #260

## Test plan
- [ ] Fresh install on clean VM, verify `/etc/docker/daemon.json` has `default-address-pools`
- [ ] Update existing install, verify config gets added
- [ ] Restart Frost on unconfigured server, verify config gets added
- [ ] Create 50+ projects, verify no network errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)