### PR TITLE
test: speed up e2e group scheduling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,12 @@ Run locally (fully managed, recommended):
 ```bash
 bun run e2e:local                       # boots isolated local Frost + runs all groups
 E2E_GROUP_GLOB='group-0[1-4]*.sh' bun run e2e:local  # run subset
+E2E_RETRY_FAILED=1 bun run e2e:local    # auto-retry failed groups once
+E2E_REPORT_PATH=/tmp/frost-e2e.json bun run e2e:local # write JSON report
 bun run e2e:smoke                       # fast high-signal subset
+bun run e2e:smoke:retry                 # smoke subset + retry failed groups
 bun run e2e:changed                     # auto-select groups based on git changes
+bun run e2e:changed:retry               # changed groups + retry failed groups
 bun run e2e:changed:print               # print selected groups only
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,17 @@ bun run db:gen       # regenerate db types (run after schema changes)
 
 ## E2E Tests
 
-Run locally (start `bun run dev` first):
+Run locally (fully managed, recommended):
 ```bash
-./apps/app/scripts/e2e-local.sh <api-key>           # run all tests
-./apps/app/scripts/e2e-local.sh <api-key> 2         # batch size 2 (fewer parallel tests)
+bun run e2e:local                       # boots isolated local Frost + runs all groups
+E2E_GROUP_GLOB='group-0[1-4]*.sh' bun run e2e:local  # run subset
+```
+
+Run against an existing local Frost instance (start `bun run dev` first):
+```bash
+bun run e2e:local:existing <api-key>          # run all tests
+bun run e2e:local:existing <api-key> 2        # custom batch size
+FROST_PORT=3301 bun run e2e:local:existing <api-key> # custom port
 
 # run single test
 SERVER_IP=localhost API_KEY=<key> E2E_LOCAL=1 FROST_DATA_DIR=./apps/app/data \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,9 @@ Run locally (fully managed, recommended):
 ```bash
 bun run e2e:local                       # boots isolated local Frost + runs all groups
 E2E_GROUP_GLOB='group-0[1-4]*.sh' bun run e2e:local  # run subset
+bun run e2e:smoke                       # fast high-signal subset
+bun run e2e:changed                     # auto-select groups based on git changes
+bun run e2e:changed:print               # print selected groups only
 ```
 
 Run against an existing local Frost instance (start `bun run dev` first):
@@ -49,6 +52,7 @@ Run against an existing local Frost instance (start `bun run dev` first):
 bun run e2e:local:existing <api-key>          # run all tests
 bun run e2e:local:existing <api-key> 2        # custom batch size
 FROST_PORT=3301 bun run e2e:local:existing <api-key> # custom port
+E2E_GROUPS='01-basic,23-change-password' bun run e2e:local:existing <api-key>  # explicit groups
 
 # run single test
 SERVER_IP=localhost API_KEY=<key> E2E_LOCAL=1 FROST_DATA_DIR=./apps/app/data \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Run locally (fully managed, recommended):
 ```bash
 bun run e2e:local                       # boots isolated local Frost + runs all groups
 E2E_GROUP_GLOB='group-0[1-4]*.sh' bun run e2e:local  # run subset
+E2E_START_STAGGER_SEC=0 bun run e2e:local  # disable between-group launch delay
 E2E_RETRY_FAILED=1 bun run e2e:local    # auto-retry failed groups once
 E2E_REPORT_PATH=/tmp/frost-e2e.json bun run e2e:local # write JSON report
 bun run e2e:smoke                       # fast high-signal subset
@@ -57,6 +58,7 @@ bun run e2e:local:existing <api-key>          # run all tests
 bun run e2e:local:existing <api-key> 2        # custom batch size
 FROST_PORT=3301 bun run e2e:local:existing <api-key> # custom port
 E2E_GROUPS='01-basic,23-change-password' bun run e2e:local:existing <api-key>  # explicit groups
+E2E_START_STAGGER_SEC=0 bun run e2e:local:existing <api-key> # disable launch delay
 
 # run single test
 SERVER_IP=localhost API_KEY=<key> E2E_LOCAL=1 FROST_DATA_DIR=./apps/app/data \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Docker-native. If it has a Dockerfile, Frost runs it.
 bun install
 bun run dev
 bun run e2e:local
+bun run e2e:smoke
+bun run e2e:changed
 ```
 
 Open http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Docker-native. If it has a Dockerfile, Frost runs it.
 ```bash
 bun install
 bun run dev
+bun run e2e:local
 ```
 
 Open http://localhost:3000

