### PR TITLE
feat: add .frost.internal suffix for internal service discovery

### DIFF
--- a/apps/app/src/app/projects/[id]/_components/sidebar-overview.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-overview.tsx
@@ -245,7 +245,7 @@ export function SidebarOverview({ service }: SidebarOverviewProps) {
                 <code className="flex-1 rounded bg-neutral-900 px-3 py-2 font-mono text-xs text-neutral-300 overflow-auto">
                   {buildConnectionString(
                     service.imageUrl?.split(":")[0] ?? "",
-                    service.name,
+                    `${service.hostname ?? service.name}.frost.internal`,
                     service.containerPort ?? 5432,
                     JSON.parse(service.envVars || "[]").reduce(
                       (acc: Record<string, string>, v: EnvVar) => {
@@ -263,7 +263,7 @@ export function SidebarOverview({ service }: SidebarOverviewProps) {
                     navigator.clipboard.writeText(
                       buildConnectionString(
                         service.imageUrl?.split(":")[0] ?? "",
-                        service.name,
+                        `${service.hostname ?? service.name}.frost.internal`,
                         service.containerPort ?? 5432,
                         JSON.parse(service.envVars || "[]").reduce(
                           (acc: Record<string, string>, v: EnvVar) => {

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/_components/domains-section.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/_components/domains-section.tsx
@@ -444,20 +444,23 @@ export function DomainsSection({
 
         {domains && domains.length === 0 && !showAddForm && (
           <div className="text-sm text-neutral-500">
-            <p>No domains configured.</p>
-            {!wildcardConfigured && (
-              <p className="mt-2">
-                Configure a{" "}
-                <a
-                  href="/settings/domain"
-                  className="text-blue-400 hover:underline"
-                >
-                  wildcard domain
-                </a>{" "}
-                in settings for auto-generated URLs, or add a custom domain
-                below.
-              </p>
-            )}
+            <p>No external domains configured.</p>
+            <p className="mt-2">
+              Add a domain above to make this service publicly accessible.
+              {!wildcardConfigured && (
+                <>
+                  {" "}
+                  Or configure a{" "}
+                  <a
+                    href="/settings/domain"
+                    className="text-blue-400 hover:underline"
+                  >
+                    wildcard domain
+                  </a>{" "}
+                  for auto-generated URLs.
+                </>
+              )}
+            </p>
           </div>
         )}
       </CardContent>

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/hostname-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/hostname-card.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { Copy, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   useDeployService,
   useService,
@@ -83,13 +82,40 @@ export function HostnameCard({ serviceId }: HostnameCardProps) {
         </Button>
       }
     >
-      <Input
-        value={hostname}
-        onChange={(e) => setHostname(e.target.value.toLowerCase())}
-        placeholder="my-service"
-        pattern="^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
-        className="font-mono"
-      />
+      <div className="space-y-4">
+        <div className="flex items-center rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 focus-within:ring-1 focus-within:ring-neutral-500">
+          <div className="inline-flex items-center font-mono text-sm">
+            <input
+              value={hostname}
+              onChange={(e) => setHostname(e.target.value.toLowerCase())}
+              placeholder="<hostname>"
+              size={Math.max(hostname.length, 10) + 1}
+              className="bg-transparent text-neutral-100 placeholder:text-neutral-500 focus:outline-none border-b border-dashed border-neutral-600 focus:border-neutral-400"
+            />
+            <span className="text-neutral-500">.frost.internal</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <code className="text-sm text-neutral-500 font-mono">
+            {hostname || "<hostname>"}.frost.internal:
+            {service.containerPort ?? 8080}
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 text-neutral-500 hover:text-neutral-300"
+            onClick={() => {
+              navigator.clipboard.writeText(
+                `${hostname}.frost.internal:${service.containerPort ?? 8080}`,
+              );
+              toast.success("Copied to clipboard");
+            }}
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
     </SettingCard>
   );
 }

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -722,6 +722,7 @@ async function runServiceDeployment(
     );
     const runtimeEnvVars = { ...frostEnvVars, ...envVars };
 
+    const internalHostname = service.hostname ?? slugify(service.name);
     const { containerId, hostPort } = await runContainerWithPortRetry(
       {
         imageName,
@@ -729,8 +730,8 @@ async function runServiceDeployment(
         name: containerName,
         envVars: runtimeEnvVars,
         network: networkName,
-        hostname: service.hostname ?? slugify(service.name),
-        networkAlias: service.hostname ?? slugify(service.name),
+        hostname: internalHostname,
+        networkAlias: `${internalHostname}.frost.internal`,
         labels: {
           ...baseLabels,
           "frost.deployment.id": deploymentId,
@@ -1085,6 +1086,7 @@ async function runRollbackDeployment(
       throw new Error("Source deployment has no image");
     }
 
+    const internalHostname = service.hostname ?? slugify(service.name);
     const { containerId, hostPort } = await runContainerWithPortRetry(
       {
         imageName: sourceDeployment.imageName,
@@ -1092,8 +1094,8 @@ async function runRollbackDeployment(
         name: containerName,
         envVars: runtimeEnvVars,
         network: networkName,
-        hostname: service.hostname ?? slugify(service.name),
-        networkAlias: service.hostname ?? slugify(service.name),
+        hostname: internalHostname,
+        networkAlias: `${internalHostname}.frost.internal`,
         labels: {
           ...baseLabels,
           "frost.deployment.id": deploymentId,

--- a/apps/app/src/lib/docker-config.ts
+++ b/apps/app/src/lib/docker-config.ts
@@ -21,6 +21,8 @@ function readDaemonConfig(): Record<string, unknown> {
 }
 
 export async function ensureDockerNetworkConfig(): Promise<boolean> {
+  if (process.platform !== "linux") return false;
+
   const config = readDaemonConfig();
   if (config["default-address-pools"]) return false;
 


### PR DESCRIPTION
## Summary

- Containers now use `{hostname}.frost.internal` as network alias
- Hostname card shows full internal URL with Vercel-style inline editing
- Connection strings updated to use `.frost.internal` format
- Skip docker network config on non-Linux (fixes macOS dev)

**BREAKING**: Services must use `{name}.frost.internal` instead of bare hostname

## Test plan

- [ ] Deploy a service
- [ ] Verify container has `.frost.internal` alias: `docker inspect frost-{serviceId}`
- [ ] Test connectivity from another service using `{name}.frost.internal`
- [ ] Verify hostname card shows full URL with copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)