### PR TITLE
fix: restart clean-exit containers and reconcile dead deployments

### DIFF
--- a/apps/app/src/components/status-dot.tsx
+++ b/apps/app/src/components/status-dot.tsx
@@ -5,13 +5,12 @@ type StatusColor = "yellow" | "red" | "green";
 interface StatusConfig {
   color: string;
   pulse: boolean;
-  label: string;
 }
 
 const colorConfig: Record<StatusColor, StatusConfig> = {
-  yellow: { color: "bg-yellow-500", pulse: true, label: "pending" },
-  red: { color: "bg-red-500", pulse: false, label: "failed" },
-  green: { color: "bg-green-500", pulse: false, label: "ok" },
+  yellow: { color: "bg-yellow-500", pulse: true },
+  red: { color: "bg-red-500", pulse: false },
+  green: { color: "bg-green-500", pulse: false },
 };
 
 function getStatusColor(status: string): StatusColor {
@@ -22,11 +21,31 @@ function getStatusColor(status: string): StatusColor {
     case "building":
     case "deploying":
       return "yellow";
+    case "stopped":
     case "failed":
     case "cancelled":
       return "red";
     default:
       return "green";
+  }
+}
+
+function getStatusLabel(status: string): string {
+  switch (status) {
+    case "pending":
+    case "cloning":
+    case "pulling":
+    case "building":
+    case "deploying":
+      return "pending";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    case "stopped":
+      return "stopped";
+    default:
+      return "ok";
   }
 }
 
@@ -43,6 +62,7 @@ export function StatusDot({
 }: StatusDotProps) {
   const statusColor = getStatusColor(status);
   const config = colorConfig[statusColor];
+  const label = getStatusLabel(status);
 
   return (
     <span className={cn("inline-flex items-center gap-2", className)}>
@@ -53,11 +73,9 @@ export function StatusDot({
           config.pulse && "animate-[pulse-dot_2s_ease-in-out_infinite]",
         )}
       />
-      {showLabel && (
-        <span className="text-xs text-neutral-400">{config.label}</span>
-      )}
+      {showLabel && <span className="text-xs text-neutral-400">{label}</span>}
     </span>
   );
 }
 
-export { getStatusColor, colorConfig };
+export { getStatusColor, colorConfig, getStatusLabel };

--- a/apps/app/src/lib/deployment-runtime.ts
+++ b/apps/app/src/lib/deployment-runtime.ts
@@ -1,0 +1,105 @@
+import type { Selectable } from "kysely";
+import { db } from "./db";
+import type { Deployments, Services } from "./db-types";
+import { getContainerStatus } from "./docker";
+
+const LIVE_CONTAINER_STATUSES = new Set(["running", "restarting", "paused"]);
+
+function isContainerLive(status: string): boolean {
+  return LIVE_CONTAINER_STATUSES.has(status);
+}
+
+function canReconcileDeployment(
+  deployment: Selectable<Deployments> | null,
+): deployment is Selectable<Deployments> & { containerId: string } {
+  return (
+    deployment !== null &&
+    deployment.status === "running" &&
+    !!deployment.containerId
+  );
+}
+
+function isDeployment(
+  deployment: Selectable<Deployments> | null,
+): deployment is Selectable<Deployments> {
+  return deployment !== null;
+}
+
+export async function reconcileDeploymentRuntimeStatus(
+  deployment: Selectable<Deployments> | null,
+): Promise<Selectable<Deployments> | null> {
+  if (!canReconcileDeployment(deployment)) {
+    return deployment;
+  }
+
+  const containerStatus = await getContainerStatus(deployment.containerId);
+  if (containerStatus === "unknown" || isContainerLive(containerStatus)) {
+    return deployment;
+  }
+
+  const finishedAt = deployment.finishedAt ?? Date.now();
+
+  await db
+    .updateTable("deployments")
+    .set({ status: "stopped", finishedAt })
+    .where("id", "=", deployment.id)
+    .execute();
+
+  await db
+    .updateTable("services")
+    .set({ currentDeploymentId: null })
+    .where("id", "=", deployment.serviceId)
+    .where("currentDeploymentId", "=", deployment.id)
+    .execute();
+
+  return { ...deployment, status: "stopped", finishedAt };
+}
+
+export async function getLatestDeploymentWithRuntimeStatus(
+  serviceId: string,
+): Promise<Selectable<Deployments> | null> {
+  const latestDeployment = await db
+    .selectFrom("deployments")
+    .selectAll()
+    .where("serviceId", "=", serviceId)
+    .orderBy("createdAt", "desc")
+    .limit(1)
+    .executeTakeFirst();
+
+  return reconcileDeploymentRuntimeStatus(latestDeployment ?? null);
+}
+
+export async function addLatestDeploymentWithRuntimeStatus<
+  T extends Selectable<Services>,
+>(
+  service: T,
+): Promise<T & { latestDeployment: Selectable<Deployments> | null }> {
+  const latestDeployment = await getLatestDeploymentWithRuntimeStatus(
+    service.id,
+  );
+  const currentDeploymentId =
+    latestDeployment?.status === "stopped" &&
+    service.currentDeploymentId === latestDeployment.id
+      ? null
+      : service.currentDeploymentId;
+  return { ...service, currentDeploymentId, latestDeployment };
+}
+
+export async function addLatestDeploymentsWithRuntimeStatus<
+  T extends Selectable<Services>,
+>(
+  services: T[],
+): Promise<(T & { latestDeployment: Selectable<Deployments> | null })[]> {
+  return Promise.all(services.map(addLatestDeploymentWithRuntimeStatus));
+}
+
+export async function reconcileDeploymentsRuntimeStatus(
+  deployments: Selectable<Deployments>[],
+): Promise<Selectable<Deployments>[]> {
+  const reconciled = await Promise.all(
+    deployments.map((deployment) =>
+      reconcileDeploymentRuntimeStatus(deployment),
+    ),
+  );
+  return reconciled.filter(isDeployment);
+}

