### PR TITLE
feat: auto-update scheduler

### DIFF
--- a/apps/app/src/app/settings/_components/auto-update-card.tsx
+++ b/apps/app/src/app/settings/_components/auto-update-card.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { SettingCard } from "@/components/setting-card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { orpc } from "@/lib/orpc-client";
+
+function utcToLocalHour(utcHour: number): number {
+  const d = new Date();
+  d.setUTCHours(utcHour, 0, 0, 0);
+  return d.getHours();
+}
+
+function localToUtcHour(localHour: number): number {
+  const d = new Date();
+  d.setHours(localHour, 0, 0, 0);
+  return d.getUTCHours();
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+
+function formatHour(hour: number): string {
+  const period = hour >= 12 ? "PM" : "AM";
+  const h = hour % 12 || 12;
+  return `${h}:00 ${period}`;
+}
+
+export function AutoUpdateCard() {
+  const queryClient = useQueryClient();
+  const { data } = useQuery(orpc.updates.getAutoUpdate.queryOptions());
+
+  const mutation = useMutation(
+    orpc.updates.updateAutoUpdate.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.refetchQueries({
+          queryKey: orpc.updates.getAutoUpdate.key(),
+        });
+      },
+    }),
+  );
+
+  const enabled = data?.enabled ?? true;
+  const utcHour = data?.hour ?? 4;
+  const localHour = utcToLocalHour(utcHour);
+
+  function handleToggle(checked: boolean) {
+    mutation.mutate({ enabled: checked });
+  }
+
+  function handleHourChange(value: string) {
+    const newLocalHour = Number.parseInt(value, 10);
+    mutation.mutate({ hour: localToUtcHour(newLocalHour) });
+  }
+
+  return (
+    <SettingCard
+      title="Auto Update"
+      description="Automatically check for and apply updates daily at a scheduled time."
+    >
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <label
+            htmlFor="auto-update-toggle"
+            className="text-sm text-neutral-300"
+          >
+            Enable auto updates
+          </label>
+          <Switch
+            id="auto-update-toggle"
+            checked={enabled}
+            onCheckedChange={handleToggle}
+          />
+        </div>
+
+        {enabled && (
+          <div className="flex items-center justify-between">
+            <label
+              htmlFor="auto-update-hour"
+              className="text-sm text-neutral-300"
+            >
+              Update hour
+            </label>
+            <Select
+              value={localHour.toString()}
+              onValueChange={handleHourChange}
+            >
+              <SelectTrigger id="auto-update-hour" className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HOURS.map((h) => (
+                  <SelectItem key={h} value={h.toString()}>
+                    {formatHour(h)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+    </SettingCard>
+  );
+}

--- a/apps/app/src/app/settings/page.tsx
+++ b/apps/app/src/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import { AutoUpdateCard } from "./_components/auto-update-card";
 import { GeneralSection } from "./_components/general-section";
 import { SessionSection } from "./_components/session-section";
 import { SystemSection } from "./_components/system-section";
@@ -7,6 +8,7 @@ export default function SettingsPage() {
     <div className="space-y-6">
       <GeneralSection />
       <SystemSection />
+      <AutoUpdateCard />
       <SessionSection />
     </div>
   );

--- a/apps/app/src/contracts/updates.ts
+++ b/apps/app/src/contracts/updates.ts
@@ -33,4 +33,18 @@ export const updatesContract = {
   clearResult: oc
     .route({ method: "DELETE", path: "/updates/result" })
     .output(z.object({ success: z.boolean() })),
+
+  getAutoUpdate: oc
+    .route({ method: "GET", path: "/updates/auto" })
+    .output(z.object({ enabled: z.boolean(), hour: z.number() })),
+
+  updateAutoUpdate: oc
+    .route({ method: "POST", path: "/updates/auto" })
+    .input(
+      z.object({
+        enabled: z.boolean().optional(),
+        hour: z.number().min(0).max(23).optional(),
+      }),
+    )
+    .output(z.object({ enabled: z.boolean(), hour: z.number() })),
 };

--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -26,6 +26,10 @@ export async function register() {
     startCleanupScheduler();
     console.log("[startup] cleanup scheduler: started");
 
+    const { startUpdateScheduler } = await import("./lib/update-scheduler");
+    startUpdateScheduler();
+    console.log("[startup] update scheduler: started");
+
     const { syncCaddyConfig } = await import("./lib/domains");
     try {
       const result = await syncCaddyConfig();

--- a/apps/app/src/lib/update-scheduler.ts
+++ b/apps/app/src/lib/update-scheduler.ts
@@ -1,0 +1,57 @@
+import { getSetting, setSetting } from "./auth";
+import { applyUpdate, checkForUpdate } from "./updater";
+
+const CHECK_INTERVAL_MS = 60 * 1000;
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let lastUpdateDate: string | null = null;
+
+async function checkAndRun(): Promise<void> {
+  try {
+    const enabled = await getSetting("auto_update_enabled");
+    if (enabled === "false") return;
+
+    const now = new Date();
+    const today = now.toISOString().split("T")[0];
+
+    if (lastUpdateDate === today) return;
+
+    const hourStr = await getSetting("auto_update_hour");
+    const hour = hourStr ? Number.parseInt(hourStr, 10) : 4;
+
+    if (now.getUTCHours() !== hour) return;
+
+    lastUpdateDate = today;
+    await setSetting("auto_update_last_run", today);
+
+    console.log("[update-scheduler] Checking for updates...");
+    const info = await checkForUpdate(true);
+    if (!info?.availableVersion) {
+      console.log("[update-scheduler] No update available");
+      return;
+    }
+
+    console.log(
+      `[update-scheduler] Applying update to v${info.availableVersion}`,
+    );
+    const result = await applyUpdate();
+    if (!result.success) {
+      console.error("[update-scheduler] Failed to apply update:", result.error);
+    }
+  } catch (err) {
+    console.error("[update-scheduler] Error:", err);
+  }
+}
+
+export function startUpdateScheduler(): void {
+  if (intervalId) return;
+  intervalId = setInterval(checkAndRun, CHECK_INTERVAL_MS);
+  console.log("[update-scheduler] Started");
+}
+
+export function stopUpdateScheduler(): void {
+  if (!intervalId) return;
+  clearInterval(intervalId);
+  intervalId = null;
+  console.log("[update-scheduler] Stopped");
+}


### PR DESCRIPTION
## Summary
- Background scheduler checks daily at a configurable UTC hour and auto-applies updates
- New Settings UI card with enable/disable toggle and local-timezone hour picker
- API endpoints: `GET /updates/auto` and `POST /updates/auto`

Closes #124

## Test plan
- [ ] Toggle auto-update on/off in Settings, verify persists on refresh
- [ ] Change hour, verify UTC conversion correct
- [ ] Check startup logs for `[update-scheduler] Started`
- [ ] Verify scheduler only runs once per day (in-memory guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)