--- a/apps/app/scripts/e2e-changed.sh
+++ b/apps/app/scripts/e2e-changed.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+E2E_DIR="$SCRIPT_DIR/e2e"
+DEFAULT_GROUPS="${E2E_DEFAULT_GROUPS:-01-basic,04-update,10-race,20-setup,28-oauth,29-mcp}"
+BATCH_SIZE="${1:-2}"
+BASE_REF="${E2E_BASE_REF:-origin/main}"
+
+cd "$REPO_ROOT"
+
+SELECTED_GROUPS=()
+SELECTED_GROUP_KEYS="|"
+
+add_group() {
+  local group="$1"
+  group="${group%.sh}"
+  group="${group##*/}"
+  group="${group#group-}"
+  [ -n "$group" ] || return 0
+
+  case "$SELECTED_GROUP_KEYS" in
+    *"|$group|"*) return 0 ;;
+  esac
+
+  SELECTED_GROUPS+=("$group")
+  SELECTED_GROUP_KEYS="${SELECTED_GROUP_KEYS}${group}|"
+}
+
+add_groups_csv() {
+  local csv="$1"
+  local normalized
+  normalized=$(echo "$csv" | tr ',\n\t' '   ')
+  for group in $normalized; do
+    add_group "$group"
+  done
+}
+
+select_from_file() {
+  local file="$1"
+
+  case "$file" in
+    apps/app/scripts/e2e/group-*.sh)
+      add_group "$(basename "$file" .sh)"
+      ;;
+  esac
+
+  case "$file" in
+    apps/app/src/server/settings.ts|apps/app/src/contracts/settings.ts|apps/app/src/lib/caddy.ts|apps/app/src/lib/domains.ts|apps/app/src/server/domains.ts|apps/app/src/lib/cloudflare.ts|apps/app/scripts/e2e/group-05-ssl.sh|apps/app/scripts/e2e/group-17-wildcard.sh|apps/app/scripts/e2e/group-23-change-password.sh)
+      add_groups_csv "05-ssl,17-wildcard,23-change-password"
+      ;;
+  esac
+
+  case "$file" in
+    apps/app/src/app/api/oauth/*|apps/app/src/lib/oauth.ts|apps/app/src/lib/oauth.test.ts|apps/app/src/app/api/mcp/*|apps/app/src/server/mcp-tokens.ts|apps/app/src/contracts/mcp-*.ts|apps/app/scripts/e2e/group-28-oauth.sh|apps/app/scripts/e2e/group-29-mcp.sh)
+      add_groups_csv "28-oauth,29-mcp"
+      ;;
+  esac
+
+  case "$file" in
+    apps/app/src/app/api/github/*|apps/app/src/lib/webhook.ts|apps/app/src/lib/github.ts|apps/app/src/server/github.ts|apps/app/scripts/e2e/group-06-webhook.sh|apps/app/scripts/e2e/group-22-preview-envs.sh)
+      add_groups_csv "06-webhook,22-preview-envs"
+      ;;
+  esac
+
+  case "$file" in
+    apps/app/src/lib/deployer.ts|apps/app/src/lib/docker.ts|apps/app/src/server/services.ts|apps/app/src/server/deployments.ts|apps/app/src/server/projects.ts|apps/app/src/server/environments.ts|apps/app/src/lib/paths.ts|apps/app/scripts/e2e/common.sh|apps/app/scripts/e2e-test.sh|apps/app/scripts/e2e-local*.sh)
+      add_groups_csv "01-basic,02-multiservice,03-envvars,04-update,07-database,08-rollback,09-healthcheck,10-race,11-frost-env,12-limits,13-timeout,14-volumes,16-concurrent,18-build-context,19-templates,21-hostname,24-zero-downtime,25-graceful-shutdown,26-replicas,27-replica-logs"
+      ;;
+  esac
+
+  case "$file" in
+    apps/app/src/app/api/setup/*|apps/app/src/app/api/auth/*|apps/app/src/lib/auth.ts|apps/app/src/proxy.ts|apps/app/scripts/e2e/group-20-setup.sh|apps/app/scripts/e2e/group-23-change-password.sh)
+      add_groups_csv "20-setup,23-change-password,28-oauth,29-mcp"
+      ;;
+  esac
+}
+
+BASE_COMMIT=""
+if git rev-parse --verify "$BASE_REF" > /dev/null 2>&1; then
+  BASE_COMMIT=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)
+fi
+
+if [ -z "$BASE_COMMIT" ]; then
+  if git rev-parse --verify HEAD~1 > /dev/null 2>&1; then
+    BASE_COMMIT="$(git rev-parse HEAD~1)"
+  else
+    BASE_COMMIT="$(git rev-parse HEAD)"
+  fi
+fi
+
+CHANGED_FILES="$(
+  {
+    git diff --name-only "$BASE_COMMIT"...HEAD 2>/dev/null || true
+    git diff --name-only
+    git diff --name-only --cached
+  } | awk 'NF' | sort -u
+)"
+
+if [ -n "$CHANGED_FILES" ]; then
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    select_from_file "$file"
+  done <<< "$CHANGED_FILES"
+fi
+
+if [ "${#SELECTED_GROUPS[@]}" -eq 0 ]; then
+  add_groups_csv "$DEFAULT_GROUPS"
+fi
+
+GROUPS_CSV=$(IFS=, ; echo "${SELECTED_GROUPS[*]}")
+
+echo "Base ref: $BASE_REF"
+echo "Base commit: $BASE_COMMIT"
+echo "Selected E2E groups: $GROUPS_CSV"
+
+if [ "${E2E_CHANGED_DRY_RUN:-0}" = "1" ]; then
+  exit 0
+fi
+
+E2E_GROUPS="$GROUPS_CSV" bash "$SCRIPT_DIR/e2e-local-managed.sh" "$BATCH_SIZE"

--- a/apps/app/scripts/e2e-changed.sh
+++ b/apps/app/scripts/e2e-changed.sh
@@ -7,33 +7,59 @@ E2E_DIR="$SCRIPT_DIR/e2e"
 DEFAULT_GROUPS="${E2E_DEFAULT_GROUPS:-01-basic,04-update,10-race,20-setup,28-oauth,29-mcp}"
 BATCH_SIZE="${1:-2}"
 BASE_REF="${E2E_BASE_REF:-origin/main}"
+VERBOSE="${E2E_CHANGED_VERBOSE:-1}"
 
 cd "$REPO_ROOT"
 
 SELECTED_GROUPS=()
-SELECTED_GROUP_KEYS="|"
+SELECTED_REASONS=()
+
+find_group_index() {
+  local target="$1"
+  local i
+  for i in "${!SELECTED_GROUPS[@]}"; do
+    if [ "${SELECTED_GROUPS[$i]}" = "$target" ]; then
+      echo "$i"
+      return 0
+    fi
+  done
+  return 1
+}
 
 add_group() {
   local group="$1"
+  local reason="${2:-unspecified}"
+  local idx
+
   group="${group%.sh}"
   group="${group##*/}"
   group="${group#group-}"
   [ -n "$group" ] || return 0
 
-  case "$SELECTED_GROUP_KEYS" in
-    *"|$group|"*) return 0 ;;
-  esac
+  if idx="$(find_group_index "$group")"; then
+    local existing_reason="${SELECTED_REASONS[$idx]}"
+    case ";$existing_reason;" in
+      *";$reason;"*) return 0 ;;
+    esac
+    if [ -n "$existing_reason" ]; then
+      SELECTED_REASONS[$idx]="${existing_reason};$reason"
+    else
+      SELECTED_REASONS[$idx]="$reason"
+    fi
+    return 0
+  fi
 
   SELECTED_GROUPS+=("$group")
-  SELECTED_GROUP_KEYS="${SELECTED_GROUP_KEYS}${group}|"
+  SELECTED_REASONS+=("$reason")
 }
 
 add_groups_csv() {
   local csv="$1"
+  local reason="$2"
   local normalized
   normalized=$(echo "$csv" | tr ',\n\t' '   ')
   for group in $normalized; do
-    add_group "$group"
+    add_group "$group" "$reason"
   done
 }
 
@@ -42,37 +68,37 @@ select_from_file() {
 
   case "$file" in
     apps/app/scripts/e2e/group-*.sh)
-      add_group "$(basename "$file" .sh)"
+      add_group "$(basename "$file" .sh)" "direct:$file"
       ;;
   esac
 
   case "$file" in
     apps/app/src/server/settings.ts|apps/app/src/contracts/settings.ts|apps/app/src/lib/caddy.ts|apps/app/src/lib/domains.ts|apps/app/src/server/domains.ts|apps/app/src/lib/cloudflare.ts|apps/app/scripts/e2e/group-05-ssl.sh|apps/app/scripts/e2e/group-17-wildcard.sh|apps/app/scripts/e2e/group-23-change-password.sh)