--- a/apps/app/src/lib/deployment-utils.test.ts
+++ b/apps/app/src/lib/deployment-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import type { Deployment } from "@/lib/api";
+import { getCurrentDeployment } from "./deployment-utils";
+
+function deployment(id: string, status: string): Deployment {
+  return { id, status } as Deployment;
+}
+
+describe("getCurrentDeployment", () => {
+  test("returns current deployment when active", () => {
+    const result = getCurrentDeployment(
+      { currentDeploymentId: "d-1" },
+      [deployment("d-1", "running"), deployment("d-2", "stopped")],
+    );
+
+    expect(result?.id).toBe("d-1");
+  });
+
+  test("returns null when current deployment is stopped", () => {
+    const result = getCurrentDeployment(
+      { currentDeploymentId: "d-1" },
+      [deployment("d-1", "stopped")],
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("falls back to active deployment when current id is missing", () => {
+    const result = getCurrentDeployment(
+      { currentDeploymentId: null },
+      [deployment("d-2", "stopped"), deployment("d-3", "running")],
+    );
+
+    expect(result?.id).toBe("d-3");
+  });
+});

--- a/apps/app/src/lib/deployment-utils.test.ts
+++ b/apps/app/src/lib/deployment-utils.test.ts
@@ -8,28 +8,27 @@ function deployment(id: string, status: string): Deployment {
 
 describe("getCurrentDeployment", () => {
   test("returns current deployment when active", () => {
-    const result = getCurrentDeployment(
-      { currentDeploymentId: "d-1" },
-      [deployment("d-1", "running"), deployment("d-2", "stopped")],
-    );
+    const result = getCurrentDeployment({ currentDeploymentId: "d-1" }, [
+      deployment("d-1", "running"),
+      deployment("d-2", "stopped"),
+    ]);
 
     expect(result?.id).toBe("d-1");
   });
 
   test("returns null when current deployment is stopped", () => {
-    const result = getCurrentDeployment(
-      { currentDeploymentId: "d-1" },
-      [deployment("d-1", "stopped")],
-    );
+    const result = getCurrentDeployment({ currentDeploymentId: "d-1" }, [
+      deployment("d-1", "stopped"),
+    ]);
 
     expect(result).toBeNull();
   });
 
   test("falls back to active deployment when current id is missing", () => {
-    const result = getCurrentDeployment(
-      { currentDeploymentId: null },
-      [deployment("d-2", "stopped"), deployment("d-3", "running")],
-    );
+    const result = getCurrentDeployment({ currentDeploymentId: null }, [
+      deployment("d-2", "stopped"),
+      deployment("d-3", "running"),
+    ]);
 
     expect(result?.id).toBe("d-3");
   });

--- a/apps/app/src/lib/deployment-utils.ts
+++ b/apps/app/src/lib/deployment-utils.ts
@@ -7,19 +7,25 @@ const IN_PROGRESS_STATUSES = [
   "building",
   "deploying",
 ] as const;
+const ACTIVE_STATUSES = [...IN_PROGRESS_STATUSES, "running"] as const;
 
 export function getCurrentDeployment(
   service: Service | { currentDeploymentId: string | null },
   deployments: Deployment[],
 ): Deployment | null {
   if (service.currentDeploymentId) {
-    return (
-      deployments.find((d) => d.id === service.currentDeploymentId) ?? null
-    );
+    const deployment =
+      deployments.find((d) => d.id === service.currentDeploymentId) ?? null;
+    if (!deployment) {
+      return null;
+    }
+    return (ACTIVE_STATUSES as readonly string[]).includes(deployment.status)
+      ? deployment
+      : null;
   }
   return (
     deployments.find((d) =>
-      (IN_PROGRESS_STATUSES as readonly string[]).includes(d.status),
+      (ACTIVE_STATUSES as readonly string[]).includes(d.status),
     ) ?? null
   );
 }

--- a/apps/app/src/lib/shell-escape.test.ts
+++ b/apps/app/src/lib/shell-escape.test.ts
@@ -49,6 +49,7 @@ describe("buildDockerRunArgs", () => {
     });
     expect(args).toContain("run");
     expect(args).toContain("-d");
+    expect(args[args.indexOf("--restart") + 1]).toBe("unless-stopped");
     expect(args).toContain("--name");
     expect(args[args.indexOf("--name") + 1]).toBe("mycontainer");
     expect(args).toContain("-p");

--- a/apps/app/src/lib/shell-escape.ts
+++ b/apps/app/src/lib/shell-escape.ts
@@ -27,7 +27,7 @@ export function buildDockerRunArgs(options: RunContainerOptions): string[] {
     "run",
     "-d",
     "--restart",
-    "on-failure:5",
+    "unless-stopped",
     "--log-opt",
     "max-size=10m",
     "--log-opt",

--- a/apps/app/src/server/environments.ts
+++ b/apps/app/src/server/environments.ts
@@ -1,8 +1,8 @@
 import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
 import { db } from "@/lib/db";
-import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
 import { deployEnvironment } from "@/lib/deployer";
+import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
 import { cleanupEnvironment } from "@/lib/lifecycle";
 import { createService } from "@/lib/services";
 import { slugify } from "@/lib/slugify";

--- a/apps/app/src/server/environments.ts
+++ b/apps/app/src/server/environments.ts
@@ -1,6 +1,7 @@
 import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
 import { db } from "@/lib/db";
+import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
 import { deployEnvironment } from "@/lib/deployer";
 import { cleanupEnvironment } from "@/lib/lifecycle";
 import { createService } from "@/lib/services";
@@ -34,19 +35,8 @@ export const environments = {
       .where("environmentId", "=", input.id)
       .execute();
 
-    const servicesWithDeployments = await Promise.all(
-      services.map(async (service) => {
-        const latestDeployment = await db
-          .selectFrom("deployments")
-          .selectAll()
-          .where("serviceId", "=", service.id)
-          .orderBy("createdAt", "desc")
-          .limit(1)
-          .executeTakeFirst();
-
-        return { ...service, latestDeployment: latestDeployment ?? null };
-      }),
-    );
+    const servicesWithDeployments =
+      await addLatestDeploymentsWithRuntimeStatus(services);
 
     return { ...environment, services: servicesWithDeployments };
   }),

--- a/apps/app/src/server/projects.ts
+++ b/apps/app/src/server/projects.ts
@@ -2,8 +2,8 @@ import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
 import { getSetting } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
 import { deployProject, deployService } from "@/lib/deployer";
+import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
 import { cleanupProject } from "@/lib/lifecycle";
 import { createService } from "@/lib/services";
 import { slugify } from "@/lib/slugify";
@@ -38,14 +38,12 @@ export const projects = {
           await addLatestDeploymentsWithRuntimeStatus(services);
 
         const latestDeploymentByService: Record<string, string | null> = {};
-        let latestDeployment:
-          | {
-              status: string;
-              commitMessage: string | null;
-              createdAt: number;
-              branch: string | null;
-            }
-          | null = null;
+        let latestDeployment: {
+          status: string;
+          commitMessage: string | null;
+          createdAt: number;
+          branch: string | null;
+        } | null = null;
         let runningHostPort: number | null = null;
 
         for (const service of servicesWithDeployments) {

--- a/apps/app/src/server/projects.ts
+++ b/apps/app/src/server/projects.ts
@@ -2,6 +2,7 @@ import { ORPCError } from "@orpc/server";
 import { nanoid } from "nanoid";
 import { getSetting } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
 import { deployProject, deployService } from "@/lib/deployer";
 import { cleanupProject } from "@/lib/lifecycle";
 import { createService } from "@/lib/services";
@@ -33,57 +34,49 @@ export const projects = {
               .execute()
           : [];
 
-        const latestDeploymentByService: Record<
-          string,
-          { status: string } | undefined
-        > = {};
-        if (productionEnv && services.length > 0) {
-          const deployments = await db
-            .selectFrom("deployments")
-            .select(["serviceId", "status", "createdAt"])
-            .where("environmentId", "=", productionEnv.id)
-            .orderBy("createdAt", "desc")
-            .execute();
+        const servicesWithDeployments =
+          await addLatestDeploymentsWithRuntimeStatus(services);
 
-          for (const d of deployments) {
-            if (!latestDeploymentByService[d.serviceId]) {
-              latestDeploymentByService[d.serviceId] = { status: d.status };
+        const latestDeploymentByService: Record<string, string | null> = {};
+        let latestDeployment:
+          | {
+              status: string;
+              commitMessage: string | null;
+              createdAt: number;
+              branch: string | null;
             }
+          | null = null;
+        let runningHostPort: number | null = null;
+
+        for (const service of servicesWithDeployments) {
+          const deployment = service.latestDeployment;
+          latestDeploymentByService[service.id] = deployment?.status ?? null;
+
+          if (deployment?.status === "running" && deployment.hostPort) {
+            runningHostPort = deployment.hostPort;
+          }
+
+          if (
+            deployment &&
+            (!latestDeployment ||
+              deployment.createdAt > latestDeployment.createdAt)
+          ) {
+            latestDeployment = {
+              status: deployment.status,
+              commitMessage: deployment.commitMessage,
+              createdAt: deployment.createdAt,
+              branch: service.branch,
+            };
           }
         }
-
-        const latestDeployment = productionEnv
-          ? await db
-              .selectFrom("deployments")
-              .innerJoin("services", "services.id", "deployments.serviceId")
-              .select([
-                "deployments.status",
-                "deployments.commitMessage",
-                "deployments.createdAt",
-                "services.branch",
-              ])
-              .where("deployments.environmentId", "=", productionEnv.id)
-              .orderBy("deployments.createdAt", "desc")
-              .executeTakeFirst()
-          : null;
-
-        const runningDeployment = productionEnv
-          ? await db
-              .selectFrom("deployments")
-              .select(["hostPort"])
-              .where("environmentId", "=", productionEnv.id)
-              .where("status", "=", "running")
-              .where("hostPort", "is not", null)
-              .executeTakeFirst()
-          : null;
 
         const repoUrl = services[0]?.repoUrl ?? null;
 
         let runningUrl: string | null = null;
-        if (runningDeployment?.hostPort) {
+        if (runningHostPort) {
           runningUrl = domain
-            ? `${domain}:${runningDeployment.hostPort}`
-            : `localhost:${runningDeployment.hostPort}`;
+            ? `${domain}:${runningHostPort}`
+            : `localhost:${runningHostPort}`;
         }
 
         return {
@@ -105,7 +98,7 @@ export const projects = {
             icon: s.icon,
             imageUrl: s.imageUrl,
             deployType: s.deployType,
-            status: latestDeploymentByService[s.id]?.status ?? null,
+            status: latestDeploymentByService[s.id] ?? null,
           })),
         };
       }),
@@ -138,19 +131,8 @@ export const projects = {
           .execute()
       : [];
 
-    const servicesWithDeployments = await Promise.all(
-      services.map(async (service) => {
-        const latestDeployment = await db
-          .selectFrom("deployments")
-          .selectAll()
-          .where("serviceId", "=", service.id)
-          .orderBy("createdAt", "desc")
-          .limit(1)
-          .executeTakeFirst();
-
-        return { ...service, latestDeployment: latestDeployment ?? null };
-      }),
-    );
+    const servicesWithDeployments =
+      await addLatestDeploymentsWithRuntimeStatus(services);
 
     return { ...project, services: servicesWithDeployments };
   }),

--- a/apps/app/src/server/services.ts
+++ b/apps/app/src/server/services.ts
@@ -1,6 +1,11 @@
 import { ORPCError } from "@orpc/server";
 import type { Selectable } from "kysely";
-import { addLatestDeployment, addLatestDeployments, db } from "@/lib/db";
+import { db } from "@/lib/db";
+import {
+  addLatestDeploymentWithRuntimeStatus,
+  addLatestDeploymentsWithRuntimeStatus,
+  reconcileDeploymentsRuntimeStatus,
+} from "@/lib/deployment-runtime";
 import type { Services } from "@/lib/db-types";
 import { deployService } from "@/lib/deployer";
 import { syncCaddyConfig } from "@/lib/domains";
@@ -23,7 +28,7 @@ export const services = {
       throw new ORPCError("NOT_FOUND", { message: "Service not found" });
     }
 
-    return addLatestDeployment(service);
+    return addLatestDeploymentWithRuntimeStatus(service);
   }),
 
   list: os.services.list.handler(async ({ input }) => {
@@ -33,7 +38,7 @@ export const services = {
       .where("environmentId", "=", input.environmentId)
       .execute();
 
-    return addLatestDeployments(services);
+    return addLatestDeploymentsWithRuntimeStatus(services);
   }),
 
   create: os.services.create.handler(async ({ input }) => {
@@ -325,15 +330,17 @@ export const services = {
     return { deploymentId };
   }),
 
-  listDeployments: os.services.listDeployments.handler(async ({ input }) =>
-    db
+  listDeployments: os.services.listDeployments.handler(async ({ input }) => {
+    const deployments = await db
       .selectFrom("deployments")
       .selectAll()
       .where("serviceId", "=", input.id)
       .orderBy("createdAt", "desc")
       .limit(20)
-      .execute(),
-  ),
+      .execute();
+
+    return reconcileDeploymentsRuntimeStatus(deployments);
+  }),
 
   getVolumes: os.services.getVolumes.handler(async ({ input }) => {
     const service = await db

--- a/apps/app/src/server/services.ts
+++ b/apps/app/src/server/services.ts
@@ -1,13 +1,13 @@
 import { ORPCError } from "@orpc/server";
 import type { Selectable } from "kysely";
 import { db } from "@/lib/db";
-import {
-  addLatestDeploymentWithRuntimeStatus,
-  addLatestDeploymentsWithRuntimeStatus,
-  reconcileDeploymentsRuntimeStatus,
-} from "@/lib/deployment-runtime";
 import type { Services } from "@/lib/db-types";
 import { deployService } from "@/lib/deployer";
+import {
+  addLatestDeploymentsWithRuntimeStatus,
+  addLatestDeploymentWithRuntimeStatus,
+  reconcileDeploymentsRuntimeStatus,
+} from "@/lib/deployment-runtime";
 import { syncCaddyConfig } from "@/lib/domains";
 import { cleanupService } from "@/lib/lifecycle";
 import { createService } from "@/lib/services";


### PR DESCRIPTION
## Summary
- switch docker run restart policy from on-failure:5 to unless-stopped
- reconcile stale running deployments against Docker runtime and mark them stopped when container is no longer live
- clear services.currentDeploymentId when the reconciled deployment is stopped
- apply runtime reconciliation in service/environment/project reads and service deployment listing
- treat stopped deployments as inactive for current deployment selection and show stopped label in status dot
- add coverage for restart policy and current deployment selection behavior

## Testing
- bun test src/lib/shell-escape.test.ts src/lib/deployment-utils.test.ts

Fixes #311
