### PR TITLE
fix(volumes): escape volume names in docker commands

### DIFF
--- a/apps/app/src/lib/volumes.ts
+++ b/apps/app/src/lib/volumes.ts
@@ -1,11 +1,13 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 
+import { shellEscape } from "./shell-escape";
+
 const execAsync = promisify(exec);
 
 export async function createVolume(name: string): Promise<void> {
   try {
-    await execAsync(`docker volume create ${name}`);
+    await execAsync(`docker volume create ${shellEscape(name)}`);
   } catch {
     // Volume might already exist
   }
@@ -13,7 +15,7 @@ export async function createVolume(name: string): Promise<void> {
 
 export async function removeVolume(name: string): Promise<void> {
   try {
-    await execAsync(`docker volume rm ${name}`);
+    await execAsync(`docker volume rm ${shellEscape(name)}`);
   } catch {
     // Volume might not exist or be in use
   }
@@ -32,7 +34,7 @@ export async function listFrostVolumes(): Promise<string[]> {
 
 export async function volumeExists(name: string): Promise<boolean> {
   try {
-    await execAsync(`docker volume inspect ${name}`);
+    await execAsync(`docker volume inspect ${shellEscape(name)}`);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- import `shellEscape` in `volumes.ts`
- escape `name` in `createVolume`, `removeVolume`, and `volumeExists`
- keep existing behavior unchanged while removing command injection vector

## Validation
- `bun test src/lib/volumes.test.ts src/lib/shell-escape.test.ts`

Closes #305