### PR TITLE
feat: replica support for services (#246)

### DIFF
--- a/apps/app/schema/008-replicas.sql
+++ b/apps/app/schema/008-replicas.sql
@@ -1,0 +1,12 @@
+ALTER TABLE services ADD COLUMN replica_count INTEGER NOT NULL DEFAULT 1;
+
+CREATE TABLE replicas (
+    id TEXT PRIMARY KEY,
+    deployment_id TEXT NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
+    replica_index INTEGER NOT NULL,
+    container_id TEXT,
+    host_port INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT (strftime('%s','now') * 1000),
+    UNIQUE(deployment_id, replica_index)
+);

--- a/apps/app/scripts/e2e/group-26-replicas.sh
+++ b/apps/app/scripts/e2e/group-26-replicas.sh
@@ -16,7 +16,7 @@ ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environme
 log "Test 1: Default single replica"
 
 SERVICE=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
-  -d '{"name":"replica-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
+  -d '{"name":"replica-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"drainTimeout":0}')
 SERVICE_ID=$(require_field "$SERVICE" '.id' "create service") || fail "Failed to create service: $SERVICE"
 
 sleep 1
@@ -68,7 +68,7 @@ for i in 0 1 2; do
 done
 
 SANITIZED_PREFIX=$(sanitize_name "frost-${SERVICE_ID}")
-sleep 3
+sleep 5
 DOCKER_COUNT=$(remote "docker ps --filter name=${SANITIZED_PREFIX} --format '{{.Names}}' | wc -l" | tr -d ' ')
 [ "$DOCKER_COUNT" = "3" ] || fail "Expected 3 docker containers, got $DOCKER_COUNT"
 log "Test 2 passed: 3 replicas running"

--- a/apps/app/scripts/e2e/group-26-replicas.sh
+++ b/apps/app/scripts/e2e/group-26-replicas.sh
@@ -68,6 +68,7 @@ for i in 0 1 2; do
 done
 
 SANITIZED_PREFIX=$(sanitize_name "frost-${SERVICE_ID}")
+sleep 3
 DOCKER_COUNT=$(remote "docker ps --filter name=${SANITIZED_PREFIX} --format '{{.Names}}' | wc -l" | tr -d ' ')
 [ "$DOCKER_COUNT" = "3" ] || fail "Expected 3 docker containers, got $DOCKER_COUNT"
 log "Test 2 passed: 3 replicas running"

--- a/apps/app/scripts/e2e/group-26-replicas.sh
+++ b/apps/app/scripts/e2e/group-26-replicas.sh
@@ -67,7 +67,8 @@ for i in 0 1 2; do
   curl -sf "http://$SERVER_IP:$PORT" > /dev/null || fail "Replica $i not responding on port $PORT"
 done
 
-DOCKER_COUNT=$(remote "docker ps --filter name=frost-${SERVICE_ID} --format '{{.Names}}' | wc -l" | tr -d ' ')
+SANITIZED_PREFIX=$(sanitize_name "frost-${SERVICE_ID}")
+DOCKER_COUNT=$(remote "docker ps --filter name=${SANITIZED_PREFIX} --format '{{.Names}}' | wc -l" | tr -d ' ')
 [ "$DOCKER_COUNT" = "3" ] || fail "Expected 3 docker containers, got $DOCKER_COUNT"
 log "Test 2 passed: 3 replicas running"
 
@@ -89,7 +90,7 @@ for i in 0 1 2; do
 done
 
 sleep 2
-DOCKER_COUNT=$(remote "docker ps --filter name=frost-${SERVICE_ID} --format '{{.Names}}' | wc -l" | tr -d ' ')
+DOCKER_COUNT=$(remote "docker ps --filter name=${SANITIZED_PREFIX} --format '{{.Names}}' | wc -l" | tr -d ' ')
 [ "$DOCKER_COUNT" = "3" ] || fail "Expected 3 containers after redeploy (not 6), got $DOCKER_COUNT"
 log "Test 3 passed: redeploy preserved 3 replicas, old ones stopped"
 
@@ -106,7 +107,7 @@ REPLICA_COUNT4=$(echo "$REPLICAS4" | jq 'length')
 [ "$REPLICA_COUNT4" = "1" ] || fail "Expected 1 replica after scale-down, got $REPLICA_COUNT4"
 
 sleep 2
-DOCKER_COUNT=$(remote "docker ps --filter name=frost-${SERVICE_ID} --format '{{.Names}}' | wc -l" | tr -d ' ')
+DOCKER_COUNT=$(remote "docker ps --filter name=${SANITIZED_PREFIX} --format '{{.Names}}' | wc -l" | tr -d ' ')
 [ "$DOCKER_COUNT" = "1" ] || fail "Expected 1 container after scale-down, got $DOCKER_COUNT"
 log "Test 4 passed: scaled down to 1 replica"
 

