### PR TITLE
refactor: consolidate cleanup logic into lifecycle module

### DIFF
--- a/apps/app/src/lib/lifecycle.ts
+++ b/apps/app/src/lib/lifecycle.ts
@@ -1,0 +1,107 @@
+import { db } from "./db";
+import { removeNetwork, stopContainer } from "./docker";
+import { syncCaddyConfig } from "./domains";
+import { removeSSLCerts } from "./ssl";
+import { buildVolumeName, removeVolume } from "./volumes";
+
+interface ServiceForCleanup {
+  id: string;
+  serviceType: string;
+  volumes: string | null;
+}
+
+async function cleanupServiceResources(
+  service: ServiceForCleanup,
+): Promise<void> {
+  if (service.volumes && service.volumes !== "[]") {
+    const volumeConfig = JSON.parse(service.volumes) as {
+      name: string;
+      path: string;
+    }[];
+    for (const v of volumeConfig) {
+      await removeVolume(buildVolumeName(service.id, v.name));
+    }
+  }
+
+  if (service.serviceType === "database") {
+    await removeSSLCerts(service.id);
+  }
+}
+
+async function stopServiceContainers(serviceId: string): Promise<void> {
+  const deployments = await db
+    .selectFrom("deployments")
+    .select("containerId")
+    .where("serviceId", "=", serviceId)
+    .execute();
+
+  for (const deployment of deployments) {
+    if (deployment.containerId) {
+      await stopContainer(deployment.containerId);
+    }
+  }
+}
+
+export async function cleanupService(serviceId: string): Promise<void> {
+  const service = await db
+    .selectFrom("services")
+    .select(["id", "serviceType", "volumes"])
+    .where("id", "=", serviceId)
+    .executeTakeFirst();
+
+  if (!service) return;
+
+  await stopServiceContainers(serviceId);
+  await cleanupServiceResources(service);
+}
+
+export async function cleanupEnvironment(
+  environment: { id: string; projectId: string },
+  options: { syncCaddy?: boolean } = {},
+): Promise<void> {
+  const { syncCaddy = true } = options;
+
+  const services = await db
+    .selectFrom("services")
+    .select(["id", "serviceType", "volumes"])
+    .where("environmentId", "=", environment.id)
+    .execute();
+
+  for (const service of services) {
+    await stopServiceContainers(service.id);
+    await cleanupServiceResources(service);
+  }
+
+  await removeNetwork(
+    `frost-net-${environment.projectId}-${environment.id}`.toLowerCase(),
+  );
+
+  await db
+    .deleteFrom("environments")
+    .where("id", "=", environment.id)
+    .execute();
+
+  if (syncCaddy) {
+    try {
+      await syncCaddyConfig();
+    } catch {}
+  }
+}
+
+export async function cleanupProject(projectId: string): Promise<void> {
+  const environments = await db
+    .selectFrom("environments")
+    .select(["id", "projectId"])
+    .where("projectId", "=", projectId)
+    .execute();
+
+  for (const env of environments) {
+    await cleanupEnvironment(env, { syncCaddy: false });
+  }
+
+  await db.deleteFrom("projects").where("id", "=", projectId).execute();
+
+  try {
+    await syncCaddyConfig();
+  } catch {}
+}

--- a/apps/app/src/server/environments.ts
+++ b/apps/app/src/server/environments.ts
@@ -2,9 +2,9 @@ import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
 import { db } from "@/lib/db";
 import { deployEnvironment } from "@/lib/deployer";
+import { cleanupEnvironment } from "@/lib/lifecycle";
 import { createService } from "@/lib/services";
 import { slugify } from "@/lib/slugify";
-import { cleanupEnvironment } from "@/lib/webhook";
 import { os } from "./orpc";
 
 export const environments = {


### PR DESCRIPTION
## Summary

- Add `lib/lifecycle.ts` with centralized cleanup functions
- Consolidate all resource cleanup (containers, volumes, SSL certs, networks, Caddy) into single source of truth
- Simplify delete handlers in services, environments, and projects

## Changes

| Function | What it cleans up |
|----------|------------------|
| `cleanupService` | containers, volumes, SSL certs |
| `cleanupEnvironment` | services + network + DB + Caddy sync |
| `cleanupProject` | environments + DB + Caddy sync |

## Why

Previously cleanup logic was duplicated across multiple files and some resources weren't being cleaned up properly (volumes, SSL certs for databases). This refactor ensures consistent cleanup regardless of delete entry point.

Closes #261

## Test plan

- [ ] Delete a service with volumes → verify volumes removed (`docker volume ls`)
- [ ] Delete a database service → verify SSL dir removed (`ls data/ssl/`)
- [ ] Delete an environment → verify network removed (`docker network ls`)
- [ ] Delete a project → verify all resources cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)