### PR TITLE
feat: bypass OS DNS cache for domain verification

### DIFF
--- a/apps/app/src/lib/domains.ts
+++ b/apps/app/src/lib/domains.ts
@@ -279,8 +279,10 @@ export async function getServerIp(): Promise<string> {
 }
 
 async function resolveDomain(domain: string): Promise<string[]> {
+  const resolver = new dns.Resolver();
+  resolver.setServers(["1.1.1.1", "8.8.8.8"]);
   try {
-    return await dns.resolve4(domain);
+    return await resolver.resolve4(domain);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- Use Node's `dns.Resolver` with public DNS servers (1.1.1.1, 8.8.8.8) to bypass OS DNS cache
- Domain verification now gets fresh results that match what Let's Encrypt sees

## Test plan
- [ ] Add a custom domain in Frost UI
- [ ] Configure DNS A record pointing to server IP  
- [ ] Click verify - should detect the record immediately (no cache delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)