--- a/apps/app/scripts/e2e/group-26-replicas.sh
+++ b/apps/app/scripts/e2e/group-26-replicas.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log "=== Replica support ==="
+
+log "Creating project..."
+PROJECT=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-replicas"}')
+PROJECT_ID=$(require_field "$PROJECT" '.id' "create project") || fail "Failed to create project: $PROJECT"
+
+log "Getting default environment..."
+ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environment"
+
+# --- Test 1: Default single replica (backward compat) ---
+log "Test 1: Default single replica"
+
+SERVICE=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
+  -d '{"name":"replica-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
+SERVICE_ID=$(require_field "$SERVICE" '.id' "create service") || fail "Failed to create service: $SERVICE"
+
+sleep 1
+DEPLOYMENTS=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments")
+DEPLOY_ID=$(json_get "$DEPLOYMENTS" '.[0].id // empty')
+if [ -z "$DEPLOY_ID" ] || [ "$DEPLOY_ID" = "null" ]; then
+  DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+  DEPLOY_ID=$(require_field "$DEPLOY" '.deploymentId' "trigger deploy") || fail "Failed: $DEPLOY"
+fi
+wait_for_deployment "$DEPLOY_ID" || fail "Default deployment failed"
+
+REPLICAS=$(api "$BASE_URL/api/deployments/$DEPLOY_ID/replicas")
+REPLICA_COUNT=$(echo "$REPLICAS" | jq 'length')
+[ "$REPLICA_COUNT" = "1" ] || fail "Expected 1 replica, got $REPLICA_COUNT"
+
+R0_STATUS=$(json_get "$REPLICAS" '.[0].status')
+R0_PORT=$(json_get "$REPLICAS" '.[0].hostPort')
+R0_CONTAINER=$(json_get "$REPLICAS" '.[0].containerId')
+[ "$R0_STATUS" = "running" ] || fail "Replica 0 status: $R0_STATUS"
+[ "$R0_PORT" != "null" ] && [ -n "$R0_PORT" ] || fail "Replica 0 missing hostPort"
+[ "$R0_CONTAINER" != "null" ] && [ -n "$R0_CONTAINER" ] || fail "Replica 0 missing containerId"
+
+curl -sf "http://$SERVER_IP:$R0_PORT" > /dev/null || fail "Replica 0 not responding on port $R0_PORT"
+log "Test 1 passed: single replica running on port $R0_PORT"
+
+# --- Test 2: Deploy with 3 replicas ---
+log "Test 2: Deploy with 3 replicas"
+
+api -X PATCH "$BASE_URL/api/services/$SERVICE_ID" -d '{"replicaCount":3}' > /dev/null
+DEPLOY2=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+DEPLOY2_ID=$(require_field "$DEPLOY2" '.deploymentId' "trigger deploy") || fail "Failed: $DEPLOY2"
+wait_for_deployment "$DEPLOY2_ID" || fail "3-replica deployment failed"
+
+REPLICAS2=$(api "$BASE_URL/api/deployments/$DEPLOY2_ID/replicas")
+REPLICA_COUNT2=$(echo "$REPLICAS2" | jq 'length')
+[ "$REPLICA_COUNT2" = "3" ] || fail "Expected 3 replicas, got $REPLICA_COUNT2"
+
+PORTS=$(echo "$REPLICAS2" | jq '[.[].hostPort] | unique | length')
+[ "$PORTS" = "3" ] || fail "Expected 3 unique ports, got $PORTS"
+
+CONTAINERS=$(echo "$REPLICAS2" | jq '[.[].containerId] | unique | length')
+[ "$CONTAINERS" = "3" ] || fail "Expected 3 unique containers, got $CONTAINERS"
+
+for i in 0 1 2; do
+  STATUS=$(json_get "$REPLICAS2" ".[$i].status")
+  PORT=$(json_get "$REPLICAS2" ".[$i].hostPort")
+  [ "$STATUS" = "running" ] || fail "Replica $i status: $STATUS"
+  curl -sf "http://$SERVER_IP:$PORT" > /dev/null || fail "Replica $i not responding on port $PORT"
+done
+
+DOCKER_COUNT=$(remote "docker ps --filter name=frost-${SERVICE_ID} --format '{{.Names}}' | wc -l" | tr -d ' ')
+[ "$DOCKER_COUNT" = "3" ] || fail "Expected 3 docker containers, got $DOCKER_COUNT"
+log "Test 2 passed: 3 replicas running"
+
+# --- Test 3: Redeploy preserves replica count ---
+log "Test 3: Redeploy preserves replica count"
+
+api -X PATCH "$BASE_URL/api/services/$SERVICE_ID" -d '{"imageUrl":"httpd:alpine","containerPort":80}' > /dev/null
+DEPLOY3=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+DEPLOY3_ID=$(require_field "$DEPLOY3" '.deploymentId' "trigger deploy") || fail "Failed: $DEPLOY3"
+wait_for_deployment "$DEPLOY3_ID" || fail "Redeploy failed"
+
+REPLICAS3=$(api "$BASE_URL/api/deployments/$DEPLOY3_ID/replicas")
+REPLICA_COUNT3=$(echo "$REPLICAS3" | jq 'length')
+[ "$REPLICA_COUNT3" = "3" ] || fail "Expected 3 replicas after redeploy, got $REPLICA_COUNT3"
+
+for i in 0 1 2; do
+  STATUS=$(json_get "$REPLICAS3" ".[$i].status")
+  [ "$STATUS" = "running" ] || fail "Replica $i after redeploy status: $STATUS"
+done
+
+sleep 2
+DOCKER_COUNT=$(remote "docker ps --filter name=frost-${SERVICE_ID} --format '{{.Names}}' | wc -l" | tr -d ' ')
+[ "$DOCKER_COUNT" = "3" ] || fail "Expected 3 containers after redeploy (not 6), got $DOCKER_COUNT"
+log "Test 3 passed: redeploy preserved 3 replicas, old ones stopped"
+
+# --- Test 4: Scale down to 1 ---
+log "Test 4: Scale down to 1"
+
+api -X PATCH "$BASE_URL/api/services/$SERVICE_ID" -d '{"replicaCount":1}' > /dev/null
+DEPLOY4=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+DEPLOY4_ID=$(require_field "$DEPLOY4" '.deploymentId' "trigger deploy") || fail "Failed: $DEPLOY4"
+wait_for_deployment "$DEPLOY4_ID" || fail "Scale-down deployment failed"
+
+REPLICAS4=$(api "$BASE_URL/api/deployments/$DEPLOY4_ID/replicas")
+REPLICA_COUNT4=$(echo "$REPLICAS4" | jq 'length')
+[ "$REPLICA_COUNT4" = "1" ] || fail "Expected 1 replica after scale-down, got $REPLICA_COUNT4"
+
+sleep 2
+DOCKER_COUNT=$(remote "docker ps --filter name=frost-${SERVICE_ID} --format '{{.Names}}' | wc -l" | tr -d ' ')
+[ "$DOCKER_COUNT" = "1" ] || fail "Expected 1 container after scale-down, got $DOCKER_COUNT"
+log "Test 4 passed: scaled down to 1 replica"
+
+# --- Test 5: Replicas blocked with volumes ---
+log "Test 5: Replicas blocked with volumes"
+
+SERVICE2=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
+  -d '{"name":"vol-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"volumes":[{"name":"data","mountPath":"/data"}]}')
+SERVICE2_ID=$(require_field "$SERVICE2" '.id' "create vol service") || fail "Failed: $SERVICE2"
+
+PATCH_RESULT=$(api -X PATCH "$BASE_URL/api/services/$SERVICE2_ID" -d '{"replicaCount":2}' 2>&1)
+if echo "$PATCH_RESULT" | grep -qi "error\|cannot\|volumes"; then
+  log "Test 5 passed: replicas blocked for volume service"
+else
+  fail "Expected error when setting replicas on volume service, got: $PATCH_RESULT"
+fi
+
+# --- Cleanup ---
+log "Cleanup..."
+api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
+
+pass

--- a/apps/app/scripts/e2e/group-27-replica-logs.sh
+++ b/apps/app/scripts/e2e/group-27-replica-logs.sh
@@ -12,18 +12,22 @@ PROJECT_ID=$(require_field "$PROJECT" '.id' "create project") || fail "Failed to
 log "Getting default environment..."
 ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environment"
 
-log "Creating service with 2 replicas..."
+log "Creating service..."
 SERVICE=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
-  -d '{"name":"log-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"replicaCount":2}')
+  -d '{"name":"log-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80}')
 SERVICE_ID=$(require_field "$SERVICE" '.id' "create service") || fail "Failed to create service: $SERVICE"
 
 sleep 1
 DEPLOYMENTS=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments")
-DEPLOY_ID=$(json_get "$DEPLOYMENTS" '.[0].id // empty')
-if [ -z "$DEPLOY_ID" ] || [ "$DEPLOY_ID" = "null" ]; then
-  DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
-  DEPLOY_ID=$(require_field "$DEPLOY" '.deploymentId' "trigger deploy") || fail "Failed: $DEPLOY"
+DEPLOY_INIT_ID=$(json_get "$DEPLOYMENTS" '.[0].id // empty')
+if [ -n "$DEPLOY_INIT_ID" ] && [ "$DEPLOY_INIT_ID" != "null" ]; then
+  wait_for_deployment "$DEPLOY_INIT_ID" || fail "Initial deployment failed"
 fi
+
+log "Setting replicaCount=2 and redeploying..."
+api -X PATCH "$BASE_URL/api/services/$SERVICE_ID" -d '{"replicaCount":2}' > /dev/null
+DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+DEPLOY_ID=$(require_field "$DEPLOY" '.deploymentId' "trigger deploy") || fail "Failed: $DEPLOY"
 wait_for_deployment "$DEPLOY_ID" || fail "Deployment failed"
 
 REPLICAS=$(api "$BASE_URL/api/deployments/$DEPLOY_ID/replicas")

--- a/apps/app/scripts/e2e/group-27-replica-logs.sh
+++ b/apps/app/scripts/e2e/group-27-replica-logs.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log "=== Replica logs ==="
+
+log "Creating project..."
+PROJECT=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-replica-logs"}')
+PROJECT_ID=$(require_field "$PROJECT" '.id' "create project") || fail "Failed to create project: $PROJECT"
+
+log "Getting default environment..."
+ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environment"
+
+log "Creating service with 2 replicas..."
+SERVICE=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
+  -d '{"name":"log-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"replicaCount":2}')
+SERVICE_ID=$(require_field "$SERVICE" '.id' "create service") || fail "Failed to create service: $SERVICE"
+
+sleep 1
+DEPLOYMENTS=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments")
+DEPLOY_ID=$(json_get "$DEPLOYMENTS" '.[0].id // empty')
+if [ -z "$DEPLOY_ID" ] || [ "$DEPLOY_ID" = "null" ]; then
+  DEPLOY=$(api -X POST "$BASE_URL/api/services/$SERVICE_ID/deploy")
+  DEPLOY_ID=$(require_field "$DEPLOY" '.deploymentId' "trigger deploy") || fail "Failed: $DEPLOY"
+fi
+wait_for_deployment "$DEPLOY_ID" || fail "Deployment failed"
+
+REPLICAS=$(api "$BASE_URL/api/deployments/$DEPLOY_ID/replicas")
+REPLICA_COUNT=$(echo "$REPLICAS" | jq 'length')
+[ "$REPLICA_COUNT" = "2" ] || fail "Expected 2 replicas, got $REPLICA_COUNT"
+
+# Hit each replica to generate access logs
+for i in 0 1; do
+  PORT=$(json_get "$REPLICAS" ".[$i].hostPort")
+  curl -sf "http://$SERVER_IP:$PORT/replica-log-test" > /dev/null 2>&1 || true
+done
+sleep 2
+
+# --- Test 1: Runtime logs stream from all replicas ---
+log "Test 1: Runtime logs from all replicas"
+
+LOG_OUTPUT=$(curl -sf --max-time 5 "http://$SERVER_IP:3000/api/deployments/$DEPLOY_ID/logs?tail=20" \
+  -H "X-Frost-Token: $API_KEY" 2>/dev/null || true)
+
+HAS_R0=$(echo "$LOG_OUTPUT" | grep -c '\[replica-0\]' || true)
+HAS_R1=$(echo "$LOG_OUTPUT" | grep -c '\[replica-1\]' || true)
+
+[ "$HAS_R0" -gt 0 ] || fail "No [replica-0] lines in merged logs"
+[ "$HAS_R1" -gt 0 ] || fail "No [replica-1] lines in merged logs"
+log "Test 1 passed: logs contain both [replica-0] and [replica-1]"
+
+# --- Test 2: Runtime logs filter by replica ---
+log "Test 2: Runtime logs filter by replica"
+
+LOG_FILTERED=$(curl -sf --max-time 5 "http://$SERVER_IP:3000/api/deployments/$DEPLOY_ID/logs?tail=20&replica=0" \
+  -H "X-Frost-Token: $API_KEY" 2>/dev/null || true)
+
+HAS_R1_FILTERED=$(echo "$LOG_FILTERED" | grep -c '\[replica-1\]' || true)
+[ "$HAS_R1_FILTERED" = "0" ] || fail "Filtered logs should not contain [replica-1], found $HAS_R1_FILTERED lines"
+log "Test 2 passed: filtered logs only show requested replica"
+
+# --- Cleanup ---
+log "Cleanup..."
+api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
+
+pass

