### PR TITLE
fix: disable unattended-upgrades in CI snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,10 @@ jobs:
         include:
           - arch: arm64
             server_type: cax21
-            snapshot_id: "349804713"
+            snapshot_id: "352742445"
           - arch: amd64
             server_type: cx23
-            snapshot_id: "349804999"
+            snapshot_id: "352743140"
 
     name: e2e-vps (${{ matrix.arch }})
 
@@ -264,10 +264,10 @@ jobs:
         include:
           - arch: arm64
             server_type: cax21
-            snapshot_id: "349804713"
+            snapshot_id: "352742445"
           - arch: amd64
             server_type: cx23
-            snapshot_id: "349804999"
+            snapshot_id: "352743140"
 
     name: e2e-upgrade (${{ matrix.arch }})
 

--- a/apps/app/scripts/create-e2e-snapshot.sh
+++ b/apps/app/scripts/create-e2e-snapshot.sh
@@ -3,6 +3,7 @@ set -e
 
 HETZNER_TOKEN="${HETZNER_API_KEY:?HETZNER_API_KEY required}"
 SSH_KEY_NAME="${SSH_KEY_NAME:-frost-e2e-ci}"
+SSH_KEY_FILE="${SSH_KEY_FILE:-$HOME/.ssh/frost-e2e-ci}"
 
 usage() {
   echo "Usage: $0 <arch>"
@@ -43,13 +44,15 @@ echo "Waiting for server to be ready..."
 sleep 60
 
 echo "Setting up server..."
-ssh -o StrictHostKeyChecking=no root@$SERVER_IP bash << 'SETUP'
+ssh -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no root@$SERVER_IP bash << 'SETUP'
 set -e
 apt-get update
 apt-get install -y docker.io git curl unzip
 
 systemctl enable docker
 systemctl start docker
+
+systemctl disable --now apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
 
 echo "Installing Bun..."
 curl -fsSL https://bun.sh/install | bash


### PR DESCRIPTION
## Summary
- Disable apt-daily and unattended-upgrades services in CI snapshot creation
- Update snapshot IDs (arm64: 352742445, amd64: 352743140)
- Add SSH key file parameter for local snapshot creation

## Problem
Fresh Ubuntu 24.04 VMs run `unattended-upgrades` on boot, holding the dpkg lock. This causes race conditions where CI install fails because apt is locked.

## Test plan
- [ ] CI e2e tests pass without apt lock errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)