### PR TITLE
Harden auth secret handling and OAuth authorize validation

### DIFF
--- a/apps/app/src/app/api/auth/login/route.ts
+++ b/apps/app/src/app/api/auth/login/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
 
   response.cookies.set("frost_session", token, {
     httpOnly: true,
-    secure: false,
+    secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     maxAge: 7 * 24 * 60 * 60,
     path: "/",

--- a/apps/app/src/lib/auth.ts
+++ b/apps/app/src/lib/auth.ts
@@ -5,7 +5,6 @@ import { getRequiredJwtSecret } from "./jwt-secret";
 
 const scryptAsync = promisify(scrypt);
 
-const JWT_SECRET = getRequiredJwtSecret();
 const SESSION_EXPIRY_DAYS = 7;
 const DEV_PASSWORD = "dev";
 
@@ -75,7 +74,9 @@ export function verifySessionToken(token: string): boolean {
 }
 
 function createSignature(data: string): string {
-  return createHmac("sha256", JWT_SECRET).update(data).digest("base64url");
+  return createHmac("sha256", getRequiredJwtSecret())
+    .update(data)
+    .digest("base64url");
 }
 
 export async function getSetting(key: string): Promise<string | null> {
@@ -113,7 +114,7 @@ export function generateApiKey(): string {
 }
 
 export function hashApiKey(key: string): string {
-  return createHmac("sha256", JWT_SECRET).update(key).digest("hex");
+  return createHmac("sha256", getRequiredJwtSecret()).update(key).digest("hex");
 }
 
 export async function verifyApiToken(token: string): Promise<boolean> {

--- a/apps/app/src/lib/auth.ts
+++ b/apps/app/src/lib/auth.ts
@@ -1,11 +1,11 @@
 import { createHmac, randomBytes, scrypt, timingSafeEqual } from "node:crypto";
 import { promisify } from "node:util";
 import { db } from "./db";
+import { getRequiredJwtSecret } from "./jwt-secret";
 
 const scryptAsync = promisify(scrypt);
 
-const DEFAULT_SECRET = "frost-default-secret-change-me";
-const JWT_SECRET = process.env.FROST_JWT_SECRET || DEFAULT_SECRET;
+const JWT_SECRET = getRequiredJwtSecret();
 const SESSION_EXPIRY_DAYS = 7;
 const DEV_PASSWORD = "dev";
 

--- a/apps/app/src/lib/crypto.ts
+++ b/apps/app/src/lib/crypto.ts
@@ -4,9 +4,9 @@ import {
   randomBytes,
   scryptSync,
 } from "node:crypto";
+import { getRequiredJwtSecret } from "./jwt-secret";
 
-const DEFAULT_SECRET = "frost-default-secret-change-me";
-const SECRET = process.env.FROST_JWT_SECRET || DEFAULT_SECRET;
+const SECRET = getRequiredJwtSecret();
 const KEY = scryptSync(SECRET, "frost-encryption-salt", 32);
 
 export function encrypt(text: string): string {

--- a/apps/app/src/lib/crypto.ts
+++ b/apps/app/src/lib/crypto.ts
@@ -6,12 +6,17 @@ import {
 } from "node:crypto";
 import { getRequiredJwtSecret } from "./jwt-secret";
 
-const SECRET = getRequiredJwtSecret();
-const KEY = scryptSync(SECRET, "frost-encryption-salt", 32);
+let keyCache: Buffer | null = null;
+
+function getEncryptionKey(): Buffer {
+  if (keyCache) return keyCache;
+  keyCache = scryptSync(getRequiredJwtSecret(), "frost-encryption-salt", 32);
+  return keyCache;
+}
 
 export function encrypt(text: string): string {
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", KEY, iv);
+  const cipher = createCipheriv("aes-256-gcm", getEncryptionKey(), iv);
   const encrypted = Buffer.concat([
     cipher.update(text, "utf8"),
     cipher.final(),
@@ -25,7 +30,7 @@ export function decrypt(data: string): string {
   const iv = buf.subarray(0, 12);
   const tag = buf.subarray(12, 28);
   const encrypted = buf.subarray(28);
-  const decipher = createDecipheriv("aes-256-gcm", KEY, iv);
+  const decipher = createDecipheriv("aes-256-gcm", getEncryptionKey(), iv);
   decipher.setAuthTag(tag);
   return decipher.update(encrypted) + decipher.final("utf8");
 }

--- a/apps/app/src/lib/jwt-secret.ts
+++ b/apps/app/src/lib/jwt-secret.ts
@@ -1,0 +1,19 @@
+const DEFAULT_SECRET = "frost-default-secret-change-me";
+
+const REQUIRED_SECRET_ERROR =
+  "FROST_JWT_SECRET must be set and must not use the default value";
+
+export function getRequiredJwtSecret(): string {
+  const secret = process.env.FROST_JWT_SECRET;
+
+  // Keep tests deterministic without requiring per-test env setup.
+  if (process.env.NODE_ENV === "test") {
+    return secret && secret !== DEFAULT_SECRET ? secret : "frost-test-secret";
+  }
+
+  if (!secret || secret === DEFAULT_SECRET) {
+    throw new Error(REQUIRED_SECRET_ERROR);
+  }
+
+  return secret;
+}

--- a/apps/app/src/lib/oauth.ts
+++ b/apps/app/src/lib/oauth.ts
@@ -1,8 +1,8 @@
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import { db } from "./db";
+import { getRequiredJwtSecret } from "./jwt-secret";
 
-const DEFAULT_SECRET = "frost-default-secret-change-me";
-const JWT_SECRET = process.env.FROST_JWT_SECRET || DEFAULT_SECRET;
+const JWT_SECRET = getRequiredJwtSecret();
 
 const AUTH_CODE_EXPIRY_MS = 10 * 60 * 1000;
 

--- a/apps/app/src/lib/oauth.ts
+++ b/apps/app/src/lib/oauth.ts
@@ -2,8 +2,6 @@ import { createHash, createHmac, randomBytes } from "node:crypto";
 import { db } from "./db";
 import { getRequiredJwtSecret } from "./jwt-secret";
 
-const JWT_SECRET = getRequiredJwtSecret();
-
 const AUTH_CODE_EXPIRY_MS = 10 * 60 * 1000;
 
 export function generateCode(): string {
@@ -19,7 +17,9 @@ export function generateRefreshToken(): string {
 }
 
 export function hashOAuthToken(token: string): string {
-  return createHmac("sha256", JWT_SECRET).update(token).digest("hex");
+  return createHmac("sha256", getRequiredJwtSecret())
+    .update(token)
+    .digest("hex");
 }
 
 export function verifyPKCE(

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -1,29 +1,11 @@
-import { createHmac } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { isSetupComplete, verifyApiToken } from "./lib/auth";
+import {
+  isSetupComplete,
+  verifyApiToken,
+  verifySessionToken,
+} from "./lib/auth";
 import { verifyOAuthToken } from "./lib/oauth";
-
-const DEFAULT_SECRET = "frost-default-secret-change-me";
-const JWT_SECRET = process.env.FROST_JWT_SECRET || DEFAULT_SECRET;
-
-function verifySessionToken(token: string): boolean {
-  const [data, signature] = token.split(".");
-  if (!data || !signature) return false;
-
-  const expectedSignature = createHmac("sha256", JWT_SECRET)
-    .update(data)
-    .digest("base64url");
-
-  if (signature !== expectedSignature) return false;
-
-  try {
-    const payload = JSON.parse(Buffer.from(data, "base64url").toString());
-    return payload.exp > Date.now();
-  } catch {
-    return false;
-  }
-}
 
 const PUBLIC_PATHS = [
   "/login",


### PR DESCRIPTION
## Summary
- set login session cookie to Secure in production
- remove default JWT secret fallback by requiring a configured non-default secret across auth, oauth, and crypto paths
- reuse shared session token verification in proxy middleware
- re-validate OAuth authorize POST inputs (client_id, redirect_uri, code_challenge_method, action) before issuing auth codes

## Validation
- bun --cwd apps/app typecheck
- bun --cwd apps/app test *(fails in Docker-dependent integration tests in this environment due Docker socket permission restrictions)*
- bunx biome check apps/app/src/lib/jwt-secret.ts apps/app/src/lib/auth.ts apps/app/src/lib/oauth.ts apps/app/src/lib/crypto.ts apps/app/src/proxy.ts apps/app/src/app/api/auth/login/route.ts apps/app/src/app/api/oauth/authorize/route.ts