--- a/apps/app/src/app/api/deployments/[id]/logs/route.ts
+++ b/apps/app/src/app/api/deployments/[id]/logs/route.ts
@@ -8,6 +8,7 @@ export async function GET(
   const { id } = await params;
   const url = new URL(request.url);
   const tail = parseInt(url.searchParams.get("tail") || "100", 10);
+  const replicaFilter = url.searchParams.get("replica");
 
   const deployment = await db
     .selectFrom("deployments")
@@ -15,49 +16,85 @@ export async function GET(
     .where("id", "=", id)
     .executeTakeFirst();
 
-  if (!deployment || !deployment.containerId) {
-    return new Response("Container not found", { status: 404 });
+  if (!deployment) {
+    return new Response("Deployment not found", { status: 404 });
   }
 
   if (deployment.status !== "running") {
     return new Response("Container not running", { status: 400 });
   }
 
+  const replicas = await db
+    .selectFrom("replicas")
+    .select(["containerId", "replicaIndex"])
+    .where("deploymentId", "=", id)
+    .where("status", "=", "running")
+    .where("containerId", "is not", null)
+    .orderBy("replicaIndex", "asc")
+    .execute();
+
+  type ReplicaContainer = { containerId: string; index: number };
+  let containers: ReplicaContainer[];
+
+  if (replicas.length > 0) {
+    containers = replicas
+      .filter(
+        (r): r is typeof r & { containerId: string } => r.containerId !== null,
+      )
+      .map((r) => ({ containerId: r.containerId, index: r.replicaIndex }));
+
+    if (replicaFilter !== null) {
+      const filterIdx = parseInt(replicaFilter, 10);
+      containers = containers.filter((c) => c.index === filterIdx);
+    }
+  } else if (deployment.containerId) {
+    containers = [{ containerId: deployment.containerId, index: 0 }];
+  } else {
+    return new Response("Container not found", { status: 404 });
+  }
+
+  if (containers.length === 0) {
+    return new Response("Replica not found", { status: 404 });
+  }
+
+  const multiReplica = replicas.length > 1 && replicaFilter === null;
   const encoder = new TextEncoder();
   let stopped = false;
-  let stopFn: (() => void) | null = null;
+  const stopFns: (() => void)[] = [];
 
   const stream = new ReadableStream({
     start(controller) {
-      const { stop } = streamContainerLogs(deployment.containerId!, {
-        tail,
-        timestamps: true,
-        onData(line) {
-          if (stopped) return;
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify(line)}\n\n`),
-          );
-        },
-        onError(err) {
-          if (stopped) return;
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ error: err.message })}\n\n`,
-            ),
-          );
-          controller.close();
-        },
-        onClose() {
-          if (stopped) return;
-          controller.close();
-        },
-      });
-
-      stopFn = stop;
+      for (const container of containers) {
+        const { stop } = streamContainerLogs(container.containerId, {
+          tail,
+          timestamps: true,
+          onData(line) {
+            if (stopped) return;
+            const prefixed = multiReplica
+              ? `[replica-${container.index}] ${line}`
+              : line;
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(prefixed)}\n\n`),
+            );
+          },
+          onError(err) {
+            if (stopped) return;
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ error: err.message })}\n\n`,
+              ),
+            );
+          },
+          onClose() {
+            if (stopped) return;
+          },
+        });
+        stopFns.push(stop);
+      }
 
       request.signal.addEventListener("abort", () => {
         stopped = true;
-        if (stopFn) stopFn();
+        for (const fn of stopFns) fn();
         try {
           controller.close();
         } catch {
@@ -67,7 +104,7 @@ export async function GET(
     },
     cancel() {
       stopped = true;
-      if (stopFn) stopFn();
+      for (const fn of stopFns) fn();
     },
   });
 

--- a/apps/app/src/app/projects/[id]/_components/service-content.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-content.tsx
@@ -31,7 +31,14 @@ export function ServiceContent({
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between">
             <p className="font-medium text-neutral-200">{service.name}</p>
-            <StatusDot status={deployment?.status || "pending"} />
+            <div className="flex items-center gap-1.5">
+              <StatusDot status={deployment?.status || "pending"} />
+              {(service.replicaCount ?? 1) > 1 && (
+                <span className="text-[10px] font-medium text-neutral-500">
+                  ×{service.replicaCount}
+                </span>
+              )}
+            </div>
           </div>
           {url && service.serviceType !== "database" && (
             <p className="text-xs text-neutral-500 truncate">{url}</p>

--- a/apps/app/src/app/projects/[id]/_components/service-node.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-node.tsx
@@ -26,21 +26,31 @@ export function ServiceNode({ data }: NodeProps<ServiceNodeType>) {
       ? `${serverIp}:${deployment.hostPort}`
       : null);
 
+  const replicaCount = service.replicaCount ?? 1;
+
   return (
     <>
       <Handle type="target" position={Position.Left} className="invisible" />
-      <Card
-        className={cn(
-          "w-64 cursor-pointer bg-neutral-900 border-neutral-800 transition-colors",
-          isSelected
-            ? "border-blue-500 ring-1 ring-blue-500"
-            : "hover:border-neutral-700",
+      <div className="relative">
+        {replicaCount >= 3 && (
+          <div className="absolute inset-0 translate-x-2 translate-y-2 rounded-xl border border-neutral-800 bg-neutral-900 opacity-30" />
         )}
-      >
-        <CardContent className="flex flex-col p-4">
-          <ServiceContent service={service} url={url} truncateImage />
-        </CardContent>
-      </Card>
+        {replicaCount >= 2 && (
+          <div className="absolute inset-0 translate-x-1 translate-y-1 rounded-xl border border-neutral-800 bg-neutral-900 opacity-50" />
+        )}
+        <Card
+          className={cn(
+            "relative w-64 cursor-pointer bg-neutral-900 border-neutral-800 transition-colors",
+            isSelected
+              ? "border-blue-500 ring-1 ring-blue-500"
+              : "hover:border-neutral-700",
+          )}
+        >
+          <CardContent className="flex flex-col p-4">
+            <ServiceContent service={service} url={url} truncateImage />
+          </CardContent>
+        </Card>
+      </div>
       <Handle type="source" position={Position.Right} className="invisible" />
     </>
   );

--- a/apps/app/src/app/projects/[id]/_components/sidebar-settings.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-settings.tsx
@@ -22,6 +22,7 @@ import { HealthCheckCard } from "../services/[serviceId]/settings/_components/he
 import { HostnameCard } from "../services/[serviceId]/settings/_components/hostname-card";
 import { ImageConfigCard } from "../services/[serviceId]/settings/_components/image-config-card";
 import { MemoryLimitCard } from "../services/[serviceId]/settings/_components/memory-limit-card";
+import { ReplicaCountCard } from "../services/[serviceId]/settings/_components/replica-count-card";
 import { RequestTimeoutCard } from "../services/[serviceId]/settings/_components/request-timeout-card";
 import { ServiceNameCard } from "../services/[serviceId]/settings/_components/service-name-card";
 import { ShutdownTimeoutCard } from "../services/[serviceId]/settings/_components/shutdown-timeout-card";
@@ -329,6 +330,7 @@ export function SidebarSettings({ service, projectId }: SidebarSettingsProps) {
         {activeTab === "runtime" && (
           <>
             <ContainerPortCard serviceId={service.id} />
+            <ReplicaCountCard serviceId={service.id} />
             <HealthCheckCard serviceId={service.id} />
             <RequestTimeoutCard serviceId={service.id} />
             <DrainTimeoutCard serviceId={service.id} />

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/replica-count-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/replica-count-card.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { SettingCard } from "@/components/setting-card";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useDeployService,
+  useService,
+  useUpdateService,
+} from "@/hooks/use-services";
+
+const REPLICA_OPTIONS = [
+  { value: "1", label: "1 (default)" },
+  { value: "2", label: "2" },
+  { value: "3", label: "3" },
+  { value: "5", label: "5" },
+  { value: "10", label: "10" },
+];
+
+interface ReplicaCountCardProps {
+  serviceId: string;
+}
+
+export function ReplicaCountCard({ serviceId }: ReplicaCountCardProps) {
+  const { data: service } = useService(serviceId);
+  const envId = service?.environmentId ?? "";
+  const updateMutation = useUpdateService(serviceId, envId);
+  const deployMutation = useDeployService(serviceId, envId);
+
+  const [replicaCount, setReplicaCount] = useState("1");
+  const initialValue = useRef("1");
+
+  const hasVolumes =
+    service?.volumes !== undefined &&
+    service.volumes !== null &&
+    service.volumes !== "[]";
+
+  useEffect(() => {
+    if (service) {
+      const value = (service.replicaCount ?? 1).toString();
+      setReplicaCount(value);
+      initialValue.current = value;
+    }
+  }, [service]);
+
+  const hasChanges = replicaCount !== initialValue.current;
+
+  async function handleSave() {
+    try {
+      await updateMutation.mutateAsync({
+        replicaCount: Number(replicaCount),
+      });
+      initialValue.current = replicaCount;
+      toast.success("Replica count saved", {
+        description: "Redeploy required for changes to take effect",
+        duration: 10000,
+        action: {
+          label: "Redeploy",
+          onClick: () => deployMutation.mutateAsync(),
+        },
+      });
+    } catch {
+      toast.error("Failed to save");
+    }
+  }
+
+  if (!service) return null;
+
+  const selectElement = (
+    <Select
+      value={replicaCount}
+      onValueChange={setReplicaCount}
+      disabled={hasVolumes}
+    >
+      <SelectTrigger className="w-48">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {REPLICA_OPTIONS.map((opt) => (
+          <SelectItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+  return (
+    <SettingCard
+      title="Replicas"
+      description="Number of container instances to run. Traffic is load-balanced across replicas using round-robin. All replicas must pass health checks."
+      footerRight={
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={updateMutation.isPending || !hasChanges || hasVolumes}
+        >
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            "Save"
+          )}
+        </Button>
+      }
+    >
+      <div
+        title={
+          hasVolumes
+            ? "Replicas not available for services with volumes"
+            : undefined
+        }
+      >
+        {selectElement}
+      </div>
+    </SettingCard>
+  );
+}

--- a/apps/app/src/contracts/deployments.ts
+++ b/apps/app/src/contracts/deployments.ts
@@ -1,6 +1,6 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
-import { deploymentsSchema } from "@/lib/db-schemas";
+import { deploymentsSchema, replicasSchema } from "@/lib/db-schemas";
 
 export const deploymentsContract = {
   get: oc
@@ -17,4 +17,9 @@ export const deploymentsContract = {
     .route({ method: "POST", path: "/deployments/{id}/rollback" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ deploymentId: z.string() })),
+
+  getReplicas: oc
+    .route({ method: "GET", path: "/deployments/{id}/replicas" })
+    .input(z.object({ id: z.string() }))
+    .output(z.array(replicasSchema)),
 };

--- a/apps/app/src/contracts/services.ts
+++ b/apps/app/src/contracts/services.ts
@@ -55,6 +55,7 @@ export const servicesContract = {
         drainTimeout: z.number().min(0).max(300).optional(),
         registryId: z.string().optional(),
         frostFilePath: z.string().optional(),
+        replicaCount: z.number().min(1).max(10).optional(),
       }),
     )
     .output(servicesSchema),
@@ -92,6 +93,7 @@ export const servicesContract = {
         registryId: z.string().nullable().optional(),
         command: z.string().nullable().optional(),
         frostFilePath: z.string().nullable().optional(),
+        replicaCount: z.number().min(1).max(10).optional(),
       }),
     )
     .output(servicesSchema),

--- a/apps/app/src/hooks/use-runtime-logs.ts
+++ b/apps/app/src/hooks/use-runtime-logs.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseRuntimeLogsOptions {
   deploymentId: string;
+  replica?: number;
 }
 
 interface UseRuntimeLogsResult {
@@ -17,6 +18,7 @@ const RECONNECT_DELAY = 2000;
 
 export function useRuntimeLogs({
   deploymentId,
+  replica,
 }: UseRuntimeLogsOptions): UseRuntimeLogsResult {
   const [logs, setLogs] = useState<string[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -46,8 +48,9 @@ export function useRuntimeLogs({
       shouldReconnectRef.current = true;
       setError(null);
 
+      const replicaParam = replica !== undefined ? `&replica=${replica}` : "";
       const es = new EventSource(
-        `/api/deployments/${deploymentId}/logs?tail=100`,
+        `/api/deployments/${deploymentId}/logs?tail=100${replicaParam}`,
       );
       eventSourceRef.current = es;
 
@@ -93,7 +96,7 @@ export function useRuntimeLogs({
         }
       };
     },
-    [deploymentId, disconnect],
+    [deploymentId, disconnect, replica],
   );
 
   useEffect(() => {

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -4,6 +4,7 @@ export type Project = ContractOutputs["projects"]["get"];
 export type ProjectListItem = ContractOutputs["projects"]["list"][number];
 export type Service = ContractOutputs["services"]["get"];
 export type Deployment = ContractOutputs["deployments"]["get"];
+export type Replica = ContractOutputs["deployments"]["getReplicas"][number];
 export type Domain = ContractOutputs["domains"]["get"];
 
 export type ProjectLatestDeployment = NonNullable<

--- a/apps/app/src/lib/db-schemas.ts
+++ b/apps/app/src/lib/db-schemas.ts
@@ -444,6 +444,7 @@ export const servicesSchema = z.object({
   hostname: z.string().nullable(),
   currentDeploymentId: z.string().nullable(),
   frostFilePath: z.string().nullable(),
+  replicaCount: z.number(),
   createdAt: z.number(),
 });
 
@@ -476,6 +477,7 @@ export const newServicesSchema = z.object({
   hostname: z.string().nullable(),
   currentDeploymentId: z.string().nullable(),
   frostFilePath: z.string().nullable().optional(),
+  replicaCount: z.number().optional(),
   createdAt: z.number(),
 });
 
@@ -508,6 +510,7 @@ export const servicesUpdateSchema = z.object({
   hostname: z.string().nullable().optional(),
   currentDeploymentId: z.string().nullable().optional(),
   frostFilePath: z.string().nullable().optional(),
+  replicaCount: z.number().optional(),
   createdAt: z.number().optional(),
 });
 
@@ -516,6 +519,47 @@ export type Services = z.infer<typeof servicesSchema>;
 export type NewServices = z.infer<typeof newServicesSchema>;
 
 export type ServicesUpdate = z.infer<typeof servicesUpdateSchema>;
+
+export const replicaStatusSchema = z.enum([
+  "pending",
+  "running",
+  "failed",
+  "stopped",
+]);
+
+export const replicasSchema = z.object({
+  id: z.string(),
+  deploymentId: z.string(),
+  replicaIndex: z.number(),
+  containerId: z.string().nullable(),
+  hostPort: z.number().nullable(),
+  status: z.string(),
+  createdAt: z.string(),
+});
+
+export const newReplicasSchema = z.object({
+  id: z.string(),
+  deploymentId: z.string(),
+  replicaIndex: z.number(),
+  containerId: z.string().nullable(),
+  hostPort: z.number().nullable(),
+  status: z.string().optional(),
+  createdAt: z.string().optional(),
+});
+
+export const replicasUpdateSchema = z.object({
+  id: z.string().optional(),
+  deploymentId: z.string().optional(),
+  replicaIndex: z.number().optional(),
+  containerId: z.string().nullable().optional(),
+  hostPort: z.number().nullable().optional(),
+  status: z.string().optional(),
+  createdAt: z.string().optional(),
+});
+
+export type Replicas = z.infer<typeof replicasSchema>;
+export type NewReplicas = z.infer<typeof newReplicasSchema>;
+export type ReplicasUpdate = z.infer<typeof replicasUpdateSchema>;
 
 export const settingsSchema = z.object({
   key: z.string(),

--- a/apps/app/src/lib/db-types.ts
+++ b/apps/app/src/lib/db-types.ts
@@ -131,6 +131,16 @@ export interface Registries {
   createdAt: number;
 }
 
+export interface Replicas {
+  id: string;
+  deploymentId: string;
+  replicaIndex: number;
+  containerId: string | null;
+  hostPort: number | null;
+  status: Generated<string>;
+  createdAt: Generated<string>;
+}
+
 export interface Services {
   id: string;
   environmentId: string;
@@ -161,6 +171,7 @@ export interface Services {
   icon: string | null;
   frostFilePath: Generated<string | null>;
   drainTimeout: number | null;
+  replicaCount: Generated<number>;
 }
 
 export interface Settings {
@@ -178,6 +189,7 @@ export interface DB {
   metrics: Metrics;
   projects: Projects;
   registries: Registries;
+  replicas: Replicas;
   services: Services;
   settings: Settings;
 }

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -212,6 +212,307 @@ function buildFrostEnvVars(
   return vars;
 }
 
+async function cancelActiveDeployments(
+  serviceId: string,
+  excludeDeploymentId?: string,
+): Promise<void> {
+  const inProgressStatuses = [
+    "pending",
+    "cloning",
+    "pulling",
+    "building",
+    "deploying",
+  ] as const;
+
+  let query = db
+    .selectFrom("deployments")
+    .select(["id", "containerId"])
+    .where("serviceId", "=", serviceId)
+    .where("status", "in", [...inProgressStatuses]);
+
+  if (excludeDeploymentId) {
+    query = query.where("id", "!=", excludeDeploymentId);
+  }
+
+  const activeDeployments = await query.execute();
+
+  for (const dep of activeDeployments) {
+    if (dep.containerId) {
+      await stopContainer(dep.containerId);
+    }
+    const depReplicas = await db
+      .selectFrom("replicas")
+      .select("containerId")
+      .where("deploymentId", "=", dep.id)
+      .where("containerId", "is not", null)
+      .execute();
+    for (const r of depReplicas) {
+      if (r.containerId) await stopContainer(r.containerId);
+    }
+    await db
+      .updateTable("deployments")
+      .set({ status: "cancelled", finishedAt: Date.now() })
+      .where("id", "=", dep.id)
+      .execute();
+  }
+}
+
+interface StartedReplica {
+  id: string;
+  containerId: string;
+  hostPort: number;
+  index: number;
+}
+
+interface StartReplicasOptions {
+  deploymentId: string;
+  replicaCount: number;
+  containerName: string;
+  imageName: string;
+  containerPort?: number;
+  runtimeEnvVars: Record<string, string>;
+  networkName: string;
+  internalHostname: string;
+  baseLabels: Record<string, string>;
+  volumes?: VolumeMount[];
+  fileMounts?: FileMount[];
+  command?: string[];
+  memoryLimit?: string;
+  cpuLimit?: number;
+  shutdownTimeout?: number;
+}
+
+async function startReplicas(
+  opts: StartReplicasOptions,
+): Promise<StartedReplica[]> {
+  for (let i = 0; i < opts.replicaCount; i++) {
+    await db
+      .insertInto("replicas")
+      .values({
+        id: nanoid(),
+        deploymentId: opts.deploymentId,
+        replicaIndex: i,
+        containerId: null,
+        hostPort: null,
+        status: "pending",
+      })
+      .execute();
+  }
+
+  const replicaRows = await db
+    .selectFrom("replicas")
+    .selectAll()
+    .where("deploymentId", "=", opts.deploymentId)
+    .orderBy("replicaIndex", "asc")
+    .execute();
+
+  const startedReplicas: StartedReplica[] = [];
+
+  try {
+    for (const replica of replicaRows) {
+      const replicaContainerName =
+        opts.replicaCount > 1
+          ? sanitizeDockerName(`${opts.containerName}-${replica.replicaIndex}`)
+          : opts.containerName;
+
+      const replicaEnvVars =
+        opts.replicaCount > 1
+          ? {
+              ...opts.runtimeEnvVars,
+              FROST_REPLICA_INDEX: String(replica.replicaIndex),
+            }
+          : opts.runtimeEnvVars;
+
+      const { containerId: cId, hostPort: hPort } =
+        await runContainerWithPortRetry(
+          {
+            imageName: opts.imageName,
+            containerPort: opts.containerPort,
+            name: replicaContainerName,
+            envVars: replicaEnvVars,
+            network: opts.networkName,
+            hostname: opts.internalHostname,
+            networkAlias: `${opts.internalHostname}.frost.internal`,
+            labels: {
+              ...opts.baseLabels,
+              "frost.deployment.id": opts.deploymentId,
+              "frost.replica.index": String(replica.replicaIndex),
+            },
+            volumes: opts.volumes,
+            fileMounts: opts.fileMounts,
+            command: opts.command,
+            memoryLimit: opts.memoryLimit,
+            cpuLimit: opts.cpuLimit,
+            shutdownTimeout: opts.shutdownTimeout,
+          },
+          async (port, attempt) => {
+            await appendLog(
+              opts.deploymentId,
+              `Port ${port} conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
+            );
+          },
+        );
+
+      startedReplicas.push({
+        id: replica.id,
+        containerId: cId,
+        hostPort: hPort,
+        index: replica.replicaIndex,
+      });
+
+      await db
+        .updateTable("replicas")
+        .set({ containerId: cId, hostPort: hPort, status: "running" })
+        .where("id", "=", replica.id)
+        .execute();
+
+      if (opts.replicaCount > 1) {
+        await appendLog(
+          opts.deploymentId,
+          `Replica ${replica.replicaIndex} started: ${cId.substring(0, 12)} on port ${hPort}\n`,
+        );
+      } else {
+        await appendLog(
+          opts.deploymentId,
+          `Container started: ${cId.substring(0, 12)}\n`,
+        );
+      }
+    }
+  } catch (err) {
+    for (const r of startedReplicas) {
+      await stopContainer(r.containerId);
+      await db
+        .updateTable("replicas")
+        .set({ status: "failed" })
+        .where("id", "=", r.id)
+        .execute();
+    }
+    throw err;
+  }
+
+  return startedReplicas;
+}
+
+async function healthCheckReplicas(
+  deploymentId: string,
+  replicas: StartedReplica[],
+  replicaCount: number,
+  healthCheckPath: string | null,
+  healthCheckTimeout: number | null,
+): Promise<void> {
+  const healthCheckType = healthCheckPath ? `HTTP ${healthCheckPath}` : "TCP";
+
+  if (replicaCount > 1) {
+    await appendLog(
+      deploymentId,
+      `Health check (${healthCheckType}) on ${replicaCount} replicas...\n`,
+    );
+  } else {
+    await appendLog(
+      deploymentId,
+      `Health check (${healthCheckType}) on port ${replicas[0].hostPort}...\n`,
+    );
+  }
+
+  const healthResults = await Promise.all(
+    replicas.map(async (r) => {
+      const isHealthy = await waitForHealthy({
+        containerId: r.containerId,
+        port: r.hostPort,
+        path: healthCheckPath,
+        timeoutSeconds: healthCheckTimeout ?? 60,
+      });
+      return { ...r, isHealthy };
+    }),
+  );
+
+  const failedReplicas = healthResults.filter((r) => !r.isHealthy);
+  if (failedReplicas.length > 0) {
+    for (const failed of failedReplicas) {
+      const containerStatus = await getContainerStatus(failed.containerId);
+      await appendLog(
+        deploymentId,
+        `Replica ${failed.index} status: ${containerStatus}\n`,
+      );
+      try {
+        const { stdout: logs } = await execAsync(
+          `docker logs ${failed.containerId} 2>&1 | tail -50`,
+        );
+        await appendLog(
+          deploymentId,
+          `Replica ${failed.index} logs:\n${logs}\n`,
+        );
+      } catch {
+        await appendLog(
+          deploymentId,
+          `Could not get logs for replica ${failed.index}\n`,
+        );
+      }
+    }
+    throw new Error(
+      `${failedReplicas.length}/${replicaCount} replica(s) failed health check`,
+    );
+  }
+}
+
+async function drainPreviousDeployments(
+  deploymentId: string,
+  serviceId: string,
+  drainTimeout: number,
+  shutdownTimeout: number,
+): Promise<void> {
+  const previousDeployments = await db
+    .selectFrom("deployments")
+    .select(["id", "containerId"])
+    .where("serviceId", "=", serviceId)
+    .where("id", "!=", deploymentId)
+    .where("status", "=", "running")
+    .execute();
+
+  if (previousDeployments.length === 0) return;
+
+  if (await isDeploymentCancelled(deploymentId)) return;
+
+  if (drainTimeout > 0) {
+    await appendLog(
+      deploymentId,
+      `Draining old container (${drainTimeout}s)...\n`,
+    );
+    await new Promise((r) => setTimeout(r, drainTimeout * 1000));
+  }
+
+  if (await isDeploymentCancelled(deploymentId)) return;
+
+  for (const prev of previousDeployments) {
+    const oldReplicas = await db
+      .selectFrom("replicas")
+      .select("containerId")
+      .where("deploymentId", "=", prev.id)
+      .where("containerId", "is not", null)
+      .execute();
+
+    if (oldReplicas.length > 0) {
+      for (const r of oldReplicas) {
+        if (r.containerId) {
+          await gracefulStopContainer(r.containerId, shutdownTimeout);
+        }
+      }
+      await db
+        .updateTable("replicas")
+        .set({ status: "stopped" })
+        .where("deploymentId", "=", prev.id)
+        .execute();
+    } else if (prev.containerId) {
+      await gracefulStopContainer(prev.containerId, shutdownTimeout);
+    }
+    await db
+      .updateTable("deployments")
+      .set({ status: "stopped", finishedAt: Date.now() })
+      .where("id", "=", prev.id)
+      .execute();
+  }
+}
+
 async function updateCommitStatusIfGitHub(
   repoUrl: string | null,
   commitSha: string,
@@ -340,30 +641,7 @@ export async function deployService(
     throw new Error("Project not found");
   }
 
-  const inProgressStatuses = [
-    "pending",
-    "cloning",
-    "pulling",
-    "building",
-    "deploying",
-  ] as const;
-  const activeDeployments = await db
-    .selectFrom("deployments")
-    .select(["id", "containerId"])
-    .where("serviceId", "=", serviceId)
-    .where("status", "in", [...inProgressStatuses])
-    .execute();
-
-  for (const dep of activeDeployments) {
-    if (dep.containerId) {
-      await stopContainer(dep.containerId);
-    }
-    await db
-      .updateTable("deployments")
-      .set({ status: "cancelled", finishedAt: Date.now() })
-      .where("id", "=", dep.id)
-      .execute();
-  }
+  await cancelActiveDeployments(serviceId);
 
   const deploymentId = nanoid();
   const now = Date.now();
@@ -704,11 +982,7 @@ async function runServiceDeployment(
       return;
     }
 
-    const oldContainerName = service.currentDeploymentId
-      ? sanitizeDockerName(`frost-${service.id}-${service.currentDeploymentId}`)
-      : null;
-
-    if (oldContainerName) {
+    if (service.currentDeploymentId) {
       await appendLog(
         deploymentId,
         "Starting new container (zero-downtime)...\n",
@@ -728,70 +1002,39 @@ async function runServiceDeployment(
     const runtimeEnvVars = { ...frostEnvVars, ...envVars };
 
     const internalHostname = service.hostname ?? slugify(service.name);
-    const { containerId, hostPort } = await runContainerWithPortRetry(
-      {
-        imageName,
-        containerPort: effectiveService.containerPort ?? undefined,
-        name: containerName,
-        envVars: runtimeEnvVars,
-        network: networkName,
-        hostname: internalHostname,
-        networkAlias: `${internalHostname}.frost.internal`,
-        labels: {
-          ...baseLabels,
-          "frost.deployment.id": deploymentId,
-        },
-        volumes,
-        fileMounts,
-        command,
-        memoryLimit: effectiveService.memoryLimit ?? undefined,
-        cpuLimit: effectiveService.cpuLimit ?? undefined,
-        shutdownTimeout: service.shutdownTimeout ?? undefined,
-      },
-      async (port, attempt) => {
-        await appendLog(
-          deploymentId,
-          `Port ${port} conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
-        );
-      },
-    );
+    const replicaCount = effectiveService.replicaCount ?? 1;
 
-    await appendLog(
+    const startedReplicas = await startReplicas({
       deploymentId,
-      `Container started: ${containerId.substring(0, 12)}\n`,
-    );
-    const healthCheckType = effectiveService.healthCheckPath
-      ? `HTTP ${effectiveService.healthCheckPath}`
-      : "TCP";
-    await appendLog(
-      deploymentId,
-      `Health check (${healthCheckType}) on port ${hostPort}...\n`,
-    );
-
-    const isHealthy = await waitForHealthy({
-      containerId,
-      port: hostPort,
-      path: effectiveService.healthCheckPath,
-      timeoutSeconds: effectiveService.healthCheckTimeout ?? 60,
+      replicaCount,
+      containerName,
+      imageName,
+      containerPort: effectiveService.containerPort ?? undefined,
+      runtimeEnvVars,
+      networkName,
+      internalHostname,
+      baseLabels,
+      volumes,
+      fileMounts,
+      command,
+      memoryLimit: effectiveService.memoryLimit ?? undefined,
+      cpuLimit: effectiveService.cpuLimit ?? undefined,
+      shutdownTimeout: service.shutdownTimeout ?? undefined,
     });
-    if (!isHealthy) {
-      const containerStatus = await getContainerStatus(containerId);
-      await appendLog(deploymentId, `Container status: ${containerStatus}\n`);
-      try {
-        const { stdout: logs } = await execAsync(
-          `docker logs ${containerId} 2>&1 | tail -50`,
-        );
-        await appendLog(deploymentId, `Container logs:\n${logs}\n`);
-      } catch {
-        await appendLog(deploymentId, `Could not get container logs\n`);
-      }
-      throw new Error("Container failed health check");
-    }
 
+    await healthCheckReplicas(
+      deploymentId,
+      startedReplicas,
+      replicaCount,
+      effectiveService.healthCheckPath,
+      effectiveService.healthCheckTimeout,
+    );
+
+    const firstReplica = startedReplicas[0];
     await updateDeployment(deploymentId, {
       status: "running",
-      containerId,
-      hostPort,
+      containerId: firstReplica.containerId,
+      hostPort: firstReplica.hostPort,
       finishedAt: Date.now(),
     });
 
@@ -803,7 +1046,7 @@ async function runServiceDeployment(
 
     await appendLog(
       deploymentId,
-      `\nDeployment successful! App available at http://localhost:${hostPort}\n`,
+      `\nDeployment successful! App available at http://localhost:${firstReplica.hostPort}\n`,
     );
     await updateCommitStatusIfGitHub(
       service.repoUrl,
@@ -834,55 +1077,17 @@ async function runServiceDeployment(
       );
     }
 
-    const drainTimeout = effectiveService.drainTimeout ?? 30;
-
-    const previousDeployments = await db
-      .selectFrom("deployments")
-      .select(["id", "containerId"])
-      .where("serviceId", "=", service.id)
-      .where("id", "!=", deploymentId)
-      .where("status", "=", "running")
-      .execute();
-
-    if (previousDeployments.length > 0 || oldContainerName) {
-      if (await isDeploymentCancelled(deploymentId)) return;
-
-      if (drainTimeout > 0) {
-        await appendLog(
-          deploymentId,
-          `Draining old container (${drainTimeout}s)...\n`,
-        );
-        await new Promise((r) => setTimeout(r, drainTimeout * 1000));
-      }
-
-      if (await isDeploymentCancelled(deploymentId)) return;
-
-      const shutdownTimeout = effectiveService.shutdownTimeout ?? 30;
-
-      if (oldContainerName) {
-        await appendLog(
-          deploymentId,
-          `Stopping old container (SIGTERM, ${shutdownTimeout}s grace)...\n`,
-        );
-        await gracefulStopContainer(oldContainerName, shutdownTimeout);
-      }
-
-      for (const prev of previousDeployments) {
-        if (prev.containerId) {
-          await gracefulStopContainer(prev.containerId, shutdownTimeout);
-        }
-        await db
-          .updateTable("deployments")
-          .set({ status: "stopped", finishedAt: Date.now() })
-          .where("id", "=", prev.id)
-          .execute();
-      }
-    }
+    await drainPreviousDeployments(
+      deploymentId,
+      service.id,
+      effectiveService.drainTimeout ?? 30,
+      effectiveService.shutdownTimeout ?? 30,
+    );
   } catch (err: any) {
     const errorMessage = err.message || "Unknown error";
     await updateDeployment(deploymentId, {
       status: "failed",
-      errorMessage: errorMessage,
+      errorMessage,
       finishedAt: Date.now(),
     });
     await appendLog(deploymentId, `\nError: ${errorMessage}\n`);
@@ -1005,31 +1210,7 @@ export async function rollbackDeployment(
     throw new Error("Image no longer available");
   }
 
-  const inProgressStatuses = [
-    "pending",
-    "cloning",
-    "pulling",
-    "building",
-    "deploying",
-  ] as const;
-  const activeDeployments = await db
-    .selectFrom("deployments")
-    .select(["id", "containerId"])
-    .where("serviceId", "=", service.id)
-    .where("id", "!=", deploymentId)
-    .where("status", "in", [...inProgressStatuses])
-    .execute();
-
-  for (const dep of activeDeployments) {
-    if (dep.containerId) {
-      await stopContainer(dep.containerId);
-    }
-    await db
-      .updateTable("deployments")
-      .set({ status: "cancelled", finishedAt: Date.now() })
-      .where("id", "=", dep.id)
-      .execute();
-  }
+  await cancelActiveDeployments(service.id, deploymentId);
 
   await db
     .updateTable("deployments")
@@ -1092,10 +1273,6 @@ async function runRollbackDeployment(
 
     await createNetwork(networkName, baseLabels);
 
-    const oldContainerName = service.currentDeploymentId
-      ? sanitizeDockerName(`frost-${service.id}-${service.currentDeploymentId}`)
-      : null;
-
     const gitInfo =
       sourceDeployment.gitCommitSha && sourceDeployment.gitBranch
         ? {
@@ -1116,69 +1293,36 @@ async function runRollbackDeployment(
     }
 
     const internalHostname = service.hostname ?? slugify(service.name);
-    const { containerId, hostPort } = await runContainerWithPortRetry(
-      {
-        imageName: sourceDeployment.imageName,
-        containerPort: sourceDeployment.containerPort ?? undefined,
-        name: containerName,
-        envVars: runtimeEnvVars,
-        network: networkName,
-        hostname: internalHostname,
-        networkAlias: `${internalHostname}.frost.internal`,
-        labels: {
-          ...baseLabels,
-          "frost.deployment.id": deploymentId,
-        },
-        memoryLimit: service.memoryLimit ?? undefined,
-        cpuLimit: service.cpuLimit ?? undefined,
-        shutdownTimeout: service.shutdownTimeout ?? undefined,
-      },
-      async (port, attempt) => {
-        await appendLog(
-          deploymentId,
-          `Port ${port} conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
-        );
-      },
-    );
+    const replicaCount = service.replicaCount ?? 1;
 
-    await appendLog(
+    const startedReplicas = await startReplicas({
       deploymentId,
-      `Container started: ${containerId.substring(0, 12)}\n`,
-    );
-
-    const healthCheckType = sourceDeployment.healthCheckPath
-      ? `HTTP ${sourceDeployment.healthCheckPath}`
-      : "TCP";
-    await appendLog(
-      deploymentId,
-      `Health check (${healthCheckType}) on port ${hostPort}...\n`,
-    );
-
-    const isHealthy = await waitForHealthy({
-      containerId,
-      port: hostPort,
-      path: sourceDeployment.healthCheckPath,
-      timeoutSeconds: sourceDeployment.healthCheckTimeout ?? 60,
+      replicaCount,
+      containerName,
+      imageName: sourceDeployment.imageName,
+      containerPort: sourceDeployment.containerPort ?? undefined,
+      runtimeEnvVars,
+      networkName,
+      internalHostname,
+      baseLabels,
+      memoryLimit: service.memoryLimit ?? undefined,
+      cpuLimit: service.cpuLimit ?? undefined,
+      shutdownTimeout: service.shutdownTimeout ?? undefined,
     });
 
-    if (!isHealthy) {
-      const containerStatus = await getContainerStatus(containerId);
-      await appendLog(deploymentId, `Container status: ${containerStatus}\n`);
-      try {
-        const { stdout: logs } = await execAsync(
-          `docker logs ${containerId} 2>&1 | tail -50`,
-        );
-        await appendLog(deploymentId, `Container logs:\n${logs}\n`);
-      } catch {
-        await appendLog(deploymentId, `Could not get container logs\n`);
-      }
-      throw new Error("Container failed health check");
-    }
+    await healthCheckReplicas(
+      deploymentId,
+      startedReplicas,
+      replicaCount,
+      sourceDeployment.healthCheckPath,
+      sourceDeployment.healthCheckTimeout,
+    );
 
+    const firstReplica = startedReplicas[0];
     await updateDeployment(deploymentId, {
       status: "running",
-      containerId,
-      hostPort,
+      containerId: firstReplica.containerId,
+      hostPort: firstReplica.hostPort,
       finishedAt: Date.now(),
     });
 
@@ -1190,7 +1334,7 @@ async function runRollbackDeployment(
 
     await appendLog(
       deploymentId,
-      `\nRollback successful! App available at http://localhost:${hostPort}\n`,
+      `\nRollback successful! App available at http://localhost:${firstReplica.hostPort}\n`,
     );
 
     await updateRollbackEligible(service.id);
@@ -1207,47 +1351,17 @@ async function runRollbackDeployment(
       );
     }
 
-    const drainTimeout = service.drainTimeout ?? 30;
-
-    const previousDeployments = await db
-      .selectFrom("deployments")
-      .select(["id", "containerId"])
-      .where("serviceId", "=", service.id)
-      .where("id", "!=", deploymentId)
-      .where("status", "=", "running")
-      .execute();
-
-    if (previousDeployments.length > 0 || oldContainerName) {
-      if (drainTimeout > 0) {
-        await appendLog(
-          deploymentId,
-          `Draining old container (${drainTimeout}s)...\n`,
-        );
-        await new Promise((r) => setTimeout(r, drainTimeout * 1000));
-      }
-
-      const shutdownTimeout = service.shutdownTimeout ?? 30;
-
-      if (oldContainerName) {
-        await gracefulStopContainer(oldContainerName, shutdownTimeout);
-      }
-
-      for (const prev of previousDeployments) {
-        if (prev.containerId) {
-          await gracefulStopContainer(prev.containerId, shutdownTimeout);
-        }
-        await db
-          .updateTable("deployments")
-          .set({ status: "stopped", finishedAt: Date.now() })
-          .where("id", "=", prev.id)
-          .execute();
-      }
-    }
+    await drainPreviousDeployments(
+      deploymentId,
+      service.id,
+      service.drainTimeout ?? 30,
+      service.shutdownTimeout ?? 30,
+    );
   } catch (err: any) {
     const errorMessage = err.message || "Unknown error";
     await updateDeployment(deploymentId, {
       status: "failed",
-      errorMessage: errorMessage,
+      errorMessage,
       finishedAt: Date.now(),
     });
     await appendLog(deploymentId, `\nError: ${errorMessage}\n`);

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -285,6 +285,11 @@ interface StartReplicasOptions {
 async function startReplicas(
   opts: StartReplicasOptions,
 ): Promise<StartedReplica[]> {
+  await db
+    .deleteFrom("replicas")
+    .where("deploymentId", "=", opts.deploymentId)
+    .execute();
+
   for (let i = 0; i < opts.replicaCount; i++) {
     await db
       .insertInto("replicas")
@@ -482,6 +487,11 @@ async function drainPreviousDeployments(
   }
 
   if (await isDeploymentCancelled(deploymentId)) return;
+
+  await appendLog(
+    deploymentId,
+    `Stopping old container (SIGTERM, ${shutdownTimeout}s timeout)...\n`,
+  );
 
   for (const prev of previousDeployments) {
     const oldReplicas = await db

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -447,6 +447,22 @@ export async function getAvailablePort(
     // Ignore - db might not be ready
   }
 
+  try {
+    const replicas = await db
+      .selectFrom("replicas")
+      .select("hostPort")
+      .where("hostPort", "is not", null)
+      .where("status", "in", ["pending", "running"])
+      .execute();
+    for (const r of replicas) {
+      if (r.hostPort) {
+        usedPorts.add(r.hostPort);
+      }
+    }
+  } catch {
+    // Ignore - table might not exist yet
+  }
+
   for (let port = start; port < end; port++) {
     if (!usedPorts.has(port) && !exclude?.has(port)) {
       return port;

--- a/apps/app/src/lib/frost-config.test.ts
+++ b/apps/app/src/lib/frost-config.test.ts
@@ -125,6 +125,7 @@ function makeService(overrides: Record<string, unknown> = {}) {
     cpuLimit: null as number | null,
     shutdownTimeout: null as number | null,
     drainTimeout: null as number | null,
+    replicaCount: 1,
     ...overrides,
   };
 }

--- a/apps/app/src/lib/frost-config.test.ts
+++ b/apps/app/src/lib/frost-config.test.ts
@@ -113,6 +113,27 @@ resources:
   test("throws on unknown keys (strict mode)", () => {
     expect(() => parseFrostConfig("unknown_key: value")).toThrow();
   });
+
+  test("parses deploy.replicas", () => {
+    const config = parseFrostConfig("deploy:\n  replicas: 3");
+    expect(config.deploy?.replicas).toBe(3);
+  });
+
+  test("throws on replicas < 1", () => {
+    expect(() => parseFrostConfig("deploy:\n  replicas: 0")).toThrow();
+  });
+
+  test("throws on replicas > 10", () => {
+    expect(() => parseFrostConfig("deploy:\n  replicas: 11")).toThrow();
+  });
+
+  test("parses deploy with replicas + drain_timeout", () => {
+    const config = parseFrostConfig(
+      "deploy:\n  replicas: 3\n  drain_timeout: 30",
+    );
+    expect(config.deploy?.replicas).toBe(3);
+    expect(config.deploy?.drain_timeout).toBe(30);
+  });
 });
 
 function makeService(overrides: Record<string, unknown> = {}) {
@@ -168,5 +189,19 @@ describe("mergeConfigWithService", () => {
     expect(result.healthCheckTimeout).toBe(60);
     expect(result.memoryLimit).toBe("1g");
     expect(result.cpuLimit).toBe(2);
+  });
+
+  test("config.deploy.replicas overrides service replicaCount", () => {
+    const service = makeService({ replicaCount: 1 });
+    const config: FrostConfig = { deploy: { replicas: 3 } };
+    const result = mergeConfigWithService(service, config);
+    expect(result.replicaCount).toBe(3);
+  });
+
+  test("service replicaCount preserved when config omits replicas", () => {
+    const service = makeService({ replicaCount: 1 });
+    const config: FrostConfig = { port: 3000 };
+    const result = mergeConfigWithService(service, config);
+    expect(result.replicaCount).toBe(1);
   });
 });

--- a/apps/app/src/lib/frost-config.ts
+++ b/apps/app/src/lib/frost-config.ts
@@ -28,6 +28,7 @@ export const frostConfigSchema = z
       .object({
         drain_timeout: z.number().min(0).max(300).optional(),
         shutdown_timeout: z.number().min(1).max(300).optional(),
+        replicas: z.number().min(1).max(10).optional(),
       })
       .optional(),
   })
@@ -118,6 +119,7 @@ type EffectiveService = Pick<
   | "cpuLimit"
   | "drainTimeout"
   | "shutdownTimeout"
+  | "replicaCount"
 >;
 
 export function mergeConfigWithService<T extends EffectiveService>(
@@ -135,5 +137,6 @@ export function mergeConfigWithService<T extends EffectiveService>(
     cpuLimit: config.resources?.cpu ?? service.cpuLimit,
     drainTimeout: config.deploy?.drain_timeout ?? service.drainTimeout,
     shutdownTimeout: config.deploy?.shutdown_timeout ?? service.shutdownTimeout,
+    replicaCount: config.deploy?.replicas ?? service.replicaCount,
   };
 }

--- a/apps/app/src/server/deployments.ts
+++ b/apps/app/src/server/deployments.ts
@@ -31,6 +31,15 @@ export const deployments = {
     },
   ),
 
+  getReplicas: os.deployments.getReplicas.handler(async ({ input }) => {
+    return db
+      .selectFrom("replicas")
+      .selectAll()
+      .where("deploymentId", "=", input.id)
+      .orderBy("replicaIndex", "asc")
+      .execute();
+  }),
+
   rollback: os.deployments.rollback.handler(async ({ input }) => {
     const deployment = await db
       .selectFrom("deployments")

--- a/apps/app/src/server/services.ts
+++ b/apps/app/src/server/services.ts
@@ -266,6 +266,17 @@ export const services = {
     if (service.deployType === "repo" && input.frostFilePath !== undefined) {
       updates.frostFilePath = input.frostFilePath;
     }
+    if (input.replicaCount !== undefined) {
+      if (input.replicaCount > 1) {
+        const volumes = service.volumes;
+        if (volumes && volumes !== "[]") {
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Cannot use replicas with volumes",
+          });
+        }
+      }
+      updates.replicaCount = input.replicaCount;
+    }
 
     if (Object.keys(updates).length > 0) {
       await db


### PR DESCRIPTION
## Summary
- Run N container replicas per service with Caddy round-robin load balancing
- New `replicas` table + `replica_count` on services (default 1, max 10)
- All replicas must pass health check — partial failure = failed deployment
- Replicas blocked for services with volumes
- Runtime logs merged with `[replica-N]` prefix, filterable per-replica

## Changes

### Core
- **Migration** (`008-replicas.sql`): `replica_count` column on services + `replicas` table with `(deployment_id, replica_index)` unique constraint
- **Deployer**: Extract `startReplicas`, `healthCheckReplicas`, `drainPreviousDeployments`, `cancelActiveDeployments` — shared by deploy + rollback paths. Delete stale replica rows before inserting (fixes rollback reuse of deployment ID)
- **Caddy/domains**: Multi-upstream with `round_robin` load balancing via replicas table join. Single upstream omits load_balancing config
- **Lifecycle**: Stop replica containers during cleanup
- **Port allocation**: Scan replicas table for used ports
- **frost.yaml**: `deploy.replicas` field (1-10)

### API
- `replicaCount` on service create/update (blocked if service has volumes)
- `GET /deployments/{id}/replicas` endpoint

### Logs
- Runtime logs route streams from all replica containers in parallel
- `[replica-N]` prefix when multi-replica
- `?replica=N` query param to filter to single replica

### UI
- Replica count setting card (select: 1, 2, 3, 5, 10) with redeploy toast
- Stacked-card canvas effect on service nodes when replicaCount > 1
- ×N badge next to status dot
- Replica status table in deployment logs drawer
- Replica filter dropdown in runtime logs sidebar

### Bug Fixes
- Fix rollback UNIQUE constraint failure — clear old replica rows before re-inserting
- Restore "Stopping old container (SIGTERM...)" log message in drain phase

## Tests

### Unit tests
- `frost-config.test.ts`: Parse `deploy.replicas` (valid, < 1, > 10, combined with drain_timeout), `mergeConfigWithService` replica override and preservation
- `caddy.test.ts`: Updated to `hostPorts[]` interface, multi-upstream generation, `round_robin` policy presence/absence, timeout + multi-upstream combination

### E2E tests
- `group-26-replicas.sh`: Default single replica, deploy with 3 replicas (unique ports/containers, all responding), redeploy preserves count (old containers stopped), scale down to 1, replicas blocked with volumes
- `group-27-replica-logs.sh`: Merged logs contain `[replica-0]`/`[replica-1]` prefixes, `?replica=0` filter excludes other replicas

## Design Decisions
- **No hot-scaling** — changing replica count requires redeploy
- **Block replicas for volume services** — same constraint as rollback
- **round_robin hardcoded** — no need to expose policy setting for v1
- **Build once, run N** — single build log per deployment, N container starts
- **`FROST_REPLICA_INDEX` env var** injected per replica (like Railway's `RAILWAY_REPLICA_ID`)
- **All replicas share Docker hostname** — Docker DNS round-robins for internal service-to-service traffic

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)