-      add_groups_csv "05-ssl,17-wildcard,23-change-password"
+      add_groups_csv "05-ssl,17-wildcard,23-change-password" "settings-or-domain:$file"
       ;;
   esac
 
   case "$file" in
     apps/app/src/app/api/oauth/*|apps/app/src/lib/oauth.ts|apps/app/src/lib/oauth.test.ts|apps/app/src/app/api/mcp/*|apps/app/src/server/mcp-tokens.ts|apps/app/src/contracts/mcp-*.ts|apps/app/scripts/e2e/group-28-oauth.sh|apps/app/scripts/e2e/group-29-mcp.sh)
-      add_groups_csv "28-oauth,29-mcp"
+      add_groups_csv "28-oauth,29-mcp" "oauth-or-mcp:$file"
       ;;
   esac
 
   case "$file" in
     apps/app/src/app/api/github/*|apps/app/src/lib/webhook.ts|apps/app/src/lib/github.ts|apps/app/src/server/github.ts|apps/app/scripts/e2e/group-06-webhook.sh|apps/app/scripts/e2e/group-22-preview-envs.sh)
-      add_groups_csv "06-webhook,22-preview-envs"
+      add_groups_csv "06-webhook,22-preview-envs" "github-webhook:$file"
       ;;
   esac
 
   case "$file" in
     apps/app/src/lib/deployer.ts|apps/app/src/lib/docker.ts|apps/app/src/server/services.ts|apps/app/src/server/deployments.ts|apps/app/src/server/projects.ts|apps/app/src/server/environments.ts|apps/app/src/lib/paths.ts|apps/app/scripts/e2e/common.sh|apps/app/scripts/e2e-test.sh|apps/app/scripts/e2e-local*.sh)
-      add_groups_csv "01-basic,02-multiservice,03-envvars,04-update,07-database,08-rollback,09-healthcheck,10-race,11-frost-env,12-limits,13-timeout,14-volumes,16-concurrent,18-build-context,19-templates,21-hostname,24-zero-downtime,25-graceful-shutdown,26-replicas,27-replica-logs"
+      add_groups_csv "01-basic,02-multiservice,03-envvars,04-update,07-database,08-rollback,09-healthcheck,10-race,11-frost-env,12-limits,13-timeout,14-volumes,16-concurrent,18-build-context,19-templates,21-hostname,24-zero-downtime,25-graceful-shutdown,26-replicas,27-replica-logs" "deployer-core:$file"
       ;;
   esac
 
   case "$file" in
     apps/app/src/app/api/setup/*|apps/app/src/app/api/auth/*|apps/app/src/lib/auth.ts|apps/app/src/proxy.ts|apps/app/scripts/e2e/group-20-setup.sh|apps/app/scripts/e2e/group-23-change-password.sh)
-      add_groups_csv "20-setup,23-change-password,28-oauth,29-mcp"
+      add_groups_csv "20-setup,23-change-password,28-oauth,29-mcp" "auth-setup:$file"
       ;;
   esac
 }
@@ -106,7 +132,7 @@ if [ -n "$CHANGED_FILES" ]; then
 fi
 
 if [ "${#SELECTED_GROUPS[@]}" -eq 0 ]; then
-  add_groups_csv "$DEFAULT_GROUPS"
+  add_groups_csv "$DEFAULT_GROUPS" "default-fallback"
 fi
 
 GROUPS_CSV=$(IFS=, ; echo "${SELECTED_GROUPS[*]}")
@@ -114,6 +140,12 @@ GROUPS_CSV=$(IFS=, ; echo "${SELECTED_GROUPS[*]}")
 echo "Base ref: $BASE_REF"
 echo "Base commit: $BASE_COMMIT"
 echo "Selected E2E groups: $GROUPS_CSV"
+if [ "$VERBOSE" = "1" ]; then
+  echo "Selection details:"
+  for i in "${!SELECTED_GROUPS[@]}"; do
+    echo "  - ${SELECTED_GROUPS[$i]} <= ${SELECTED_REASONS[$i]}"
+  done
+fi
 
 if [ "${E2E_CHANGED_DRY_RUN:-0}" = "1" ]; then
   exit 0

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PORT="${FROST_PORT:-3301}"
+BATCH_SIZE="${1:-2}"
+DEV_LOG="${E2E_DEV_LOG:-/tmp/frost-e2e-dev.log}"
+JWT_SECRET="${FROST_JWT_SECRET:-frost-e2e-$(openssl rand -hex 24)}"
+KEEP_DATA="${E2E_KEEP_DATA:-0}"
+
+TEMP_DATA_DIR=0
+if [ -n "${FROST_DATA_DIR:-}" ]; then
+  DATA_DIR="$FROST_DATA_DIR"
+else
+  DATA_DIR="$(mktemp -d /tmp/frost-e2e.XXXXXX)"
+  TEMP_DATA_DIR=1
+fi
+
+cleanup() {
+  local STATUS=$?
+
+  if [ -n "${DEV_PID:-}" ] && kill -0 "$DEV_PID" > /dev/null 2>&1; then
+    kill "$DEV_PID" > /dev/null 2>&1 || true
+    wait "$DEV_PID" > /dev/null 2>&1 || true
+  fi
+
+  if [ "$TEMP_DATA_DIR" -eq 1 ] && [ "$KEEP_DATA" != "1" ] && [ -d "$DATA_DIR" ]; then
+    rm -rf "$DATA_DIR"
+  fi
+
+  exit "$STATUS"
+}
+trap cleanup EXIT
+
+for cmd in curl docker git jq openssl bun; do
+  if ! command -v "$cmd" > /dev/null 2>&1; then
+    echo "Error: required command '$cmd' not found"
+    exit 1
+  fi
+done
+
+if ! (cd "$APP_DIR" && bun --bun next --version > /dev/null 2>&1); then
+  echo "Installing dependencies (bun install)..."
+  (cd "$REPO_ROOT" && bun install)
+fi
+
+mkdir -p "$DATA_DIR"
+rm -f "$DEV_LOG"
+
+echo "========================================"
+echo "Managed Local E2E"
+echo "========================================"
+echo "Port: $PORT"
+echo "Data dir: $DATA_DIR"
+echo "Batch size: $BATCH_SIZE"
+echo "Group glob: ${E2E_GROUP_GLOB:-group-*.sh}"
+echo ""
+
+echo "Starting local Frost dev server..."
+(
+  cd "$APP_DIR"
+  NEXT_TELEMETRY_DISABLED=1 \
+    NODE_ENV=development \
+    FROST_DATA_DIR="$DATA_DIR" \
+    FROST_JWT_SECRET="$JWT_SECRET" \
+    bun --bun next dev -p "$PORT"
+) > "$DEV_LOG" 2>&1 &
+DEV_PID=$!
+
+READY=0
+for i in $(seq 1 90); do
+  if curl -sf "http://localhost:$PORT/api/health" > /dev/null 2>&1; then
+    READY=1
+    break
+  fi
+
+  if ! kill -0 "$DEV_PID" > /dev/null 2>&1; then
+    echo "Dev server exited early. Logs:"
+    tail -n 80 "$DEV_LOG" || true
+    exit 1
+  fi
+
+  sleep 1
+done
+
+if [ "$READY" -ne 1 ]; then
+  echo "Frost dev server did not become healthy on port $PORT"
+  tail -n 80 "$DEV_LOG" || true
+  exit 1
+fi
+echo "✓ Frost dev server is healthy"
+
+echo "Creating API key for test run..."
+API_KEY="$(
+  cd "$APP_DIR"
+  FROST_JWT_SECRET="$JWT_SECRET" \
+    FROST_DATA_DIR="$DATA_DIR" \
+    bun scripts/create-api-key.ts "e2e-local-$(date +%s)"
+)"
+API_KEY="$(echo "$API_KEY" | tr -d '\r\n')"
+
+if [ -z "$API_KEY" ]; then
+  echo "Failed to create API key"
+  exit 1
+fi
+
+AUTH_CODE="$(
+  curl -s -o /dev/null -w "%{http_code}" \
+    -H "X-Frost-Token: $API_KEY" \
+    "http://localhost:$PORT/api/projects"
+)"
+if [ "$AUTH_CODE" != "200" ]; then
+  echo "Generated API key failed auth check (HTTP $AUTH_CODE)"
+  exit 1
+fi
+echo "✓ API key created and verified"
+
+echo ""
+echo "Running E2E tests..."
+FROST_PORT="$PORT" \
+FROST_DATA_DIR="$DATA_DIR" \
+ADMIN_PASSWORD="e2eTestPassword123" \
+  "$SCRIPT_DIR/e2e-local.sh" "$API_KEY" "$BATCH_SIZE"
+
+if [ "$KEEP_DATA" = "1" ] && [ -d "$DATA_DIR" ]; then
+  echo "Kept local E2E data at $DATA_DIR"
+fi

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -7,7 +7,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 PORT="${FROST_PORT:-3301}"
 BATCH_SIZE="${1:-2}"
-DEV_LOG="${E2E_DEV_LOG:-/tmp/frost-e2e-dev.log}"
+DEV_LOG="${E2E_DEV_LOG:-/tmp/frost-dev.log}"
 JWT_SECRET="${FROST_JWT_SECRET:-frost-e2e-$(openssl rand -hex 24)}"
 KEEP_DATA="${E2E_KEEP_DATA:-0}"
 
@@ -94,16 +94,23 @@ fi
 echo "✓ Frost dev server is healthy"
 
 echo "Creating API key for test run..."
-API_KEY="$(
-  cd "$APP_DIR"
-  FROST_JWT_SECRET="$JWT_SECRET" \
-    FROST_DATA_DIR="$DATA_DIR" \
-    bun scripts/create-api-key.ts "e2e-local-$(date +%s)"
-)"
-API_KEY="$(echo "$API_KEY" | tr -d '\r\n')"
+API_KEY=""
+for i in $(seq 1 30); do
+  API_KEY="$(
+    cd "$APP_DIR"
+    FROST_JWT_SECRET="$JWT_SECRET" \
+      FROST_DATA_DIR="$DATA_DIR" \
+      bun scripts/create-api-key.ts "e2e-local-$(date +%s)" 2>/dev/null || true
+  )"
+  API_KEY="$(echo "$API_KEY" | tr -d '\r\n')"
+  if [ -n "$API_KEY" ]; then
+    break
+  fi
+  sleep 1
+done
 
 if [ -z "$API_KEY" ]; then
-  echo "Failed to create API key"
+  echo "Failed to create API key (db may not be ready)"
   exit 1
 fi
 

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -61,7 +61,11 @@ echo "========================================"
 echo "Port: $PORT"
 echo "Data dir: $DATA_DIR"
 echo "Batch size: $BATCH_SIZE"
-echo "Group glob: ${E2E_GROUP_GLOB:-group-*.sh}"
+if [ -n "${E2E_GROUPS:-}" ]; then
+  echo "Groups: $E2E_GROUPS"
+else
+  echo "Group glob: ${E2E_GROUP_GLOB:-group-*.sh}"
+fi
 echo ""
 
 echo "Starting local Frost dev server..."

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -61,10 +61,14 @@ echo "========================================"
 echo "Port: $PORT"
 echo "Data dir: $DATA_DIR"
 echo "Batch size: $BATCH_SIZE"
+echo "Retry failed groups: ${E2E_RETRY_FAILED:-0}"
 if [ -n "${E2E_GROUPS:-}" ]; then
   echo "Groups: $E2E_GROUPS"
 else
   echo "Group glob: ${E2E_GROUP_GLOB:-group-*.sh}"
+fi
+if [ -n "${E2E_REPORT_PATH:-}" ]; then
+  echo "Report path: $E2E_REPORT_PATH"
 fi
 echo ""
 

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -10,6 +10,7 @@ BATCH_SIZE="${1:-2}"
 DEV_LOG="${E2E_DEV_LOG:-/tmp/frost-dev.log}"
 JWT_SECRET="${FROST_JWT_SECRET:-frost-e2e-$(openssl rand -hex 24)}"
 KEEP_DATA="${E2E_KEEP_DATA:-0}"
+KEEP_REPOS="${E2E_KEEP_REPOS:-0}"
 
 TEMP_DATA_DIR=0
 if [ -n "${FROST_DATA_DIR:-}" ]; then
@@ -29,6 +30,10 @@ cleanup() {
 
   if [ "$TEMP_DATA_DIR" -eq 1 ] && [ "$KEEP_DATA" != "1" ] && [ -d "$DATA_DIR" ]; then
     rm -rf "$DATA_DIR"
+  fi
+
+  if [ "$KEEP_REPOS" != "1" ] && [ -d "$APP_DIR/repos" ]; then
+    rm -rf "$APP_DIR/repos"
   fi
 
   exit "$STATUS"

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -72,6 +72,33 @@ docker rm -f $(docker ps -aq --filter "label=frost.managed=true") 2>/dev/null ||
 docker network prune -f > /dev/null 2>&1
 echo "✓ Docker cleanup done"
 
+if [ "${E2E_SKIP_PREPULL:-0}" != "1" ]; then
+  if [ -n "${E2E_PREPULL_IMAGES:-}" ]; then
+    read -r -a PREPULL_IMAGES <<< "$E2E_PREPULL_IMAGES"
+  else
+    PREPULL_IMAGES=("nginx:alpine" "httpd:alpine" "postgres:17" "node:20-alpine" "mariadb:11")
+  fi
+
+  if [ "${#PREPULL_IMAGES[@]}" -gt 0 ]; then
+    echo "Pre-pulling common images..."
+    for image in "${PREPULL_IMAGES[@]}"; do
+      pulled=0
+      for attempt in 1 2 3; do
+        if docker pull "$image" > /dev/null 2>&1; then
+          pulled=1
+          break
+        fi
+        sleep 2
+      done
+      if [ "$pulled" -ne 1 ]; then
+        echo "Error: failed to pull image '$image' after 3 attempts"
+        exit 1
+      fi
+    done
+    echo "✓ Image pre-pull complete"
+  fi
+fi
+
 export SERVER_IP="localhost"
 export API_KEY
 export E2E_LOCAL=1

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -9,6 +9,7 @@ E2E_DIR="$SCRIPT_DIR/e2e"
 BATCH_SIZE=${2:-2}
 PORT=${FROST_PORT:-3000}
 GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
+GROUP_LIST="${E2E_GROUPS:-}"
 
 echo "========================================"
 echo "Local E2E Tests"
@@ -108,12 +109,55 @@ export FROST_PORT="$PORT"
 chmod +x "$E2E_DIR"/*.sh
 
 FAILED=0
-shopt -s nullglob
-ALL_GROUPS=("$E2E_DIR"/$GROUP_GLOB)
-shopt -u nullglob
+ALL_GROUPS=()
+GROUP_KEYS="|"
+
+add_group_path() {
+  local path="$1"
+  [ -f "$path" ] || return 1
+  local key
+  key="$(basename "$path")"
+  case "$GROUP_KEYS" in
+    *"|$key|"*) return 0 ;;
+  esac
+  ALL_GROUPS+=("$path")
+  GROUP_KEYS="${GROUP_KEYS}${key}|"
+  return 0
+}
+
+if [ -n "$GROUP_LIST" ]; then
+  MISSING_GROUP=0
+  GROUP_LIST_NORMALIZED=$(echo "$GROUP_LIST" | tr ',\n\t' '   ')
+  for group in $GROUP_LIST_NORMALIZED; do
+    group="${group%.sh}"
+    case "$group" in
+      */*) GROUP_PATH="$group" ;;
+      group-*) GROUP_PATH="$E2E_DIR/$group.sh" ;;
+      *) GROUP_PATH="$E2E_DIR/group-$group.sh" ;;
+    esac
+
+    if ! add_group_path "$GROUP_PATH"; then
+      echo "Error: requested E2E group not found: $group"
+      MISSING_GROUP=1
+    fi
+  done
+  [ "$MISSING_GROUP" -eq 0 ] || exit 1
+else
+  shopt -s nullglob
+  MATCHED_GROUPS=("$E2E_DIR"/$GROUP_GLOB)
+  shopt -u nullglob
+
+  for group in "${MATCHED_GROUPS[@]}"; do
+    add_group_path "$group" || true
+  done
+fi
 
 if [ "${#ALL_GROUPS[@]}" -eq 0 ]; then
