### PR TITLE
test: speed up e2e group scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,7 @@ jobs:
           ./apps/app/scripts/e2e-test.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}" 2>&1 | tee /tmp/e2e-tests.log
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
+          E2E_GROUPS: 01-basic,04-update,10-race,20-setup,28-oauth,29-mcp
 
       - name: Reset to release version for UI update test
         if: steps.release.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,51 +526,6 @@ jobs:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
           E2E_GROUPS: 01-basic,04-update,10-race,20-setup,28-oauth,29-mcp
 
-      - name: Reset to release version for UI update test
-        if: steps.release.outputs.skip != 'true'
-        run: |
-          TAG="${{ steps.release.outputs.tag }}"
-          echo "Resetting to release $TAG for UI update test..."
-
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "cd /opt/frost && \
-            systemctl stop frost && \
-            rm -rf repos apps && \
-            git fetch origin && \
-            git checkout -f $TAG && \
-            git reset --hard $TAG && \
-            git clean -fdx -e data -e .env && \
-            export BUN_INSTALL=\"\$HOME/.bun\" && \
-            export PATH=\"\$BUN_INSTALL/bin:\$PATH\" && \
-            bun install 2>&1 && \
-            (for attempt in 1 2 3; do if NEXT_TELEMETRY_DISABLED=1 bun run build 2>&1; then exit 0; fi; echo \"Build failed (attempt \$attempt/3), retrying...\"; rm -rf apps/app/.next; sleep 2; done; exit 1) && \
-            bun run migrate 2>&1 && \
-            sed -i 's|ExecStart=.*|ExecStart=/usr/local/bin/bun run start|' /etc/systemd/system/frost.service && \
-            systemctl daemon-reload && \
-            systemctl start frost" 2>&1 | tee /tmp/e2e-reset-ui.log
-
-          echo "Waiting for Frost on port 3000..."
-          for i in {1..24}; do
-            if curl -s "http://${{ steps.server.outputs.ip }}:3000/api/health" | grep -q "ok"; then
-              echo "Frost is ready!"
-              exit 0
-            fi
-            echo "Attempt $i: Frost not ready..."
-            sleep 5
-          done
-          echo "Frost failed to start"
-          ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 100" || true
-          exit 1
-
-      - name: Test UI-triggered update flow
-        if: steps.release.outputs.skip != 'true'
-        run: |
-          chmod +x ./apps/app/scripts/e2e-update-ui.sh
-          ./apps/app/scripts/e2e-update-ui.sh \
-            "${{ steps.server.outputs.ip }}" \
-            "${{ steps.install.outputs.api_key }}" \
-            "${{ github.head_ref || github.ref_name }}" \
-            "${{ github.repository }}" 2>&1 | tee /tmp/e2e-update-ui.log
-
       - name: Create broken branch for rollback test
         if: steps.release.outputs.skip != 'true'
         id: broken
@@ -599,11 +554,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Reset to release version for rollback test
+      - name: Reset to release version for rollback and UI tests
         if: steps.release.outputs.skip != 'true'
         run: |
           TAG="${{ steps.release.outputs.tag }}"
-          echo "Resetting to release $TAG for rollback test..."
+          echo "Resetting to release $TAG..."
 
           ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "cd /opt/frost && \
             systemctl stop frost && \
@@ -619,7 +574,7 @@ jobs:
             bun run migrate 2>&1 && \
             sed -i 's|ExecStart=.*|ExecStart=/usr/local/bin/bun run start|' /etc/systemd/system/frost.service && \
             systemctl daemon-reload && \
-            systemctl start frost" 2>&1 | tee /tmp/e2e-reset-rollback.log
+            systemctl start frost" 2>&1 | tee /tmp/e2e-reset-release.log
 
           echo "Waiting for Frost on port 3000..."
           for i in {1..24}; do
@@ -643,6 +598,16 @@ jobs:
             "${{ steps.install.outputs.api_key }}" \
             "${{ steps.broken.outputs.branch }}" \
             "${{ github.repository }}" 2>&1 | tee /tmp/e2e-rollback.log
+
+      - name: Test UI-triggered update flow
+        if: steps.release.outputs.skip != 'true'
+        run: |
+          chmod +x ./apps/app/scripts/e2e-update-ui.sh
+          ./apps/app/scripts/e2e-update-ui.sh \
+            "${{ steps.server.outputs.ip }}" \
+            "${{ steps.install.outputs.api_key }}" \
+            "${{ github.head_ref || github.ref_name }}" \
+            "${{ github.repository }}" 2>&1 | tee /tmp/e2e-update-ui.log
 
       - name: Cleanup broken branch
         if: always() && steps.broken.outputs.branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Run locally (fully managed, recommended):
 ```bash
 bun run e2e:local                       # boots isolated local Frost + runs all groups
 E2E_GROUP_GLOB='group-0[1-4]*.sh' bun run e2e:local  # run subset
+E2E_START_STAGGER_SEC=0 bun run e2e:local  # disable between-group launch delay
 E2E_RETRY_FAILED=1 bun run e2e:local    # auto-retry failed groups once
 E2E_REPORT_PATH=/tmp/frost-e2e.json bun run e2e:local # write JSON report
 bun run e2e:smoke                       # fast high-signal subset
@@ -57,6 +58,7 @@ bun run e2e:local:existing <api-key>          # run all tests
 bun run e2e:local:existing <api-key> 2        # custom batch size
 FROST_PORT=3301 bun run e2e:local:existing <api-key> # custom port
 E2E_GROUPS='01-basic,23-change-password' bun run e2e:local:existing <api-key>  # explicit groups
+E2E_START_STAGGER_SEC=0 bun run e2e:local:existing <api-key> # disable launch delay
 
 # run single test
 SERVER_IP=localhost API_KEY=<key> E2E_LOCAL=1 FROST_DATA_DIR=./apps/app/data \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,10 @@ bun run e2e:smoke                       # fast high-signal subset
 bun run e2e:smoke:retry                 # smoke subset + retry failed groups
 bun run e2e:changed                     # auto-select groups based on git changes
 bun run e2e:changed:retry               # changed groups + retry failed groups
+bun run e2e:changed:fast                # changed groups + retry + JSON report
 bun run e2e:changed:print               # print selected groups only
+bun run e2e:profile:week1               # baseline harness: full + individual + CI step timings
+bun run e2e:soak:week1                  # stability soak matrix (full + individual + top slow groups)
 ```
 
 Run against an existing local Frost instance (start `bun run dev` first):
@@ -59,6 +62,7 @@ bun run e2e:local:existing <api-key> 2        # custom batch size
 FROST_PORT=3301 bun run e2e:local:existing <api-key> # custom port
 E2E_GROUPS='01-basic,23-change-password' bun run e2e:local:existing <api-key>  # explicit groups
 E2E_START_STAGGER_SEC=0 bun run e2e:local:existing <api-key> # disable launch delay
+E2E_BATCH_SIZE=4 bun run e2e:local:existing <api-key>        # shared batch-size env knob
 
 # run single test
 SERVER_IP=localhost API_KEY=<key> E2E_LOCAL=1 FROST_DATA_DIR=./apps/app/data \
@@ -68,7 +72,25 @@ SERVER_IP=localhost API_KEY=<key> E2E_LOCAL=1 FROST_DATA_DIR=./apps/app/data \
 Run against remote VPS:
 ```bash
 ./apps/app/scripts/e2e-test.sh <ip> <api-key>
+E2E_GROUPS='01-basic,10-race,29-mcp' ./apps/app/scripts/e2e-test.sh <ip> <api-key> # explicit groups
+E2E_START_STAGGER_SEC=0 ./apps/app/scripts/e2e-test.sh <ip> <api-key>                # max speed
 ```
