### PR TITLE
feat: add change password setting

### DIFF
--- a/apps/app/scripts/e2e/group-23-change-password.sh
+++ b/apps/app/scripts/e2e/group-23-change-password.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-e2eTestPassword123}"
+NEW_PASSWORD="newE2ePassword456"
+
+log "=== Change password ==="
+
+# wrong current password → error
+log "Attempting change with wrong password..."
+RESULT=$(api -X PUT "$BASE_URL/api/settings/password" \
+  -d '{"currentPassword":"wrong-password-here","newPassword":"something"}')
+ERROR=$(json_get "$RESULT" '.message // .error // empty')
+if [ -z "$ERROR" ]; then
+  fail "Expected error for wrong current password, got: $RESULT"
+fi
+log "Wrong password correctly rejected"
+
+# too-short new password → error (zod validation, min 4)
+log "Attempting change with too-short new password..."
+RESULT=$(api -X PUT "$BASE_URL/api/settings/password" \
+  -d "{\"currentPassword\":\"$ADMIN_PASSWORD\",\"newPassword\":\"ab\"}")
+ERROR=$(json_get "$RESULT" '.message // .error // empty')
+if [ -z "$ERROR" ]; then
+  fail "Expected error for short password, got: $RESULT"
+fi
+log "Short password correctly rejected"
+
+# correct change
+log "Changing password..."
+RESULT=$(api -X PUT "$BASE_URL/api/settings/password" \
+  -d "{\"currentPassword\":\"$ADMIN_PASSWORD\",\"newPassword\":\"$NEW_PASSWORD\"}")
+SUCCESS=$(json_get "$RESULT" '.success // empty')
+if [ "$SUCCESS" != "true" ]; then
+  fail "Password change failed: $RESULT"
+fi
+log "Password changed successfully"
+
+# verify login with new password
+log "Verifying login with new password..."
+LOGIN_RESULT=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"password\":\"$NEW_PASSWORD\"}")
+SUCCESS=$(echo "$LOGIN_RESULT" | jq -r '.success // empty')
+if [ "$SUCCESS" != "true" ]; then
+  fail "Login with new password failed: $LOGIN_RESULT"
+fi
+log "Login with new password works"
+
+# verify old password no longer works
+log "Verifying old password is rejected on login..."
+LOGIN_RESULT=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"password\":\"$ADMIN_PASSWORD\"}")
+ERROR=$(echo "$LOGIN_RESULT" | jq -r '.error // empty')
+if [ -z "$ERROR" ]; then
+  fail "Old password should not work anymore: $LOGIN_RESULT"
+fi
+log "Old password correctly rejected"
+
+# restore original password
+log "Restoring original password..."
+RESULT=$(api -X PUT "$BASE_URL/api/settings/password" \
+  -d "{\"currentPassword\":\"$NEW_PASSWORD\",\"newPassword\":\"$ADMIN_PASSWORD\"}")
+SUCCESS=$(json_get "$RESULT" '.success // empty')
+if [ "$SUCCESS" != "true" ]; then
+  fail "Failed to restore password: $RESULT"
+fi
+log "Password restored"
+
+pass

--- a/apps/app/src/app/settings/_components/password-section.tsx
+++ b/apps/app/src/app/settings/_components/password-section.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { SettingCard } from "@/components/setting-card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { orpc } from "@/lib/orpc-client";
+
+export function PasswordSection() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+
+  const mutation = useMutation(
+    orpc.settings.changePassword.mutationOptions({
+      onSuccess() {
+        toast.success("Password updated");
+        setCurrentPassword("");
+        setNewPassword("");
+      },
+      onError(error) {
+        toast.error(error.message || "Failed to update password");
+      },
+    }),
+  );
+
+  function handleSave() {
+    if (newPassword.length < 4) {
+      toast.error("New password must be at least 4 characters");
+      return;
+    }
+    mutation.mutate({ currentPassword, newPassword });
+  }
+
+  return (
+    <SettingCard
+      title="Password"
+      description="Change your login password."
+      footerRight={
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={mutation.isPending || !currentPassword || !newPassword}
+        >
+          {mutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            "Save"
+          )}
+        </Button>
+      }
+    >
+      <div className="space-y-3">
+        <Input
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          placeholder="Current password"
+        />
+        <Input
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          placeholder="New password"
+        />
+      </div>
+    </SettingCard>
+  );
+}

--- a/apps/app/src/app/settings/page.tsx
+++ b/apps/app/src/app/settings/page.tsx
@@ -1,5 +1,6 @@
 import { AutoUpdateCard } from "./_components/auto-update-card";
 import { GeneralSection } from "./_components/general-section";
+import { PasswordSection } from "./_components/password-section";
 import { SessionSection } from "./_components/session-section";
 import { SystemSection } from "./_components/system-section";
 
@@ -9,6 +10,7 @@ export default function SettingsPage() {
       <GeneralSection />
       <SystemSection />
       <AutoUpdateCard />
+      <PasswordSection />
       <SessionSection />
     </div>
   );

--- a/apps/app/src/contracts/settings.ts
+++ b/apps/app/src/contracts/settings.ts
@@ -92,6 +92,16 @@ export const settingsContract = {
       .output(z.object({ success: z.boolean() })),
   },
 
+  changePassword: oc
+    .route({ method: "PUT", path: "/settings/password" })
+    .input(
+      z.object({
+        currentPassword: z.string(),
+        newPassword: z.string().min(4),
+      }),
+    )
+    .output(z.object({ success: z.boolean() })),
+
   wildcard: {
     get: oc.route({ method: "GET", path: "/settings/wildcard" }).output(
       z.object({


### PR DESCRIPTION
## Summary
- Add `PUT /settings/password` API endpoint to change the admin login password
- Verify current password before allowing change, require ≥ 4 chars for new password
- New `PasswordSection` component on `/settings` page with current/new password inputs

## Test plan
- [ ] Go to `/settings`, verify Password card appears
- [ ] Enter wrong current password → error toast
- [ ] Enter correct current password + new password (≥ 4 chars) → success toast, fields clear
- [ ] Sign out, sign in with new password → works
- [ ] Sign in with old password → fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)