-  echo "No E2E groups matched E2E_GROUP_GLOB='$GROUP_GLOB'"
+  if [ -n "$GROUP_LIST" ]; then
+    echo "No E2E groups selected from E2E_GROUPS='$GROUP_LIST'"
+  else
+    echo "No E2E groups matched E2E_GROUP_GLOB='$GROUP_GLOB'"
+  fi
   exit 1
 fi
 
@@ -121,7 +165,11 @@ TOTAL=${#ALL_GROUPS[@]}
 BATCH=0
 
 echo ""
-echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, glob: $GROUP_GLOB)"
+if [ -n "$GROUP_LIST" ]; then
+  echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, groups: $GROUP_LIST)"
+else
+  echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, glob: $GROUP_GLOB)"
+fi
 echo "Data dir: $FROST_DATA_DIR"
 echo ""
 

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -10,6 +10,7 @@ BATCH_SIZE=${2:-2}
 PORT=${FROST_PORT:-3000}
 GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
 GROUP_LIST="${E2E_GROUPS:-}"
+START_STAGGER_SEC="${E2E_START_STAGGER_SEC:-1}"
 RETRY_FAILED="${E2E_RETRY_FAILED:-0}"
 REPORT_PATH="${E2E_REPORT_PATH:-}"
 REPORT_TMP=""