+
+Script knobs (standardized):
+- `E2E_GROUPS` - comma-separated explicit groups (e.g. `01-basic,28-oauth`)
+- `E2E_GROUP_GLOB` - shell glob for group files (default: `group-*.sh`)
+- `E2E_START_STAGGER_SEC` - delay between group starts in a batch
+- `E2E_BATCH_SIZE` - groups per batch (CI defaults to 4)
+
+Image-pull resiliency knobs:
+- `FROST_IMAGE_PULL_RETRIES` (default `3`)
+- `FROST_IMAGE_PULL_BACKOFF_MS` (default `2000`)
+- `FROST_IMAGE_PULL_MAX_BACKOFF_MS` (default `10000`)
+
+Troubleshooting transient pull flakes:
+- If logs contain `context deadline exceeded`, `i/o timeout`, or `proxyconnect tcp`, treat as infra/transient first.
+- Re-run with retries enabled (default runtime pull retries are already on).
+- For local runs, keep pre-pull enabled and avoid over-aggressive parallelism (`E2E_START_STAGGER_SEC=1`).
 
 E2E tests run automatically via GitHub Actions on PRs.
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,32 @@ bun run dev
 bun run e2e:local
 bun run e2e:smoke
 bun run e2e:changed
+bun run e2e:changed:fast
+bun run e2e:profile:week1
 ```
 
 Open http://localhost:3000
+
+### E2E Speed + Profiling
+
+```bash
+# Fast local loop (changed groups + retry + report)
+bun run e2e:changed:fast
+
+# Full profile artifacts in /tmp/frost-e2e-week1
+bun run e2e:profile:week1
+
+# Standardized knobs
+E2E_GROUPS='01-basic,04-update,29-mcp' bun run e2e:local
+E2E_GROUP_GLOB='group-2*.sh' bun run e2e:local
+E2E_BATCH_SIZE=4 E2E_START_STAGGER_SEC=1 bun run e2e:local
+```
+
+### Troubleshooting Transient Pull Failures
+
+- Runtime image pulls automatically retry with backoff (`FROST_IMAGE_PULL_RETRIES`, `FROST_IMAGE_PULL_BACKOFF_MS`, `FROST_IMAGE_PULL_MAX_BACKOFF_MS`).
+- Timeout signatures such as `context deadline exceeded`, `i/o timeout`, and `proxyconnect tcp` are treated as transient infra failures in deployment logs.
+- If a local run flakes on pull, rerun with the managed runner (`bun run e2e:local`) so pre-pull and retries are applied.
 
 ## Requirements
 

--- a/apps/app/scripts/e2e-ci-step-durations.sh
+++ b/apps/app/scripts/e2e-ci-step-durations.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+OUTPUT_PATH="${1:-/tmp/frost-e2e-week1/ci-step-durations.json}"
+RUN_ID="${E2E_CI_RUN_ID:-}"
+REPO="${E2E_CI_REPO:-elitan/frost}"
+
+cd "$REPO_ROOT"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+if ! command -v gh > /dev/null 2>&1; then
+  echo "[]" > "$OUTPUT_PATH"
+  echo "gh CLI not found, wrote empty CI step durations to $OUTPUT_PATH"
+  exit 0
+fi
+
+if [ -z "$RUN_ID" ]; then
+  BRANCH="${E2E_CI_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+  RUN_ID="$(
+    gh run list \
+      --repo "$REPO" \
+      --workflow ci.yml \
+      --branch "$BRANCH" \
+      --limit 1 \
+      --json databaseId \
+      --jq '.[0].databaseId // empty'
+  )"
+fi
+
+if [ -z "$RUN_ID" ]; then
+  echo "[]" > "$OUTPUT_PATH"
+  echo "No CI run found, wrote empty CI step durations to $OUTPUT_PATH"
+  exit 0
+fi
+
+gh run view "$RUN_ID" --repo "$REPO" --json jobs \
+  | jq --argjson runId "$RUN_ID" '
+      [
+        .jobs[] as $job
+        | .steps[]?
+        | select(.startedAt != null and .completedAt != null)
+        | {
+            runId: $runId,
+            job: $job.name,
+            step: .name,
+            status: .status,
+            conclusion: .conclusion,
+            startedAt: .startedAt,
+            completedAt: .completedAt,
+            durationSec: ((.completedAt | fromdateiso8601) - (.startedAt | fromdateiso8601))
+          }
+      ]
+    ' > "$OUTPUT_PATH"
+
+echo "Wrote CI step durations for run $RUN_ID to $OUTPUT_PATH"

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -11,6 +11,11 @@ DEV_LOG="${E2E_DEV_LOG:-/tmp/frost-dev.log}"
 JWT_SECRET="${FROST_JWT_SECRET:-frost-e2e-$(openssl rand -hex 24)}"
 KEEP_DATA="${E2E_KEEP_DATA:-0}"
 KEEP_REPOS="${E2E_KEEP_REPOS:-0}"
+API_KEY_RETRIES="${E2E_API_KEY_RETRIES:-60}"
+API_KEY_RETRY_SEC="${E2E_API_KEY_RETRY_SEC:-1}"
+API_KEY_VERIFY_RETRIES="${E2E_API_KEY_VERIFY_RETRIES:-30}"
+API_KEY_VERIFY_RETRY_SEC="${E2E_API_KEY_VERIFY_RETRY_SEC:-1}"
+KILL_STALE_PORT="${E2E_KILL_STALE_PORT:-1}"
 
 TEMP_DATA_DIR=0
 if [ -n "${FROST_DATA_DIR:-}" ]; then
@@ -26,6 +31,13 @@ cleanup() {
   if [ -n "${DEV_PID:-}" ] && kill -0 "$DEV_PID" > /dev/null 2>&1; then
     kill "$DEV_PID" > /dev/null 2>&1 || true
     wait "$DEV_PID" > /dev/null 2>&1 || true
+  fi
+
+  if [ "$KILL_STALE_PORT" = "1" ] && command -v lsof > /dev/null 2>&1; then
+    PORT_PIDS="$(lsof -ti tcp:"$PORT" 2>/dev/null || true)"
+    if [ -n "$PORT_PIDS" ]; then
+      kill $PORT_PIDS > /dev/null 2>&1 || true
+    fi
   fi
 
   if [ "$TEMP_DATA_DIR" -eq 1 ] && [ "$KEEP_DATA" != "1" ] && [ -d "$DATA_DIR" ]; then
@@ -47,6 +59,20 @@ for cmd in curl docker git jq openssl bun; do
   fi
 done
 
+if [ "$KILL_STALE_PORT" = "1" ] && command -v lsof > /dev/null 2>&1; then
+  STALE_PIDS="$(lsof -ti tcp:"$PORT" 2>/dev/null || true)"
+  if [ -n "$STALE_PIDS" ]; then
+    echo "Port $PORT already in use; terminating stale process(es): $STALE_PIDS"
+    kill $STALE_PIDS > /dev/null 2>&1 || true
+    sleep 1
+    STALE_PIDS="$(lsof -ti tcp:"$PORT" 2>/dev/null || true)"
+    if [ -n "$STALE_PIDS" ]; then
+      kill -9 $STALE_PIDS > /dev/null 2>&1 || true
+      sleep 1
+    fi
+  fi
+fi
+
 if ! (cd "$APP_DIR" && bun --bun next --version > /dev/null 2>&1); then
   echo "Installing dependencies (bun install)..."
   (cd "$REPO_ROOT" && bun install)
@@ -54,6 +80,12 @@ fi
 
 mkdir -p "$DATA_DIR"
 rm -f "$DEV_LOG"
+
+echo "Preparing local data dir (migrations)..."
+(
+  cd "$APP_DIR"
+  FROST_DATA_DIR="$DATA_DIR" bun run migrate > /dev/null 2>&1
+)
 
 echo "========================================"
 echo "Managed Local E2E"
@@ -85,15 +117,15 @@ DEV_PID=$!
 
 READY=0
 for i in $(seq 1 90); do
-  if curl -sf "http://localhost:$PORT/api/health" > /dev/null 2>&1; then
-    READY=1
-    break
-  fi
-
   if ! kill -0 "$DEV_PID" > /dev/null 2>&1; then
     echo "Dev server exited early. Logs:"
     tail -n 80 "$DEV_LOG" || true
     exit 1
+  fi
+
+  if curl -sf "http://localhost:$PORT/api/health" > /dev/null 2>&1; then
+    READY=1
+    break
   fi
 
   sleep 1
@@ -108,7 +140,7 @@ echo "✓ Frost dev server is healthy"
 
 echo "Creating API key for test run..."
 API_KEY=""
-for i in $(seq 1 30); do
+for i in $(seq 1 "$API_KEY_RETRIES"); do
   API_KEY="$(
     cd "$APP_DIR"
     FROST_JWT_SECRET="$JWT_SECRET" \
@@ -119,21 +151,29 @@ for i in $(seq 1 30); do
   if [ -n "$API_KEY" ]; then
     break
   fi
-  sleep 1
+  sleep "$API_KEY_RETRY_SEC"
 done
 
 if [ -z "$API_KEY" ]; then
-  echo "Failed to create API key (db may not be ready)"
+  echo "Failed to create API key after $API_KEY_RETRIES attempts (db may not be ready)"
   exit 1
 fi
 
-AUTH_CODE="$(
-  curl -s -o /dev/null -w "%{http_code}" \
-    -H "X-Frost-Token: $API_KEY" \
-    "http://localhost:$PORT/api/projects"
-)"
+AUTH_CODE=""
+for i in $(seq 1 "$API_KEY_VERIFY_RETRIES"); do
+  AUTH_CODE="$(
+    curl -s -o /dev/null -w "%{http_code}" \
+      -H "X-Frost-Token: $API_KEY" \
+      "http://localhost:$PORT/api/projects"
+  )"
+  if [ "$AUTH_CODE" = "200" ]; then
+    break
+  fi
+  sleep "$API_KEY_VERIFY_RETRY_SEC"
+done
+
 if [ "$AUTH_CODE" != "200" ]; then
-  echo "Generated API key failed auth check (HTTP $AUTH_CODE)"
+  echo "Generated API key failed auth check after $API_KEY_VERIFY_RETRIES attempts (last HTTP $AUTH_CODE)"
   exit 1
 fi
 echo "✓ API key created and verified"

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -6,7 +6,7 @@ APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 PORT="${FROST_PORT:-3301}"
-BATCH_SIZE="${1:-2}"
+BATCH_SIZE="${1:-${E2E_BATCH_SIZE:-2}}"
 DEV_LOG="${E2E_DEV_LOG:-/tmp/frost-dev.log}"
 JWT_SECRET="${FROST_JWT_SECRET:-frost-e2e-$(openssl rand -hex 24)}"
 KEEP_DATA="${E2E_KEEP_DATA:-0}"

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -89,6 +89,10 @@ docker network prune -f > /dev/null 2>&1
 echo "✓ Docker cleanup done"
 
 if [ "${E2E_SKIP_PREPULL:-0}" != "1" ]; then
+  PREPULL_RETRIES="${E2E_PREPULL_RETRIES:-3}"
+  PREPULL_BACKOFF_SEC="${E2E_PREPULL_BACKOFF_SEC:-2}"
+  PREPULL_STRICT="${E2E_PREPULL_STRICT:-0}"
+
   if [ -n "${E2E_PREPULL_IMAGES:-}" ]; then
     read -r -a PREPULL_IMAGES <<< "$E2E_PREPULL_IMAGES"
   else
@@ -97,20 +101,27 @@ if [ "${E2E_SKIP_PREPULL:-0}" != "1" ]; then
 
   if [ "${#PREPULL_IMAGES[@]}" -gt 0 ]; then
     echo "Pre-pulling common images..."
+    PREPULL_FAILED=0
     for image in "${PREPULL_IMAGES[@]}"; do
       pulled=0
-      for attempt in 1 2 3; do
+      for attempt in $(seq 1 "$PREPULL_RETRIES"); do
         if docker pull "$image" > /dev/null 2>&1; then
           pulled=1
           break
         fi
-        sleep 2
+        sleep "$PREPULL_BACKOFF_SEC"
       done
       if [ "$pulled" -ne 1 ]; then
-        echo "Error: failed to pull image '$image' after 3 attempts"
-        exit 1
+        echo "Warning: failed to pre-pull image '$image' after $PREPULL_RETRIES attempts"
+        PREPULL_FAILED=1
       fi
     done
+
+    if [ "$PREPULL_FAILED" -eq 1 ] && [ "$PREPULL_STRICT" = "1" ]; then
+      echo "Error: pre-pull failed and E2E_PREPULL_STRICT=1"
+      exit 1
+    fi
+
     echo "✓ Image pre-pull complete"
   fi
 fi

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -6,7 +6,7 @@ APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 E2E_DIR="$SCRIPT_DIR/e2e"
 
-BATCH_SIZE=${2:-2}
+BATCH_SIZE="${2:-${E2E_BATCH_SIZE:-2}}"
 PORT=${FROST_PORT:-3000}
 GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
 GROUP_LIST="${E2E_GROUPS:-}"

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -10,6 +10,7 @@ BATCH_SIZE=${2:-2}
 PORT=${FROST_PORT:-3000}
 GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
 GROUP_LIST="${E2E_GROUPS:-}"
+START_STAGGER_SEC="${E2E_START_STAGGER_SEC:-1}"
 RETRY_FAILED="${E2E_RETRY_FAILED:-0}"
 REPORT_PATH="${E2E_REPORT_PATH:-}"
 REPORT_TMP=""
@@ -204,6 +205,7 @@ if [ -n "$GROUP_LIST" ]; then
 else
   echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, glob: $GROUP_GLOB)"
 fi
+echo "Start stagger: ${START_STAGGER_SEC}s"
 echo "Data dir: $FROST_DATA_DIR"
 echo ""
 
@@ -227,7 +229,9 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
     START_TIMES+=("$(date +%s)")
     "$group" &
     PIDS+=($!)
-    sleep 2
+    if [ "$START_STAGGER_SEC" -gt 0 ] && [ "$j" -lt $((END - 1)) ]; then
+      sleep "$START_STAGGER_SEC"
+    fi
   done
 
   for k in "${!PIDS[@]}"; do
@@ -235,12 +239,14 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
     GROUP_PATH=${GROUP_PATHS[$k]}
     GROUP=${GROUP_NAMES[$k]}
     START_TS=${START_TIMES[$k]}
-    END_TS=$(date +%s)
-    DURATION=$((END_TS - START_TS))
     if wait "$PID"; then
+      END_TS=$(date +%s)
+      DURATION=$((END_TS - START_TS))
       echo "✓ $GROUP passed"
       record_result "$GROUP" "passed" "$DURATION" 1
     else
+      END_TS=$(date +%s)
+      DURATION=$((END_TS - START_TS))
       echo "✗ $GROUP FAILED"
       record_result "$GROUP" "failed" "$DURATION" 1
       FAILED=1

--- a/apps/app/scripts/e2e-profile-week1.sh
+++ b/apps/app/scripts/e2e-profile-week1.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+E2E_DIR="$SCRIPT_DIR/e2e"
+
+OUT_DIR="${1:-/tmp/frost-e2e-week1}"
+FULL_REPORT="$OUT_DIR/full-run.json"
+FULL_LOG="$OUT_DIR/full-run.log"
+INDIVIDUAL_REPORT="$OUT_DIR/individual-runs.json"
+BASELINE_TABLE_JSON="$OUT_DIR/baseline-table.json"
+BASELINE_TABLE_TSV="$OUT_DIR/baseline-table.tsv"
+CI_STEP_DURATIONS="$OUT_DIR/ci-step-durations.json"
+LOG_DIR="$OUT_DIR/logs"
+
+FULL_BATCH_SIZE="${E2E_PROFILE_FULL_BATCH_SIZE:-4}"
+INDIVIDUAL_BATCH_SIZE="${E2E_PROFILE_INDIVIDUAL_BATCH_SIZE:-1}"
+STAGGER_SEC="${E2E_PROFILE_STAGGER_SEC:-1}"
+
+mkdir -p "$OUT_DIR" "$LOG_DIR"
+
+classify_failure() {
+  local log_file="$1"
+  if grep -Eiq "context deadline exceeded|i/o timeout|tls handshake timeout|proxyconnect tcp|dial tcp|connection timed out" "$log_file"; then
+    echo "infra/transient-network"
+    return
+  fi
+  if grep -Eiq "toomanyrequests|rate limit|429" "$log_file"; then
+    echo "infra/rate-limit"
+    return
+  fi
+  if grep -Eiq "unauthorized|authentication required|pull access denied|denied" "$log_file"; then
+    echo "registry/auth"
+    return
+  fi
+  if grep -Eiq "manifest unknown|name unknown|not found" "$log_file"; then
+    echo "image/not-found"
+    return
+  fi
+  echo "assertion-or-unknown"
+}
+
+echo "Output directory: $OUT_DIR"
+echo "Running full E2E suite profile..."
+
+set +e
+E2E_REPORT_PATH="$FULL_REPORT" \
+E2E_START_STAGGER_SEC="$STAGGER_SEC" \
+E2E_RETRY_FAILED=0 \
+  bash "$SCRIPT_DIR/e2e-local-managed.sh" "$FULL_BATCH_SIZE" 2>&1 | tee "$FULL_LOG"
+FULL_EXIT=${PIPESTATUS[0]}
+set -e
+
+if [ ! -f "$FULL_REPORT" ]; then
+  echo "[]" > "$FULL_REPORT"
+fi
+
+echo "Running individual group profiles..."
+INDIVIDUAL_NDJSON="$OUT_DIR/individual-runs.ndjson"
+: > "$INDIVIDUAL_NDJSON"
+
+for group_path in "$E2E_DIR"/group-*.sh; do
+  group_name="$(basename "$group_path" .sh)"
+  group_id="${group_name#group-}"
+  group_log="$LOG_DIR/${group_name}.log"
+  group_report="$LOG_DIR/${group_name}.json"
+
+  start_ts=$(date +%s)
+  set +e
+  E2E_GROUPS="$group_id" \
+  E2E_REPORT_PATH="$group_report" \
+  E2E_START_STAGGER_SEC=0 \
+  E2E_RETRY_FAILED=0 \
+    bash "$SCRIPT_DIR/e2e-local-managed.sh" "$INDIVIDUAL_BATCH_SIZE" > "$group_log" 2>&1
+  group_exit=$?
+  set -e
+  end_ts=$(date +%s)
+
+  if [ "$group_exit" -eq 0 ]; then
+    status="passed"
+    failure_class="none"
+  else
+    status="failed"
+    failure_class="$(classify_failure "$group_log")"
+  fi
+
+  duration_sec=$((end_ts - start_ts))
+
+  jq -nc \
+    --arg group "$group_name" \
+    --arg mode "individual" \
+    --arg status "$status" \
+    --argjson durationSec "$duration_sec" \
+    --arg failureClass "$failure_class" \
+    '{group: $group, mode: $mode, status: $status, durationSec: $durationSec, failureClass: $failureClass}' \
+    >> "$INDIVIDUAL_NDJSON"
+done
+
+jq -s '.' "$INDIVIDUAL_NDJSON" > "$INDIVIDUAL_REPORT"
+
+jq -n \
+  --slurpfile full "$FULL_REPORT" \
+  --slurpfile individual "$INDIVIDUAL_REPORT" '
+    (
+      ($full[0] // [])
+      | map({
+          group: .group,
+          mode: "full",
+          status: .status,
+          durationSec: .durationSec,
+          failureClass: (if .status == "failed" then "unknown" else "none" end)
+        })
+    )
+    + (($individual[0] // []))
+  ' > "$BASELINE_TABLE_JSON"
+
+jq -r '.[] | [.group, .mode, .status, .durationSec, .failureClass] | @tsv' \
+  "$BASELINE_TABLE_JSON" > "$BASELINE_TABLE_TSV"
+
+set +e
+bash "$SCRIPT_DIR/e2e-ci-step-durations.sh" "$CI_STEP_DURATIONS"
+set -e
+
+echo ""
+echo "Artifacts written:"
+echo "  $FULL_REPORT"
+echo "  $INDIVIDUAL_REPORT"
+echo "  $BASELINE_TABLE_JSON"
+echo "  $BASELINE_TABLE_TSV"
+echo "  $CI_STEP_DURATIONS"
+
+if [ "$FULL_EXIT" -ne 0 ]; then
+  echo "Full suite profile run had failures (exit $FULL_EXIT). Artifacts still captured."
+fi

--- a/apps/app/scripts/e2e-soak-week1.sh
+++ b/apps/app/scripts/e2e-soak-week1.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+E2E_DIR="$SCRIPT_DIR/e2e"
+
+OUT_DIR="${1:-/tmp/frost-e2e-week1/soak-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$OUT_DIR/logs"
+
+FULL_RUN_COUNT="${E2E_SOAK_FULL_RUN_COUNT:-3}"
+TOP_GROUPS="${E2E_SOAK_TOP_GROUPS:-19-templates,16-concurrent,20-setup,26-replicas,27-replica-logs,28-oauth}"
+TOP_GROUP_REPEAT="${E2E_SOAK_TOP_GROUP_REPEAT:-3}"
+FULL_BATCH_SIZE="${E2E_SOAK_FULL_BATCH_SIZE:-4}"
+STAGGER_SEC="${E2E_SOAK_STAGGER_SEC:-1}"
+
+RESULTS_NDJSON="$OUT_DIR/results.ndjson"
+: > "$RESULTS_NDJSON"
+
+record_result() {
+  local group="$1"
+  local mode="$2"
+  local status="$3"
+  local duration="$4"
+  local run_index="$5"
+
+  jq -nc \
+    --arg group "$group" \
+    --arg mode "$mode" \
+    --arg status "$status" \
+    --argjson durationSec "$duration" \
+    --argjson run "$run_index" \
+    '{group: $group, mode: $mode, status: $status, durationSec: $durationSec, run: $run}' \
+    >> "$RESULTS_NDJSON"
+}
+
+run_managed() {
+  local mode="$1"
+  local label="$2"
+  local run_index="$3"
+  local log_file="$4"
+  shift 4
+
+  local start_ts
+  local end_ts
+  local exit_code
+  local status
+  local duration
+
+  start_ts=$(date +%s)
+  set +e
+  "$@" > "$log_file" 2>&1
+  exit_code=$?
+  set -e
+  end_ts=$(date +%s)
+  duration=$((end_ts - start_ts))
+
+  if [ "$exit_code" -eq 0 ]; then
+    status="passed"
+  else
+    status="failed"
+  fi
+
+  record_result "$label" "$mode" "$status" "$duration" "$run_index"
+}
+
+echo "Output directory: $OUT_DIR"
+echo "Running full-suite soak ($FULL_RUN_COUNT runs)..."
+for run in $(seq 1 "$FULL_RUN_COUNT"); do
+  report_path="$OUT_DIR/full-run-${run}.json"
+  log_path="$OUT_DIR/logs/full-run-${run}.log"
+  run_managed "full" "all-groups" "$run" "$log_path" \
+    env \
+      E2E_REPORT_PATH="$report_path" \
+      E2E_START_STAGGER_SEC="$STAGGER_SEC" \
+      E2E_RETRY_FAILED=0 \
+      bash "$SCRIPT_DIR/e2e-local-managed.sh" "$FULL_BATCH_SIZE"
+done
+
+echo "Running individual sweep (all groups once)..."
+run=1
+for group_path in "$E2E_DIR"/group-*.sh; do
+  group_name="$(basename "$group_path" .sh)"
+  group_id="${group_name#group-}"
+  report_path="$OUT_DIR/logs/${group_name}-individual.json"
+  log_path="$OUT_DIR/logs/${group_name}-individual.log"
+  run_managed "individual" "$group_name" "$run" "$log_path" \
+    env \
+      E2E_GROUPS="$group_id" \
+      E2E_REPORT_PATH="$report_path" \
+      E2E_START_STAGGER_SEC=0 \
+      E2E_RETRY_FAILED=0 \
+      bash "$SCRIPT_DIR/e2e-local-managed.sh" 1
+done
+
+echo "Running top slow groups ($TOP_GROUP_REPEAT repeats each)..."
+TOP_GROUPS_NORMALIZED=$(echo "$TOP_GROUPS" | tr ',\n\t' '   ')
+for group in $TOP_GROUPS_NORMALIZED; do
+  for run in $(seq 1 "$TOP_GROUP_REPEAT"); do
+    report_path="$OUT_DIR/logs/group-${group}-top-${run}.json"
+    log_path="$OUT_DIR/logs/group-${group}-top-${run}.log"
+    run_managed "top-repeat" "group-${group}" "$run" "$log_path" \
+      env \
+        E2E_GROUPS="$group" \
+        E2E_REPORT_PATH="$report_path" \
+        E2E_START_STAGGER_SEC=0 \
+        E2E_RETRY_FAILED=0 \
+        bash "$SCRIPT_DIR/e2e-local-managed.sh" 1
+  done
+done
+
+jq -s '.' "$RESULTS_NDJSON" > "$OUT_DIR/results.json"
+jq -r '.[] | [.group, .mode, .run, .status, .durationSec] | @tsv' "$OUT_DIR/results.json" > "$OUT_DIR/results.tsv"
+
+echo "Soak artifacts:"
+echo "  $OUT_DIR/results.json"
+echo "  $OUT_DIR/results.tsv"

--- a/apps/app/scripts/e2e-test.sh
+++ b/apps/app/scripts/e2e-test.sh
@@ -28,7 +28,21 @@ echo "========================================"
 echo ""
 
 echo "Pre-pulling base images to avoid concurrent pull contention..."
-ssh -o StrictHostKeyChecking=no root@"$SERVER_IP" "docker pull nginx:alpine & docker pull postgres:17 & docker pull node:20-alpine & wait" 2>&1 | grep -v "already exists" || true
+PREPULL_RETRIES="${E2E_PREPULL_RETRIES:-3}"
+PREPULL_BACKOFF_SEC="${E2E_PREPULL_BACKOFF_SEC:-2}"
+if [ -n "${E2E_PREPULL_IMAGES:-}" ]; then
+  read -r -a PREPULL_IMAGES <<< "${E2E_PREPULL_IMAGES}"
+else
+  PREPULL_IMAGES=("nginx:alpine" "httpd:alpine" "postgres:17" "node:20-alpine" "mariadb:11")
+fi
+
+for image in "${PREPULL_IMAGES[@]}"; do
+  if ! ssh -o StrictHostKeyChecking=no root@"$SERVER_IP" \
+    "for attempt in \$(seq 1 $PREPULL_RETRIES); do docker pull '$image' >/dev/null 2>&1 && exit 0; sleep $PREPULL_BACKOFF_SEC; done; exit 1"
+  then
+    echo "Warning: failed to pre-pull $image after $PREPULL_RETRIES attempts (continuing)"
+  fi
+done
 echo "Base images ready"
 echo ""
 

--- a/apps/app/scripts/e2e-test.sh
+++ b/apps/app/scripts/e2e-test.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-SERVER_IP=$1
-API_KEY=$2
-BATCH_SIZE=${3:-4}  # Run 4 groups in parallel (port allocator is thread-safe)
+SERVER_IP="${1:-}"
+API_KEY="${2:-}"
+BATCH_SIZE="${3:-${E2E_BATCH_SIZE:-4}}"
+START_STAGGER_SEC="${E2E_START_STAGGER_SEC:-1}"
+GROUP_GLOB="${E2E_GROUP_GLOB:-group-*.sh}"
+GROUP_LIST="${E2E_GROUPS:-}"
 
 if [ -z "$SERVER_IP" ] || [ -z "$API_KEY" ]; then
   echo "Usage: $0 <server-ip> <api-key> [batch-size]"
+  echo "Optional env: E2E_GROUPS='01-basic,04-update' E2E_GROUP_GLOB='group-0*.sh' E2E_START_STAGGER_SEC=1"
   exit 1
 fi
 
@@ -19,6 +23,7 @@ E2E_DIR="$SCRIPT_DIR/e2e"
 echo "========================================"
 echo "Running E2E tests against http://$SERVER_IP:3000"
 echo "Batch size: $BATCH_SIZE groups at a time"
+echo "Start stagger: ${START_STAGGER_SEC}s"
 echo "========================================"
 echo ""
 
@@ -30,9 +35,44 @@ echo ""
 chmod +x "$E2E_DIR"/*.sh
 
 FAILED=0
-ALL_GROUPS=("$E2E_DIR"/group-*.sh)
+ALL_GROUPS=()
+
+if [ -n "$GROUP_LIST" ]; then
+  MISSING_GROUP=0
+  GROUP_LIST_NORMALIZED=$(echo "$GROUP_LIST" | tr ',\n\t' '   ')
+  for group in $GROUP_LIST_NORMALIZED; do
+    group="${group%.sh}"
+    case "$group" in
+      */*) GROUP_PATH="$group" ;;
+      group-*) GROUP_PATH="$E2E_DIR/$group.sh" ;;
+      *) GROUP_PATH="$E2E_DIR/group-$group.sh" ;;
+    esac
+
+    if [ -f "$GROUP_PATH" ]; then
+      ALL_GROUPS+=("$GROUP_PATH")
+    else
+      echo "Error: requested E2E group not found: $group"
+      MISSING_GROUP=1
+    fi
+  done
+  [ "$MISSING_GROUP" -eq 0 ] || exit 1
+else
+  shopt -s nullglob
+  ALL_GROUPS=("$E2E_DIR"/$GROUP_GLOB)
+  shopt -u nullglob
+fi
+
 TOTAL=${#ALL_GROUPS[@]}
 BATCH=0
+
+if [ "$TOTAL" -eq 0 ]; then
+  if [ -n "$GROUP_LIST" ]; then
+    echo "No E2E groups selected from E2E_GROUPS='$GROUP_LIST'"
+  else
+    echo "No E2E groups matched E2E_GROUP_GLOB='$GROUP_GLOB'"
+  fi
+  exit 1
+fi
 
 echo "Total test groups: $TOTAL"
 echo ""
@@ -53,7 +93,9 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
     GROUP_NAMES+=("$GROUP_NAME")
     "$group" &
     PIDS+=($!)
-    sleep 5  # Stagger starts to avoid port allocation race
+    if [ "$START_STAGGER_SEC" -gt 0 ] && [ "$j" -lt $((END - 1)) ]; then
+      sleep "$START_STAGGER_SEC"
+    fi
   done
 
   for k in "${!PIDS[@]}"; do

--- a/apps/app/scripts/e2e/common.sh
+++ b/apps/app/scripts/e2e/common.sh
@@ -127,6 +127,26 @@ wait_for_deployment() {
   return 1
 }
 
+wait_for_service_deployment_id() {
+  local SERVICE_ID=$1
+  local MAX=${2:-30}
+  local INTERVAL=${3:-1}
+  local DEPLOYS
+  local DEPLOY_ID
+
+  for _ in $(seq 1 "$MAX"); do
+    DEPLOYS=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments" 2>/dev/null || echo "[]")
+    DEPLOY_ID=$(echo "$DEPLOYS" | jq -r '.[0].id // empty' 2>/dev/null || echo "")
+    if [ -n "$DEPLOY_ID" ] && [ "$DEPLOY_ID" != "null" ]; then
+      echo "$DEPLOY_ID"
+      return 0
+    fi
+    sleep "$INTERVAL"
+  done
+
+  return 1
+}
+
 remote() {
   if [ "${E2E_LOCAL:-}" = "1" ]; then
     bash -c "$@"

--- a/apps/app/scripts/e2e/common.sh
+++ b/apps/app/scripts/e2e/common.sh
@@ -182,6 +182,99 @@ cleanup_github_app_settings() {
   api -X POST "$BASE_URL/api/settings/github/disconnect" > /dev/null || true
 }
 
+sign_github_webhook_payload() {
+  local PAYLOAD=$1
+  local WEBHOOK_SECRET=$2
+  local HASH
+  local OPENSSL_OUT
+
+  OPENSSL_OUT=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" 2>/dev/null || true)
+  HASH=$(echo "$OPENSSL_OUT" | awk '{print $NF}' | tr -d '\r\n')
+
+  if [ -z "$HASH" ] && command -v bun > /dev/null 2>&1; then
+    HASH=$(
+      PAYLOAD="$PAYLOAD" WEBHOOK_SECRET="$WEBHOOK_SECRET" \
+        bun -e "const crypto=require('node:crypto'); const p=process.env.PAYLOAD||''; const s=process.env.WEBHOOK_SECRET||''; process.stdout.write(crypto.createHmac('sha256', s).update(p).digest('hex'));" 2>/dev/null || true
+    )
+    HASH=$(echo "$HASH" | tr -d '\r\n')
+  fi
+
+  if [ "${E2E_DEBUG_WEBHOOK:-0}" = "1" ]; then
+    echo "[webhook-debug] openssl_out=$OPENSSL_OUT" >&2
+    if [ -z "$HASH" ]; then
+      echo "[webhook-debug] WARNING: empty webhook signature hash" >&2
+    fi
+  fi
+
+  printf 'sha256=%s' "$HASH"
+}
+
+send_signed_github_webhook() {
+  local EVENT=$1
+  local PAYLOAD=$2
+  local WEBHOOK_SECRET=$3
+  local RETRIES=${4:-3}
+  local BACKOFF_SEC=${5:-1}
+  local ATTEMPT
+  local SIGNATURE
+  local RESULT
+
+  for ATTEMPT in $(seq 1 "$RETRIES"); do
+    SIGNATURE=$(sign_github_webhook_payload "$PAYLOAD" "$WEBHOOK_SECRET")
+    if [ "${E2E_DEBUG_WEBHOOK:-0}" = "1" ]; then
+      echo "[webhook-debug] attempt=$ATTEMPT event=$EVENT payload_len=${#PAYLOAD} secret_len=${#WEBHOOK_SECRET} signature=$SIGNATURE" >&2
+    fi
+    RESULT=$(curl -sS -X POST "$BASE_URL/api/github/webhook" \
+      -H "Content-Type: application/json" \
+      -H "X-Hub-Signature-256: $SIGNATURE" \
+      -H "X-GitHub-Event: $EVENT" \
+      --data-raw "$PAYLOAD" 2>&1 || true)
+    if [ "${E2E_DEBUG_WEBHOOK:-0}" = "1" ]; then
+      echo "[webhook-debug] attempt=$ATTEMPT response=$RESULT" >&2
+    fi
+
+    if echo "$RESULT" | grep -q '"error":"Invalid signature"'; then
+      if [ "$ATTEMPT" -lt "$RETRIES" ]; then
+        setup_github_app_settings "$WEBHOOK_SECRET" > /dev/null || true
+        sleep "$BACKOFF_SEC"
+        continue
+      fi
+    fi
+
+    echo "$RESULT"
+    return 0
+  done
+
+  echo "$RESULT"
+  return 0
+}
+
+acquire_e2e_lock() {
+  local LOCK_NAME=$1
+  local MAX_WAIT_SEC=${2:-120}
+  local LOCK_DIR="/tmp/frost-e2e-lock-${LOCK_NAME}"
+  local ATTEMPT
+
+  for ATTEMPT in $(seq 1 "$MAX_WAIT_SEC"); do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      echo "$$" > "$LOCK_DIR/pid"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Failed to acquire E2E lock '$LOCK_NAME' within ${MAX_WAIT_SEC}s" >&2
+  return 1
+}
+
+release_e2e_lock() {
+  local LOCK_NAME=$1
+  local LOCK_DIR="/tmp/frost-e2e-lock-${LOCK_NAME}"
+  if [ -d "$LOCK_DIR" ]; then
+    rm -rf "$LOCK_DIR"
+  fi
+}
+
 log() {
   local GROUP=$(basename "$0" .sh | sed 's/group-/G/')
   echo "[$GROUP] $*"

--- a/apps/app/scripts/e2e/group-05-ssl.sh
+++ b/apps/app/scripts/e2e/group-05-ssl.sh
@@ -3,6 +3,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+SETTINGS_LOCK="settings"
+acquire_e2e_lock "$SETTINGS_LOCK" || fail "Could not acquire settings lock"
+trap 'release_e2e_lock "$SETTINGS_LOCK"' EXIT
+
 log "=== Domain & SSL ==="
 
 log "Enabling SSL with staging certs..."

--- a/apps/app/scripts/e2e/group-16-concurrent.sh
+++ b/apps/app/scripts/e2e/group-16-concurrent.sh
@@ -28,9 +28,7 @@ done
 log "Waiting for initial deployments..."
 for i in $(seq 0 $((NUM_SERVICES - 1))); do
   SERVICE_ID=${SERVICE_IDS[$i]}
-  sleep 1
-  DEPLOYS=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments")
-  DEPLOY_ID=$(require_field "$DEPLOYS" '.[0].id' "get initial deploy $i") || fail "No initial deployment for service $i: $DEPLOYS"
+  DEPLOY_ID=$(wait_for_service_deployment_id "$SERVICE_ID" 30 1) || fail "No initial deployment for service $i"
   wait_for_deployment "$DEPLOY_ID" || fail "Initial deployment for service $i failed"
   log "Service $i initial deployment complete"
 done

--- a/apps/app/scripts/e2e/group-19-templates.sh
+++ b/apps/app/scripts/e2e/group-19-templates.sh
@@ -56,9 +56,7 @@ SERVICE=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
 SERVICE_ID=$(require_field "$SERVICE" '.id' "create nginx") || fail "Failed: $SERVICE"
 
 log "Waiting for nginx deployment..."
-sleep 2
-DEPLOYS=$(api "$BASE_URL/api/services/$SERVICE_ID/deployments")
-DEPLOY_ID=$(require_field "$DEPLOYS" '.[0].id' "get deploy") || fail "No deployment: $DEPLOYS"
+DEPLOY_ID=$(wait_for_service_deployment_id "$SERVICE_ID" 30 1) || fail "No deployment found for nginx service"
 wait_for_deployment "$DEPLOY_ID" 60 || fail "nginx deployment failed"
 
 log "Verifying nginx responds..."
@@ -94,9 +92,7 @@ PG_DB=$(echo "$DB_ENVVARS" | jq -r '.[] | select(.key == "POSTGRES_DB") | .value
 log "Credentials generated (pw length: ${#PG_PASS})"
 
 log "Waiting for postgres..."
-sleep 2
-DB_DEPLOYS=$(api "$BASE_URL/api/services/$DB_SERVICE_ID/deployments")
-DB_DEPLOY_ID=$(require_field "$DB_DEPLOYS" '.[0].id' "get db deploy") || fail "No deploy: $DB_DEPLOYS"
+DB_DEPLOY_ID=$(wait_for_service_deployment_id "$DB_SERVICE_ID" 45 1) || fail "No deployment found for postgres service"
 wait_for_deployment "$DB_DEPLOY_ID" 90 || fail "postgres deployment failed"
 
 log "Verifying postgres is ready..."
@@ -125,9 +121,7 @@ APP_SERVICE=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
 APP_SERVICE_ID=$(require_field "$APP_SERVICE" '.id' "create app") || fail "Failed: $APP_SERVICE"
 
 log "Waiting for app deployment..."
-sleep 2
-APP_DEPLOYS=$(api "$BASE_URL/api/services/$APP_SERVICE_ID/deployments")
-APP_DEPLOY_ID=$(require_field "$APP_DEPLOYS" '.[0].id' "get app deploy") || fail "No deploy: $APP_DEPLOYS"
+APP_DEPLOY_ID=$(wait_for_service_deployment_id "$APP_SERVICE_ID" 45 1) || fail "No deployment found for app service"
 wait_for_deployment "$APP_DEPLOY_ID" 120 || fail "app deployment failed"
 
 log "Verifying app can connect to database..."
@@ -135,8 +129,6 @@ APP_DEPLOY=$(api "$BASE_URL/api/deployments/$APP_DEPLOY_ID")
 APP_HOST_PORT=$(require_field "$APP_DEPLOY" '.hostPort' "get app hostPort") || fail "No hostPort"
 APP_CONTAINER_ID=$(json_get "$APP_DEPLOY" '.containerId')
 log "App container: $APP_CONTAINER_ID on port $APP_HOST_PORT"
-
-sleep 3
 
 CONTAINER_STATUS=$(remote "docker inspect $APP_CONTAINER_ID --format '{{.State.Status}}'" 2>&1 || echo "unknown")
 log "Container status: $CONTAINER_STATUS"
@@ -152,8 +144,16 @@ ROOT_RESP=$(remote "curl -sf --max-time 5 http://localhost:$APP_HOST_PORT/" 2>&1
 log "Root response: $ROOT_RESP"
 
 log "Checking health endpoint..."
-HEALTH_RESP=$(remote "curl -sf --max-time 10 http://localhost:$APP_HOST_PORT/health" 2>&1 || echo "{}")
-HEALTH_STATUS=$(echo "$HEALTH_RESP" | jq -r '.status' 2>/dev/null || echo "error")
+HEALTH_RESP="{}"
+HEALTH_STATUS="error"
+for _ in $(seq 1 12); do
+  HEALTH_RESP=$(remote "curl -sf --max-time 5 http://localhost:$APP_HOST_PORT/health" 2>&1 || echo "{}")
+  HEALTH_STATUS=$(echo "$HEALTH_RESP" | jq -r '.status' 2>/dev/null || echo "error")
+  if [ "$HEALTH_STATUS" = "ok" ]; then
+    break
+  fi
+  sleep 1
+done
 if [ "$HEALTH_STATUS" != "ok" ]; then
   log "Health check failed, container logs:"
   remote "docker logs $APP_CONTAINER_ID 2>&1 | tail -30" || true

--- a/apps/app/scripts/e2e/group-19-templates.sh
+++ b/apps/app/scripts/e2e/group-19-templates.sh
@@ -175,8 +175,7 @@ fi
 log "App connected to database successfully!"
 
 log "Verifying cross-service communication via hostname..."
-# Replicate sanitizeDockerName: lowercase, replace non-alphanumeric with -, collapse --, remove leading/trailing -
-NETWORK_NAME=$(echo "frost-net-$PROJECT_ID-$ENV_ID" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9.-]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
+NETWORK_NAME=$(sanitize_name "frost-net-$PROJECT_ID-$ENV_ID")
 log "Looking for network: $NETWORK_NAME"
 log "All frost networks:"
 remote "docker network ls --filter name=frost-net --format '{{.Name}}'" || true

--- a/apps/app/scripts/e2e/group-23-change-password.sh
+++ b/apps/app/scripts/e2e/group-23-change-password.sh
@@ -3,6 +3,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+SETTINGS_LOCK="settings"
+acquire_e2e_lock "$SETTINGS_LOCK" || fail "Could not acquire settings lock"
+trap 'release_e2e_lock "$SETTINGS_LOCK"' EXIT
+
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-e2eTestPassword123}"
 NEW_PASSWORD="newE2ePassword456"
 

--- a/apps/app/scripts/e2e/group-24-zero-downtime.sh
+++ b/apps/app/scripts/e2e/group-24-zero-downtime.sh
@@ -14,7 +14,7 @@ ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environme
 
 log "Creating service with nginx:alpine..."
 SERVICE=$(api -X POST "$BASE_URL/api/environments/$ENV_ID/services" \
-  -d '{"name":"zd-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"drainTimeout":0}')
+  -d '{"name":"zd-test","deployType":"image","imageUrl":"nginx:alpine","containerPort":80,"drainTimeout":0,"shutdownTimeout":1}')
 SERVICE_ID=$(require_field "$SERVICE" '.id' "create service") || fail "Failed to create service: $SERVICE"
 log "Created service: $SERVICE_ID"
 
@@ -31,6 +31,7 @@ wait_for_deployment "$DEPLOY1_ID" || fail "v1 deployment failed"
 log "Verifying v1 responds..."
 DEPLOY1_DATA=$(api "$BASE_URL/api/deployments/$DEPLOY1_ID")
 HOST_PORT1=$(require_field "$DEPLOY1_DATA" '.hostPort' "get hostPort") || fail "Failed: $DEPLOY1_DATA"
+CONTAINER1_ID=$(json_get "$DEPLOY1_DATA" '.containerId // empty')
 curl -sf "http://$SERVER_IP:$HOST_PORT1" > /dev/null || fail "v1 not responding on port $HOST_PORT1"
 log "v1 responding on port $HOST_PORT1"
 
@@ -43,21 +44,44 @@ wait_for_deployment "$DEPLOY2_ID" || fail "v2 deployment failed"
 log "Verifying v2 responds..."
 DEPLOY2_DATA=$(api "$BASE_URL/api/deployments/$DEPLOY2_ID")
 HOST_PORT2=$(require_field "$DEPLOY2_DATA" '.hostPort' "get hostPort") || fail "Failed: $DEPLOY2_DATA"
+CONTAINER2_ID=$(json_get "$DEPLOY2_DATA" '.containerId // empty')
 curl -sf "http://$SERVER_IP:$HOST_PORT2" > /dev/null || fail "v2 not responding on port $HOST_PORT2"
 log "v2 responding on port $HOST_PORT2"
+if [ -n "$CONTAINER1_ID" ] && [ "$CONTAINER1_ID" != "null" ]; then
+  log "v1 container id: ${CONTAINER1_ID:0:12}"
+fi
+if [ -n "$CONTAINER2_ID" ] && [ "$CONTAINER2_ID" != "null" ]; then
+  log "v2 container id: ${CONTAINER2_ID:0:12}"
+fi
 
-log "Verifying v1 deployment is stopped..."
-sleep 2
-DEPLOY1_STATUS=$(api "$BASE_URL/api/deployments/$DEPLOY1_ID")
-V1_STATUS=$(json_get "$DEPLOY1_STATUS" '.status')
+log "Waiting for v1 deployment to stop..."
+V1_STATUS=""
+for _ in $(seq 1 20); do
+  DEPLOY1_STATUS=$(api "$BASE_URL/api/deployments/$DEPLOY1_ID")
+  V1_STATUS=$(json_get "$DEPLOY1_STATUS" '.status')
+  if [ "$V1_STATUS" = "stopped" ]; then
+    break
+  fi
+  sleep 1
+done
 [ "$V1_STATUS" = "stopped" ] || fail "Expected v1 status 'stopped', got '$V1_STATUS'"
 log "v1 status: $V1_STATUS"
 
-log "Verifying v1 port no longer responds..."
-if curl -sf --max-time 3 "http://$SERVER_IP:$HOST_PORT1" > /dev/null 2>&1; then
-  fail "v1 port $HOST_PORT1 still responding (container should be stopped)"
+if [ "$HOST_PORT1" = "$HOST_PORT2" ]; then
+  log "v1/v2 share host port $HOST_PORT1; skipping old-port-down check"
+else
+  log "Verifying v1 port no longer responds..."
+  V1_PORT_DOWN=0
+  for _ in $(seq 1 120); do
+    if ! curl -sf --max-time 3 "http://$SERVER_IP:$HOST_PORT1" > /dev/null 2>&1; then
+      V1_PORT_DOWN=1
+      break
+    fi
+    sleep 1
+  done
+  [ "$V1_PORT_DOWN" = "1" ] || fail "v1 port $HOST_PORT1 still responding after v1 stopped"
+  log "v1 port $HOST_PORT1 no longer responds"
 fi
-log "v1 port $HOST_PORT1 no longer responds"
 
 log "Cleanup..."
 api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -467,6 +467,29 @@ async function drainPreviousDeployments(
   drainTimeout: number,
   shutdownTimeout: number,
 ): Promise<void> {
+  const isContainerLive = (status: string) =>
+    status === "running" || status === "restarting" || status === "paused";
+
+  const stopOldContainer = async (containerId: string) => {
+    await gracefulStopContainer(containerId, shutdownTimeout);
+    let status = await getContainerStatus(containerId);
+
+    if (isContainerLive(status)) {
+      await appendLog(
+        deploymentId,
+        `Graceful stop did not fully stop old container ${containerId.substring(0, 12)} (status=${status}); forcing stop...\n`,
+      );
+      await stopContainer(containerId);
+      status = await getContainerStatus(containerId);
+    }
+
+    if (isContainerLive(status)) {
+      throw new Error(
+        `Failed to stop old container ${containerId.substring(0, 12)} (status=${status})`,
+      );
+    }
+  };
+
   const previousDeployments = await db
     .selectFrom("deployments")
     .select(["id", "containerId"])
@@ -505,7 +528,7 @@ async function drainPreviousDeployments(
     if (oldReplicas.length > 0) {
       for (const r of oldReplicas) {
         if (r.containerId) {
-          await gracefulStopContainer(r.containerId, shutdownTimeout);
+          await stopOldContainer(r.containerId);
         }
       }
       await db
@@ -514,7 +537,7 @@ async function drainPreviousDeployments(
         .where("deploymentId", "=", prev.id)
         .execute();
     } else if (prev.containerId) {
-      await gracefulStopContainer(prev.containerId, shutdownTimeout);
+      await stopOldContainer(prev.containerId);
     }
     await db
       .updateTable("deployments")

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -753,7 +753,22 @@ async function runServiceDeployment(
       await appendLog(deploymentId, pullResult.log);
 
       if (!pullResult.success) {
-        throw new Error(pullResult.error || "Pull failed");
+        const failureClass = pullResult.failureClass || "unknown";
+        const attemptCount = pullResult.attempts || 1;
+        const failureType = failureClass.startsWith("infra/")
+          ? "transient infrastructure issue"
+          : "deterministic pull failure";
+
+        await appendLog(
+          deploymentId,
+          `Image pull failed after ${attemptCount} attempt(s). class=${failureClass} (${failureType})\n`,
+        );
+
+        throw new Error(
+          pullResult.error
+            ? `${pullResult.error} [class=${failureClass}]`
+            : `Pull failed [class=${failureClass}]`,
+        );
       }
 
       if (await isDeploymentCancelled(deploymentId)) {

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -13,6 +13,8 @@ export interface BuildResult {
   imageName: string;
   log: string;
   error?: string;
+  failureClass?: string;
+  attempts?: number;
 }
 
 export interface RunResult {
@@ -109,6 +111,74 @@ export async function buildImage(
 }
 
 export async function pullImage(imageName: string): Promise<BuildResult> {
+  const retryCount = parseEnvInt("FROST_IMAGE_PULL_RETRIES", 3, 1);
+  const backoffMs = parseEnvInt("FROST_IMAGE_PULL_BACKOFF_MS", 2000, 0);
+  const maxBackoffMs = parseEnvInt(
+    "FROST_IMAGE_PULL_MAX_BACKOFF_MS",
+    10000,
+    backoffMs,
+  );
+
+  let combinedLog = "";
+  let lastError = "Pull failed";
+  let lastFailureClass = "unknown";
+
+  for (let attempt = 1; attempt <= retryCount; attempt++) {
+    combinedLog += `\n[pull-attempt ${attempt}/${retryCount}] docker pull ${imageName}\n`;
+    const attemptResult = await runDockerPull(imageName);
+    const failureClass = classifyPullFailure(
+      attemptResult.log,
+      attemptResult.error,
+    );
+
+    combinedLog += attemptResult.log;
+
+    if (attemptResult.success) {
+      return {
+        success: true,
+        imageName,
+        log: combinedLog,
+        attempts: attempt,
+      };
+    }
+
+    lastError =
+      attemptResult.error || `Pull exited with code ${attemptResult.code}`;
+    lastFailureClass = failureClass;
+    combinedLog += `[pull-attempt ${attempt}/${retryCount}] failed class=${failureClass} error=${lastError}\n`;
+
+    const retryable =
+      failureClass === "infra/transient-network" ||
+      failureClass === "infra/rate-limit" ||
+      failureClass === "unknown";
+
+    if (!retryable) {
+      combinedLog += `[pull-attempt ${attempt}/${retryCount}] not retryable; aborting retries\n`;
+      break;
+    }
+
+    if (attempt < retryCount) {
+      const delayMs = Math.min(backoffMs * 2 ** (attempt - 1), maxBackoffMs);
+      combinedLog += `[pull-attempt ${attempt}/${retryCount}] retrying in ${delayMs}ms\n`;
+      if (delayMs > 0) {
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  return {
+    success: false,
+    imageName,
+    log: combinedLog,
+    error: lastError,
+    failureClass: lastFailureClass,
+    attempts: retryCount,
+  };
+}
+
+function runDockerPull(
+  imageName: string,
+): Promise<{ success: boolean; log: string; error?: string; code?: number }> {
   return new Promise((resolve) => {
     let log = "";
     const proc = spawn("docker", ["pull", imageName]);
@@ -123,20 +193,80 @@ export async function pullImage(imageName: string): Promise<BuildResult> {
 
     proc.on("close", (code) => {
       if (code === 0) {
-        resolve({ success: true, imageName, log });
+        resolve({ success: true, log });
       } else {
         resolve({
           success: false,
-          imageName,
           log,
           error: `Pull exited with code ${code}`,
+          code: code ?? undefined,
         });
       }
     });
 
     proc.on("error", (err) => {
-      resolve({ success: false, imageName, log, error: err.message });
+      resolve({ success: false, log, error: err.message });
     });
+  });
+}
+
+function classifyPullFailure(log: string, error?: string): string {
+  const full = `${log}\n${error ?? ""}`.toLowerCase();
+
+  if (
+    full.includes("context deadline exceeded") ||
+    full.includes("i/o timeout") ||
+    full.includes("tls handshake timeout") ||
+    full.includes("proxyconnect tcp") ||
+    full.includes("dial tcp")
+  ) {
+    return "infra/transient-network";
+  }
+
+  if (
+    full.includes("toomanyrequests") ||
+    full.includes("rate limit") ||
+    full.includes("429")
+  ) {
+    return "infra/rate-limit";
+  }
+
+  if (
+    full.includes("unauthorized") ||
+    full.includes("authentication required") ||
+    full.includes("denied")
+  ) {
+    return "registry/auth";
+  }
+
+  if (
+    full.includes("manifest unknown") ||
+    full.includes("not found") ||
+    full.includes("name unknown")
+  ) {
+    return "image/not-found";
+  }
+
+  return "unknown";
+}
+
+function parseEnvInt(name: string, fallback: number, minimum: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return Math.max(value, minimum);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
   });
 }
 

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -404,7 +404,7 @@ export async function gracefulStopContainer(
     // Container might not exist or already stopped
   }
   try {
-    await execAsync(`docker rm ${shellEscape(name)}`);
+    await execAsync(`docker rm -f ${shellEscape(name)}`);
   } catch {
     // Container might already be removed
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "e2e:smoke:retry": "E2E_RETRY_FAILED=1 E2E_GROUPS='01-basic,04-update,10-race,20-setup,28-oauth,29-mcp' bash ./apps/app/scripts/e2e-local-managed.sh 1",
     "e2e:changed": "bash ./apps/app/scripts/e2e-changed.sh",
     "e2e:changed:retry": "E2E_RETRY_FAILED=1 bash ./apps/app/scripts/e2e-changed.sh",
+    "e2e:changed:fast": "E2E_RETRY_FAILED=1 E2E_REPORT_PATH=/tmp/frost-e2e-changed-report.json bash ./apps/app/scripts/e2e-changed.sh",
     "e2e:changed:print": "E2E_CHANGED_DRY_RUN=1 bash ./apps/app/scripts/e2e-changed.sh",
+    "e2e:ci:durations": "bash ./apps/app/scripts/e2e-ci-step-durations.sh",
+    "e2e:profile:week1": "bash ./apps/app/scripts/e2e-profile-week1.sh",
+    "e2e:soak:week1": "bash ./apps/app/scripts/e2e-soak-week1.sh",
     "dev:marketing": "bun --cwd apps/marketing dev",
     "build:marketing": "bun --cwd apps/marketing build"
   },


### PR DESCRIPTION
## Summary
- reduce E2E group launch staggering overhead by default (`E2E_START_STAGGER_SEC=1`)
- avoid sleeping after the last group start in each batch
- add `E2E_GROUPS` / `E2E_GROUP_GLOB` support to `e2e-test.sh` so CI can run targeted subsets
- fix local JSON report group durations to measure actual runtime (previously measured before `wait`)
- in `e2e-upgrade`, run a smoke subset for the "Run standard E2E tests" step
- document `E2E_START_STAGGER_SEC` for local runs

## Why
- current CI E2E runtime is dominated by orchestration overhead and can be reduced without cutting the highest-signal coverage
- upgrade workflow already validates migration + update + rollback; smoke checks are sufficient for its standard E2E phase
- better local timing data helps identify the real slow groups

## Validation
- `bash -n apps/app/scripts/e2e-test.sh`
- `bash -n apps/app/scripts/e2e-local.sh`
- local benchmark (same 6-group subset, batch=4):
  - `E2E_START_STAGGER_SEC=5`: `real 35.54s`
  - `E2E_START_STAGGER_SEC=1`: `real 22.48s`
  - `E2E_START_STAGGER_SEC=0`: `real 20.76s`
- `bun run lint`
- `bun run typecheck`
