### PR TITLE
test: verify Caddy pre-built binary speedup in e2e-upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ else
   systemctl restart docker
 fi
 
-# Install Caddy with DNS modules if missing
+# Install Caddy with DNS modules if missing (pinned; update when upgrading Caddy)
 CADDY_VERSION="v2.10.2"
 
 if ! caddy list-modules 2>/dev/null | grep -q "dns.providers.cloudflare"; then

--- a/update.sh
+++ b/update.sh
@@ -109,7 +109,7 @@ curl -fsSL https://bun.sh/install 2>/dev/null | bash > /dev/null 2>&1 || true
 
 mkdir -p /usr/local/bin
 
-# Rebuild Caddy if DNS modules missing (fixes apt-installed Caddy)
+# Install Caddy with DNS modules if missing (pinned; update when upgrading Caddy)
 CADDY_VERSION="v2.10.2"
 
 if ! caddy list-modules 2>/dev/null | grep -q "dns.providers.cloudflare"; then


### PR DESCRIPTION
## Summary
- Trivial change to trigger CI and verify e2e-upgrade timing with v0.12.0 (which includes pre-built Caddy binary)
- Previous e2e-upgrade (amd64): ~31 min
- Expected: significantly faster install step

## Test plan
- [ ] Compare e2e-upgrade install times vs previous PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)