@@ -204,6 +205,7 @@ if [ -n "$GROUP_LIST" ]; then
 else
   echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, glob: $GROUP_GLOB)"
 fi
+echo "Start stagger: ${START_STAGGER_SEC}s"
 echo "Data dir: $FROST_DATA_DIR"
 echo ""
 
@@ -227,7 +229,9 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
     START_TIMES+=("$(date +%s)")
     "$group" &
     PIDS+=($!)
-    sleep 2
+    if [ "$START_STAGGER_SEC" -gt 0 ] && [ "$j" -lt $((END - 1)) ]; then
+      sleep "$START_STAGGER_SEC"
+    fi
   done
 
   for k in "${!PIDS[@]}"; do
@@ -235,12 +239,14 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
     GROUP_PATH=${GROUP_PATHS[$k]}
     GROUP=${GROUP_NAMES[$k]}
     START_TS=${START_TIMES[$k]}
-    END_TS=$(date +%s)
-    DURATION=$((END_TS - START_TS))
     if wait "$PID"; then
+      END_TS=$(date +%s)
+      DURATION=$((END_TS - START_TS))
       echo "✓ $GROUP passed"
       record_result "$GROUP" "passed" "$DURATION" 1
     else
+      END_TS=$(date +%s)
+      DURATION=$((END_TS - START_TS))
       echo "✗ $GROUP FAILED"
       record_result "$GROUP" "failed" "$DURATION" 1
       FAILED=1

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 E2E_DIR="$SCRIPT_DIR/e2e"
 
-BATCH_SIZE=${2:-4}
+BATCH_SIZE=${2:-2}
 PORT=${FROST_PORT:-3000}
+GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
 
 echo "========================================"
 echo "Local E2E Tests"
@@ -15,6 +16,13 @@ echo "========================================"
 echo ""
 
 cd "$APP_DIR"
+
+for cmd in curl docker git jq openssl bun; do
+  if ! command -v "$cmd" > /dev/null 2>&1; then
+    echo "Error: required command '$cmd' not found"
+    exit 1
+  fi
+done
 
 if ! curl -sf "http://localhost:$PORT/api/health" > /dev/null 2>&1; then
   echo "Error: Frost not running on localhost:$PORT"
@@ -25,8 +33,28 @@ echo "✓ Frost running on port $PORT"
 
 API_KEY="${1:-${FROST_API_KEY:-}}"
 if [ -z "$API_KEY" ]; then
+  if [ -n "${FROST_JWT_SECRET:-}" ]; then
+    echo "No API key provided, attempting to create one from local DB..."
+    GENERATED_KEY=$(FROST_JWT_SECRET="$FROST_JWT_SECRET" \
+      FROST_DATA_DIR="${FROST_DATA_DIR:-$APP_DIR/data}" \
+      bun scripts/create-api-key.ts "e2e-local-$(date +%s)" 2>/dev/null || true)
+
+    if [ -n "$GENERATED_KEY" ]; then
+      AUTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "X-Frost-Token: $GENERATED_KEY" \
+        "http://localhost:$PORT/api/projects")
+      if [ "$AUTH_CODE" = "200" ]; then
+        API_KEY="$GENERATED_KEY"
+        echo "✓ Created API key automatically"
+      fi
+    fi
+  fi
+fi
+
+if [ -z "$API_KEY" ]; then
   echo "Usage: $0 <api-key>"
   echo "Or set FROST_API_KEY environment variable"
+  echo "Tip: use ./apps/app/scripts/e2e-local-managed.sh for fully managed local E2E"
   exit 1
 fi
 echo "✓ API key provided"
@@ -47,17 +75,27 @@ echo "✓ Docker cleanup done"
 export SERVER_IP="localhost"
 export API_KEY
 export E2E_LOCAL=1
