### PR TITLE
fix: surface Caddy sync errors in wildcard settings

### DIFF
--- a/apps/app/src/app/settings/_components/wildcard-section.tsx
+++ b/apps/app/src/app/settings/_components/wildcard-section.tsx
@@ -58,6 +58,12 @@ export function WildcardSection() {
             duration: 10000,
           });
         }
+        if (data.caddyWarning) {
+          toast.warning("Caddy config sync failed", {
+            description: data.caddyWarning,
+            duration: 10000,
+          });
+        }
         setSuccess(true);
         setApiToken("");
         await queryClient.refetchQueries({
@@ -74,7 +80,13 @@ export function WildcardSection() {
 
   const removeMutation = useMutation(
     orpc.settings.wildcard.delete.mutationOptions({
-      onSuccess: async () => {
+      onSuccess: async (data) => {
+        if (data.caddyWarning) {
+          toast.warning("Caddy config sync failed", {
+            description: data.caddyWarning,
+            duration: 10000,
+          });
+        }
         setDomain("");
         setApiToken("");
         setTokenValid(null);

--- a/apps/app/src/contracts/settings.ts
+++ b/apps/app/src/contracts/settings.ts
@@ -125,13 +125,17 @@ export const settingsContract = {
         z.object({
           success: z.boolean(),
           dnsWarning: z.string().optional(),
+          caddyWarning: z.string().optional(),
           backfilledCount: z.number(),
         }),
       ),
 
-    delete: oc
-      .route({ method: "DELETE", path: "/settings/wildcard" })
-      .output(z.object({ success: z.boolean() })),
+    delete: oc.route({ method: "DELETE", path: "/settings/wildcard" }).output(
+      z.object({
+        success: z.boolean(),
+        caddyWarning: z.string().optional(),
+      }),
+    ),
 
     test: oc
       .route({ method: "POST", path: "/settings/wildcard/test" })

--- a/apps/app/src/server/settings.ts
+++ b/apps/app/src/server/settings.ts
@@ -306,9 +306,16 @@ export const settings = {
 
       const backfilledCount = await backfillWildcardDomains();
 
-      await syncCaddyConfig().catch(() => {});
+      let caddyWarning: string | undefined;
+      try {
+        await syncCaddyConfig();
+      } catch (error) {
+        console.error("Failed to sync Caddy config:", error);
+        caddyWarning =
+          error instanceof Error ? error.message : "Caddy config sync failed";
+      }
 
-      return { success: true, dnsWarning, backfilledCount };
+      return { success: true, dnsWarning, caddyWarning, backfilledCount };
     }),
 
     delete: os.settings.wildcard.delete.handler(async () => {
@@ -316,9 +323,16 @@ export const settings = {
       await setSetting("dns_provider", "");
       await setSetting("dns_api_token", "");
 
-      await syncCaddyConfig().catch(() => {});
+      let caddyWarning: string | undefined;
+      try {
+        await syncCaddyConfig();
+      } catch (error) {
+        console.error("Failed to sync Caddy config:", error);
+        caddyWarning =
+          error instanceof Error ? error.message : "Caddy config sync failed";
+      }
 
-      return { success: true };
+      return { success: true, caddyWarning };
     }),
 
     test: os.settings.wildcard.test.handler(async ({ input }) => {


### PR DESCRIPTION
## Summary
- Replace silent `.catch(() => {})` on `syncCaddyConfig()` in wildcard set/delete handlers with try/catch that captures errors as `caddyWarning`
- Add `caddyWarning` field to wildcard set/delete API contracts
- Show toast warnings in UI when Caddy config sync fails (same pattern as existing `dnsWarning`)

## Test plan
- [ ] Set wildcard domain — verify it works normally and no spurious warning appears
- [ ] Delete wildcard domain — same check
- [ ] Simulate Caddy failure — verify warning toast appears with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)