-export FROST_DATA_DIR="$APP_DIR/data"
+export FROST_DATA_DIR="${FROST_DATA_DIR:-$APP_DIR/data}"
+export FROST_PORT="$PORT"
 
 chmod +x "$E2E_DIR"/*.sh
 
 FAILED=0
-ALL_GROUPS=("$E2E_DIR"/group-*.sh)
+shopt -s nullglob
+ALL_GROUPS=("$E2E_DIR"/$GROUP_GLOB)
+shopt -u nullglob
+
+if [ "${#ALL_GROUPS[@]}" -eq 0 ]; then
+  echo "No E2E groups matched E2E_GROUP_GLOB='$GROUP_GLOB'"
+  exit 1
+fi
+
 TOTAL=${#ALL_GROUPS[@]}
 BATCH=0
 
 echo ""
-echo "Running $TOTAL test groups (batch size: $BATCH_SIZE)"
+echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, glob: $GROUP_GLOB)"
+echo "Data dir: $FROST_DATA_DIR"
 echo ""
 
 for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -10,6 +10,20 @@ BATCH_SIZE=${2:-2}
 PORT=${FROST_PORT:-3000}
 GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
 GROUP_LIST="${E2E_GROUPS:-}"
+RETRY_FAILED="${E2E_RETRY_FAILED:-0}"
+REPORT_PATH="${E2E_REPORT_PATH:-}"
+REPORT_TMP=""
+
+cleanup_report() {
+  if [ -n "${REPORT_TMP:-}" ] && [ -f "$REPORT_TMP" ]; then
+    rm -f "$REPORT_TMP"
+  fi
+}
+trap cleanup_report EXIT
+
+if [ -n "$REPORT_PATH" ]; then
+  REPORT_TMP="$(mktemp /tmp/frost-e2e-report.XXXXXX)"
+fi
 
 echo "========================================"
 echo "Local E2E Tests"
@@ -125,6 +139,24 @@ add_group_path() {
   return 0
 }
 
+record_result() {
+  local group="$1"
+  local status="$2"
+  local duration="$3"
+  local attempt="$4"
+
+  if [ -z "$REPORT_PATH" ]; then
+    return 0
+  fi
+
+  jq -nc \
+    --arg group "$group" \
+    --arg status "$status" \
+    --argjson durationSec "$duration" \
+    --argjson attempt "$attempt" \
+    '{group: $group, status: $status, durationSec: $durationSec, attempt: $attempt}' >> "$REPORT_TMP"
+}
+
 if [ -n "$GROUP_LIST" ]; then
   MISSING_GROUP=0
   GROUP_LIST_NORMALIZED=$(echo "$GROUP_LIST" | tr ',\n\t' '   ')
@@ -163,6 +195,8 @@ fi
 
 TOTAL=${#ALL_GROUPS[@]}
 BATCH=0
+FAILED_GROUP_PATHS=()
+FAILED_GROUP_NAMES=()
 
 echo ""
 if [ -n "$GROUP_LIST" ]; then
@@ -176,7 +210,9 @@ echo ""
 for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
   BATCH=$((BATCH+1))
   PIDS=()
+  GROUP_PATHS=()
   GROUP_NAMES=()
+  START_TIMES=()
 
   END=$((i + BATCH_SIZE))
   [ $END -gt $TOTAL ] && END=$TOTAL
@@ -186,7 +222,9 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
   for ((j=i; j<END; j++)); do
     group="${ALL_GROUPS[$j]}"
     GROUP_NAME=$(basename "$group" .sh)
+    GROUP_PATHS+=("$group")
     GROUP_NAMES+=("$GROUP_NAME")
+    START_TIMES+=("$(date +%s)")
     "$group" &
     PIDS+=($!)
     sleep 2
@@ -194,16 +232,84 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
 
   for k in "${!PIDS[@]}"; do
     PID=${PIDS[$k]}
+    GROUP_PATH=${GROUP_PATHS[$k]}
     GROUP=${GROUP_NAMES[$k]}
+    START_TS=${START_TIMES[$k]}
+    END_TS=$(date +%s)
+    DURATION=$((END_TS - START_TS))
     if wait "$PID"; then
       echo "✓ $GROUP passed"
+      record_result "$GROUP" "passed" "$DURATION" 1
     else
       echo "✗ $GROUP FAILED"
+      record_result "$GROUP" "failed" "$DURATION" 1
       FAILED=1
+      FAILED_GROUP_PATHS+=("$GROUP_PATH")
+      FAILED_GROUP_NAMES+=("$GROUP")
     fi
   done
   echo ""
 done
+
+if [ "$FAILED" -ne 0 ] && [ "$RETRY_FAILED" = "1" ] && [ "${#FAILED_GROUP_PATHS[@]}" -gt 0 ]; then
+  echo "Retrying failed groups once..."
+  RETRY_UNIQUE_KEYS="|"
+  RETRY_REMAINING_PATHS=()
+  RETRY_REMAINING_NAMES=()
+
+  for idx in "${!FAILED_GROUP_PATHS[@]}"; do
+    GROUP_PATH="${FAILED_GROUP_PATHS[$idx]}"
+    GROUP="${FAILED_GROUP_NAMES[$idx]}"
+    GROUP_KEY="$(basename "$GROUP_PATH")"
+
+    case "$RETRY_UNIQUE_KEYS" in
+      *"|$GROUP_KEY|"*) continue ;;
+    esac
+    RETRY_UNIQUE_KEYS="${RETRY_UNIQUE_KEYS}${GROUP_KEY}|"
+
+    echo "--- Retry: $GROUP ---"
+    START_TS=$(date +%s)
+    if "$GROUP_PATH"; then
+      END_TS=$(date +%s)
+      DURATION=$((END_TS - START_TS))
+      echo "✓ $GROUP passed on retry"
+      record_result "$GROUP" "passed" "$DURATION" 2
+    else
+      END_TS=$(date +%s)
+      DURATION=$((END_TS - START_TS))
+      echo "✗ $GROUP FAILED on retry"
+      record_result "$GROUP" "failed" "$DURATION" 2
+      RETRY_REMAINING_PATHS+=("$GROUP_PATH")
+      RETRY_REMAINING_NAMES+=("$GROUP")
+    fi
+    echo ""
+  done
+
+  if [ "${#RETRY_REMAINING_PATHS[@]}" -eq 0 ]; then
+    FAILED=0
+    FAILED_GROUP_PATHS=()
+    FAILED_GROUP_NAMES=()
+  else
+    FAILED=1
+    FAILED_GROUP_PATHS=("${RETRY_REMAINING_PATHS[@]}")
+    FAILED_GROUP_NAMES=("${RETRY_REMAINING_NAMES[@]}")
+  fi
+fi
+
+FINAL_FAILED_COUNT=${#FAILED_GROUP_NAMES[@]}
+FINAL_PASSED_COUNT=$((TOTAL - FINAL_FAILED_COUNT))
+
+if [ "$FINAL_FAILED_COUNT" -gt 0 ]; then
+  echo "Failed groups: ${FAILED_GROUP_NAMES[*]}"
+fi
+
+echo "Summary: $FINAL_PASSED_COUNT passed, $FINAL_FAILED_COUNT failed"
+
+if [ -n "$REPORT_PATH" ]; then
+  mkdir -p "$(dirname "$REPORT_PATH")"
+  jq -s '.' "$REPORT_TMP" > "$REPORT_PATH"
+  echo "Wrote E2E report: $REPORT_PATH"
+fi
 
 if [ "$FAILED" -eq 0 ]; then
   echo "========================================"

--- a/apps/app/scripts/e2e-test.sh
+++ b/apps/app/scripts/e2e-test.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-SERVER_IP=$1
-API_KEY=$2
-BATCH_SIZE=${3:-4}  # Run 4 groups in parallel (port allocator is thread-safe)
+SERVER_IP="${1:-}"
+API_KEY="${2:-}"
+BATCH_SIZE="${3:-${E2E_BATCH_SIZE:-4}}"
+START_STAGGER_SEC="${E2E_START_STAGGER_SEC:-1}"
+GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
+GROUP_LIST="${E2E_GROUPS:-}"
 
 if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ]; then
   echo "Usage: $0 <server-ip> <api-key> [batch-size]"
+  echo "Optional env: E2E_GROUPS='01-basic,04-update' E2E_GROUP_GLOB='group-0*.sh' E2E_START_STAGGER_SEC=1"
   exit 1
 fi
 
@@ -19,6 +23,7 @@ E2E_DIR="$SCRIPT_DIR/e2e"
 echo "========================================"
 echo "Running E2E tests against http://$SERVER_IP:3000"
 echo "Batch size: $BATCH_SIZE groups at a time"
+echo "Start stagger: ${START_STAGGER_SEC}s"
 echo "========================================"
 echo ""
 
@@ -30,9 +35,44 @@ echo ""
 chmod +x "$E2E_DIR"/*.sh
 
 FAILED=0
-ALL_GROUPS=("$E2E_DIR"/group-*.sh)
+ALL_GROUPS=()
+
+if [ -n "$GROUP_LIST" ]; then
+  MISSING_GROUP=0
+  GROUP_LIST_NORMALIZED=$(echo "$GROUP_LIST" | tr ',\n\t' '   ')
+  for group in $GROUP_LIST_NORMALIZED; do
+    group="${group%.sh}"
+    case "$group" in
+      */*) GROUP_PATH="$group" ;;
+      group-*) GROUP_PATH="$E2E_DIR/$group.sh" ;;
+      *) GROUP_PATH="$E2E_DIR/group-$group.sh" ;;
+    esac
+
+    if [ -f "$GROUP_PATH" ]; then
+      ALL_GROUPS+=("$GROUP_PATH")
+    else
+      echo "Error: requested E2E group not found: $group"
+      MISSING_GROUP=1
+    fi
+  done
+  [ "$MISSING_GROUP" -eq 0 ] || exit 1
+else
+  shopt -s nullglob
+  ALL_GROUPS=("$E2E_DIR"/$GROUP_GLOB)
+  shopt -u nullglob
+fi
+
 TOTAL=${#ALL_GROUPS[@]}
 BATCH=0
+
+if [ "$TOTAL" -eq 0 ]; then
+  if [ -n "$GROUP_LIST" ]; then
+    echo "No E2E groups selected from E2E_GROUPS='$GROUP_LIST'"
+  else
+    echo "No E2E groups matched E2E_GROUP_GLOB='$GROUP_GLOB'"
+  fi
+  exit 1
+fi
 
 echo "Total test groups: $TOTAL"
 echo ""
@@ -53,7 +93,9 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
     GROUP_NAMES+=("$GROUP_NAME")
     "$group" &
     PIDS+=($!)
-    sleep 5  # Stagger starts to avoid port allocation race
+    if [ "$START_STAGGER_SEC" -gt 0 ] && [ "$j" -lt $((END - 1)) ]; then
+      sleep "$START_STAGGER_SEC"
+    fi
   done
 
   for k in "${!PIDS[@]}"; do

--- a/apps/app/scripts/e2e/common.sh
+++ b/apps/app/scripts/e2e/common.sh
@@ -2,7 +2,8 @@
 
 export SERVER_IP="${SERVER_IP:?SERVER_IP required}"
 export API_KEY="${API_KEY:?API_KEY required}"
-export BASE_URL="http://$SERVER_IP:3000"
+E2E_PORT="${FROST_PORT:-3000}"
+export BASE_URL="http://$SERVER_IP:$E2E_PORT"
 
 if [ -z "${FROST_DATA_DIR:-}" ]; then
   if [ "${E2E_LOCAL:-}" = "1" ]; then

--- a/apps/app/scripts/e2e/common.sh
+++ b/apps/app/scripts/e2e/common.sh
@@ -4,6 +4,7 @@ export SERVER_IP="${SERVER_IP:?SERVER_IP required}"
 export API_KEY="${API_KEY:?API_KEY required}"
 E2E_PORT="${FROST_PORT:-3000}"
 export BASE_URL="http://$SERVER_IP:$E2E_PORT"
+export E2E_FAIL_ON_5XX="${E2E_FAIL_ON_5XX:-1}"
 
 if [ -z "${FROST_DATA_DIR:-}" ]; then
   if [ "${E2E_LOCAL:-}" = "1" ]; then
@@ -52,6 +53,10 @@ api() {
     fi
   fi
   echo "$RESPONSE"
+
+  if [ "$HTTP_CODE" -ge 500 ] 2>/dev/null && [ "$E2E_FAIL_ON_5XX" = "1" ]; then
+    return 1
+  fi
 }
 
 json_get() {

--- a/apps/app/scripts/e2e/group-26-replicas.sh
+++ b/apps/app/scripts/e2e/group-26-replicas.sh
@@ -107,8 +107,14 @@ REPLICAS4=$(api "$BASE_URL/api/deployments/$DEPLOY4_ID/replicas")
 REPLICA_COUNT4=$(echo "$REPLICAS4" | jq 'length')
 [ "$REPLICA_COUNT4" = "1" ] || fail "Expected 1 replica after scale-down, got $REPLICA_COUNT4"
 
-sleep 2
-DOCKER_COUNT=$(remote "docker ps --filter name=${SANITIZED_PREFIX} --format '{{.Names}}' | wc -l" | tr -d ' ')
+DOCKER_COUNT=""
+for i in $(seq 1 20); do
+  DOCKER_COUNT=$(remote "docker ps --filter name=${SANITIZED_PREFIX} --format '{{.Names}}' | wc -l" | tr -d ' ')
+  if [ "$DOCKER_COUNT" = "1" ]; then
+    break
+  fi
+  sleep 1
+done
 [ "$DOCKER_COUNT" = "1" ] || fail "Expected 1 container after scale-down, got $DOCKER_COUNT"
 log "Test 4 passed: scaled down to 1 replica"
 

--- a/apps/app/scripts/e2e/group-27-replica-logs.sh
+++ b/apps/app/scripts/e2e/group-27-replica-logs.sh
@@ -44,7 +44,7 @@ sleep 2
 # --- Test 1: Runtime logs stream from all replicas ---
 log "Test 1: Runtime logs from all replicas"
 
-LOG_OUTPUT=$(curl -sf --max-time 5 "http://$SERVER_IP:3000/api/deployments/$DEPLOY_ID/logs?tail=20" \
+LOG_OUTPUT=$(curl -sf --max-time 5 "$BASE_URL/api/deployments/$DEPLOY_ID/logs?tail=20" \
   -H "X-Frost-Token: $API_KEY" 2>/dev/null || true)
 
 HAS_R0=$(echo "$LOG_OUTPUT" | grep -c '\[replica-0\]' || true)
@@ -57,7 +57,7 @@ log "Test 1 passed: logs contain both [replica-0] and [replica-1]"
 # --- Test 2: Runtime logs filter by replica ---
 log "Test 2: Runtime logs filter by replica"
 
-LOG_FILTERED=$(curl -sf --max-time 5 "http://$SERVER_IP:3000/api/deployments/$DEPLOY_ID/logs?tail=20&replica=0" \
+LOG_FILTERED=$(curl -sf --max-time 5 "$BASE_URL/api/deployments/$DEPLOY_ID/logs?tail=20&replica=0" \
   -H "X-Frost-Token: $API_KEY" 2>/dev/null || true)
 
 HAS_R1_FILTERED=$(echo "$LOG_FILTERED" | grep -c '\[replica-1\]' || true)

--- a/apps/app/src/server/settings.ts
+++ b/apps/app/src/server/settings.ts
@@ -1,5 +1,6 @@
 import { promises as dns } from "node:dns";
 import https from "node:https";
+import { ORPCError } from "@orpc/server";
 import {
   getAdminPasswordHash,
   getSetting,
@@ -170,16 +171,16 @@ export const settings = {
 
     const caddyRunning = await isCaddyRunning();
     if (!caddyRunning) {
-      throw new Error(
-        "Caddy is not running. Please ensure Caddy is installed.",
-      );
+      throw new ORPCError("BAD_REQUEST", {
+        message: "Caddy is not running. Please ensure Caddy is installed.",
+      });
     }
 
     const dnsValid = await verifyDns(domain);
     if (!dnsValid) {
-      throw new Error(
-        "DNS not configured correctly. Domain must point to this server.",
-      );
+      throw new ORPCError("BAD_REQUEST", {
+        message: "DNS not configured correctly. Domain must point to this server.",
+      });
     }
 
     await configureDomain(domain, email, staging);
@@ -197,12 +198,14 @@ export const settings = {
 
     const storedHash = await getAdminPasswordHash();
     if (!storedHash) {
-      throw new Error("No password configured");
+      throw new ORPCError("BAD_REQUEST", { message: "No password configured" });
     }
 
     const valid = await verifyPassword(currentPassword, storedHash);
     if (!valid) {
-      throw new Error("Current password is incorrect");
+      throw new ORPCError("BAD_REQUEST", {
+        message: "Current password is incorrect",
+      });
     }
 
     const newHash = await hashPassword(newPassword);
@@ -242,7 +245,9 @@ export const settings = {
       const sslEnabled = await getSetting("ssl_enabled");
 
       if (!domain || sslEnabled !== "true") {
-        throw new Error("Domain with SSL must be configured first");
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Domain with SSL must be configured first",
+        });
       }
 
       const manifest = buildManifest(domain) as Record<string, unknown>;
@@ -282,7 +287,9 @@ export const settings = {
       const { wildcardDomain, dnsProvider, dnsApiToken } = input;
 
       if (dnsProvider !== "cloudflare") {
-        throw new Error("Only cloudflare is supported as DNS provider");
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Only cloudflare is supported as DNS provider",
+        });
       }
 
       const domainWithoutWildcard = wildcardDomain.replace(/^\*\./, "");
@@ -339,7 +346,9 @@ export const settings = {
       const { dnsProvider, dnsApiToken } = input;
 
       if (dnsProvider !== "cloudflare") {
-        throw new Error("Only cloudflare is supported");
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Only cloudflare is supported",
+        });
       }
 
       try {

--- a/apps/app/src/server/settings.ts
+++ b/apps/app/src/server/settings.ts
@@ -179,7 +179,8 @@ export const settings = {
     const dnsValid = await verifyDns(domain);
     if (!dnsValid) {
       throw new ORPCError("BAD_REQUEST", {
-        message: "DNS not configured correctly. Domain must point to this server.",
+        message:
+          "DNS not configured correctly. Domain must point to this server.",
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,13 @@
     "db:gen": "bun --cwd apps/app db:gen",
     "test": "bun --cwd apps/app test",
     "e2e:local": "bash ./apps/app/scripts/e2e-local-managed.sh",
+    "e2e:local:retry": "E2E_RETRY_FAILED=1 bash ./apps/app/scripts/e2e-local-managed.sh",
+    "e2e:local:report": "E2E_REPORT_PATH=/tmp/frost-e2e-report.json bash ./apps/app/scripts/e2e-local-managed.sh",
     "e2e:local:existing": "bash ./apps/app/scripts/e2e-local.sh",
     "e2e:smoke": "E2E_GROUPS='01-basic,04-update,10-race,20-setup,28-oauth,29-mcp' bash ./apps/app/scripts/e2e-local-managed.sh 1",
+    "e2e:smoke:retry": "E2E_RETRY_FAILED=1 E2E_GROUPS='01-basic,04-update,10-race,20-setup,28-oauth,29-mcp' bash ./apps/app/scripts/e2e-local-managed.sh 1",
     "e2e:changed": "bash ./apps/app/scripts/e2e-changed.sh",
+    "e2e:changed:retry": "E2E_RETRY_FAILED=1 bash ./apps/app/scripts/e2e-changed.sh",
     "e2e:changed:print": "E2E_CHANGED_DRY_RUN=1 bash ./apps/app/scripts/e2e-changed.sh",
     "dev:marketing": "bun --cwd apps/marketing dev",
     "build:marketing": "bun --cwd apps/marketing build"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "format": "biome format --write .",
     "db:gen": "bun --cwd apps/app db:gen",
     "test": "bun --cwd apps/app test",
+    "e2e:local": "bash ./apps/app/scripts/e2e-local-managed.sh",
+    "e2e:local:existing": "bash ./apps/app/scripts/e2e-local.sh",
     "dev:marketing": "bun --cwd apps/marketing dev",
     "build:marketing": "bun --cwd apps/marketing build"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test": "bun --cwd apps/app test",
     "e2e:local": "bash ./apps/app/scripts/e2e-local-managed.sh",
     "e2e:local:existing": "bash ./apps/app/scripts/e2e-local.sh",
+    "e2e:smoke": "E2E_GROUPS='01-basic,04-update,10-race,20-setup,28-oauth,29-mcp' bash ./apps/app/scripts/e2e-local-managed.sh 1",
+    "e2e:changed": "bash ./apps/app/scripts/e2e-changed.sh",
+    "e2e:changed:print": "E2E_CHANGED_DRY_RUN=1 bash ./apps/app/scripts/e2e-changed.sh",
     "dev:marketing": "bun --cwd apps/marketing dev",
     "build:marketing": "bun --cwd apps/marketing build"
   },


### PR DESCRIPTION
## Summary
- reduce E2E group launch staggering overhead by default (`E2E_START_STAGGER_SEC=1`)
- avoid sleeping after the last group start in each batch
- add `E2E_GROUPS` / `E2E_GROUP_GLOB` support to `e2e-test.sh` so CI can run targeted subsets
- fix local JSON report group durations to measure actual runtime (previously measured before `wait`)
- document `E2E_START_STAGGER_SEC` for local runs

## Why
- current CI E2E runtime is dominated by orchestration overhead and can be reduced without cutting test coverage
- better local timing data helps identify the real slow groups

## Validation
- `bash -n apps/app/scripts/e2e-test.sh`
- `bash -n apps/app/scripts/e2e-local.sh`
- `bun run lint`
- `bun run typecheck`
