### PR TITLE
feat(deployments): stream build logs via sse

### DIFF
--- a/apps/app/src/app/api/deployments/[id]/build-logs/route.ts
+++ b/apps/app/src/app/api/deployments/[id]/build-logs/route.ts
@@ -1,0 +1,110 @@
+import { subscribeBuildLogChunks } from "@/lib/build-log-stream";
+import { db } from "@/lib/db";
+
+const ACTIVE_STATUSES = new Set([
+  "pending",
+  "cloning",
+  "pulling",
+  "building",
+  "deploying",
+  "running",
+]);
+
+function isActiveStatus(status: string): boolean {
+  return ACTIVE_STATUSES.has(status);
+}
+
+function encodeData(encoder: TextEncoder, value: string): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(value)}\n\n`);
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const deployment = await db
+    .selectFrom("deployments")
+    .select(["status", "buildLog"])
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  if (!deployment) {
+    return new Response("Deployment not found", { status: 404 });
+  }
+
+  const encoder = new TextEncoder();
+  let cleanup = function cleanup() {};
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let stopped = false;
+      let lineBuffer = "";
+      let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+      function pushChunk(chunk: string): void {
+        if (!chunk) return;
+        lineBuffer += chunk;
+        const lines = lineBuffer.split("\n");
+        lineBuffer = lines.pop() ?? "";
+        for (const line of lines) {
+          controller.enqueue(encodeData(encoder, line));
+        }
+      }
+
+      function handleAbort(): void {
+        stop();
+      }
+
+      const unsubscribe = subscribeBuildLogChunks(id, function onChunk(chunk) {
+        if (stopped) return;
+        pushChunk(chunk);
+      });
+
+      function stop(): void {
+        if (stopped) return;
+        stopped = true;
+        if (heartbeat) {
+          clearInterval(heartbeat);
+          heartbeat = null;
+        }
+        unsubscribe();
+        request.signal.removeEventListener("abort", handleAbort);
+        if (lineBuffer) {
+          controller.enqueue(encodeData(encoder, lineBuffer));
+          lineBuffer = "";
+        }
+        try {
+          controller.close();
+        } catch {}
+      }
+
+      pushChunk(deployment.buildLog ?? "");
+
+      request.signal.addEventListener("abort", handleAbort);
+
+      if (isActiveStatus(deployment.status)) {
+        heartbeat = setInterval(function sendHeartbeat() {
+          if (stopped) return;
+          controller.enqueue(encoder.encode(": ping\n\n"));
+        }, 15000);
+      } else {
+        stop();
+      }
+
+      cleanup = stop;
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/apps/app/src/hooks/use-build-logs.ts
+++ b/apps/app/src/hooks/use-build-logs.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseBuildLogsOptions {
+  deploymentId: string;
+  enabled?: boolean;
+  shouldReconnect?: boolean;
+}
+
+interface UseBuildLogsResult {
+  logs: string[];
+  isConnected: boolean;
+  error: string | null;
+}
+
+const MAX_LINES = 1000;
+const RECONNECT_DELAY = 2000;
+
+export function useBuildLogs({
+  deploymentId,
+  enabled = true,
+  shouldReconnect = true,
+}: UseBuildLogsOptions): UseBuildLogsResult {
+  const [logs, setLogs] = useState<string[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const shouldReconnectRef = useRef(shouldReconnect);
+
+  const disconnect = useCallback(function disconnect() {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    setIsConnected(false);
+  }, []);
+
+  const connect = useCallback(
+    function connect() {
+      if (!deploymentId || !enabled) return;
+
+      disconnect();
+      shouldReconnectRef.current = shouldReconnect;
+      setLogs([]);
+      setError(null);
+
+      const es = new EventSource(`/api/deployments/${deploymentId}/build-logs`);
+      eventSourceRef.current = es;
+
+      es.onopen = function onopen() {
+        setIsConnected(true);
+        setError(null);
+      };
+
+      es.onmessage = function onmessage(event) {
+        try {
+          const data = JSON.parse(event.data);
+          if (typeof data === "object" && data.error) {
+            setError(data.error);
+            return;
+          }
+          if (typeof data === "string") {
+            setLogs(function updateLogs(prev) {
+              const next = [...prev, data];
+              if (next.length > MAX_LINES) {
+                return next.slice(-MAX_LINES);
+              }
+              return next;
+            });
+          }
+        } catch {
+          setLogs(function updateLogs(prev) {
+            const next = [...prev, event.data];
+            if (next.length > MAX_LINES) {
+              return next.slice(-MAX_LINES);
+            }
+            return next;
+          });
+        }
+      };
+
+      es.onerror = function onerror() {
+        setIsConnected(false);
+        es.close();
+        eventSourceRef.current = null;
+
+        if (enabled && shouldReconnectRef.current) {
+          reconnectTimeoutRef.current = setTimeout(function reconnect() {
+            connect();
+          }, RECONNECT_DELAY);
+        }
+      };
+    },
+    [deploymentId, disconnect, enabled, shouldReconnect],
+  );
+
+  useEffect(
+    function effectConnect() {
+      if (deploymentId && enabled) {
+        connect();
+      } else {
+        disconnect();
+        setLogs([]);
+        setError(null);
+      }
+
+      return disconnect;
+    },
+    [connect, deploymentId, disconnect, enabled],
+  );
+
+  useEffect(
+    function effectShouldReconnect() {
+      shouldReconnectRef.current = shouldReconnect;
+    },
+    [shouldReconnect],
+  );
+
+  return { logs, isConnected, error };
+}

--- a/apps/app/src/lib/build-log-stream.ts
+++ b/apps/app/src/lib/build-log-stream.ts
@@ -1,0 +1,24 @@
+import { EventEmitter } from "node:events";
+
+const buildLogEmitter = new EventEmitter();
+buildLogEmitter.setMaxListeners(0);
+
+function getEventName(deploymentId: string): string {
+  return `build-log:${deploymentId}`;
+}
+
+export function emitBuildLogChunk(deploymentId: string, chunk: string): void {
+  if (!chunk) return;
+  buildLogEmitter.emit(getEventName(deploymentId), chunk);
+}
+
+export function subscribeBuildLogChunks(
+  deploymentId: string,
+  listener: (chunk: string) => void,
+): () => void {
+  const eventName = getEventName(deploymentId);
+  buildLogEmitter.on(eventName, listener);
+  return function unsubscribe(): void {
+    buildLogEmitter.off(eventName, listener);
+  };
+}

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -5,11 +5,13 @@ import { promisify } from "node:util";
 import type { Selectable } from "kysely";
 import { nanoid } from "nanoid";
 import { getSetting } from "./auth";
+import { emitBuildLogChunk } from "./build-log-stream";
 import { decrypt } from "./crypto";
 import { db } from "./db";
 import type { Environments, Projects, Registries, Services } from "./db-types";
 import {
   buildImage,
+  type BuildResult,
   createNetwork,
   dockerLogin,
   type FileMount,
@@ -81,7 +83,12 @@ async function updateDeployment(
     .execute();
 }
 
-async function appendLog(id: string, log: string) {
+async function appendLog(
+  id: string,
+  log: string,
+  options?: { emit?: boolean },
+) {
+  if (!log) return;
   const deployment = await db
     .selectFrom("deployments")
     .select("buildLog")
@@ -90,6 +97,39 @@ async function appendLog(id: string, log: string) {
 
   const existingLog = deployment?.buildLog || "";
   await updateDeployment(id, { buildLog: existingLog + log });
+  if (options?.emit !== false) {
+    emitBuildLogChunk(id, log);
+  }
+}
+
+function createLogChunkAppender(deploymentId: string): {
+  append: (chunk: string) => void;
+  flush: () => Promise<void>;
+} {
+  let queue = Promise.resolve();
+  let queueError: Error | null = null;
+
+  function append(chunk: string): void {
+    if (!chunk || queueError) return;
+    emitBuildLogChunk(deploymentId, chunk);
+    queue = queue
+      .then(function writeChunk() {
+        return appendLog(deploymentId, chunk, { emit: false });
+      })
+      .catch(function onQueueError(err) {
+        queueError =
+          err instanceof Error ? err : new Error(String(err ?? "Unknown error"));
+      });
+  }
+
+  async function flush(): Promise<void> {
+    await queue;
+    if (queueError) {
+      throw queueError;
+    }
+  }
+
+  return { append, flush };
 }
 
 async function isDeploymentCancelled(deploymentId: string): Promise<boolean> {
@@ -851,31 +891,55 @@ async function runServiceDeployment(
         }
       }
 
-      const cloneResult = await new Promise<string>((resolve, reject) => {
-        let output = "";
-        const proc = spawn("git", [
-          "clone",
-          "--depth",
-          "1",
-          "--branch",
-          branch,
-          cloneUrl,
-          repoPath,
-        ]);
-        proc.stdout.on("data", (data) => {
-          output += data.toString();
+      const cloneLogAppender = createLogChunkAppender(deploymentId);
+      let cloneResult: { output: string; code: number | null } | null = null;
+      try {
+        cloneResult = await new Promise<{
+          output: string;
+          code: number | null;
+        }>((resolve, reject) => {
+          let output = "";
+          const proc = spawn("git", [
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            cloneUrl,
+            repoPath,
+          ]);
+          proc.stdout.on("data", (data) => {
+            const chunk = data.toString();
+            output += chunk;
+            cloneLogAppender.append(chunk);
+          });
+          proc.stderr.on("data", (data) => {
+            const chunk = data.toString();
+            output += chunk;
+            cloneLogAppender.append(chunk);
+          });
+          proc.on("close", (code) => {
+            resolve({ output, code });
+          });
+          proc.on("error", reject);
         });
-        proc.stderr.on("data", (data) => {
-          output += data.toString();
-        });
-        proc.on("close", (code) => {
-          if (code === 0) resolve(output);
-          else
-            reject(new Error(output || `git clone exited with code ${code}`));
-        });
-        proc.on("error", reject);
-      });
-      await appendLog(deploymentId, cloneResult || "Cloned successfully\n");
+      } finally {
+        await cloneLogAppender.flush();
+      }
+
+      if (!cloneResult) {
+        throw new Error("git clone failed");
+      }
+
+      if (!cloneResult.output) {
+        await appendLog(deploymentId, "Cloned successfully\n");
+      }
+      if (cloneResult.code !== 0) {
+        throw new Error(
+          cloneResult.output ||
+            `git clone exited with code ${cloneResult.code}`,
+        );
+      }
 
       const frostConfigResult = loadFrostConfig(
         repoPath,
@@ -945,19 +1009,26 @@ async function runServiceDeployment(
       );
 
       imageName = `${sanitizeDockerName(`frost-${project.id}-${service.name}`)}:${commitSha}`;
-      const buildResult = await buildImage({
-        repoPath,
-        imageName,
-        dockerfilePath: effectiveService.dockerfilePath ?? undefined,
-        buildContext: service.buildContext ?? undefined,
-        envVars,
-        labels: baseLabels,
-      });
+      const buildLogAppender = createLogChunkAppender(deploymentId);
+      let buildResult: BuildResult | null = null;
+      try {
+        buildResult = await buildImage({
+          repoPath,
+          imageName,
+          dockerfilePath: effectiveService.dockerfilePath ?? undefined,
+          buildContext: service.buildContext ?? undefined,
+          envVars,
+          labels: baseLabels,
+          onData(chunk) {
+            buildLogAppender.append(chunk);
+          },
+        });
+      } finally {
+        await buildLogAppender.flush();
+      }
 
-      await appendLog(deploymentId, buildResult.log);
-
-      if (!buildResult.success) {
-        throw new Error(buildResult.error || "Build failed");
+      if (!buildResult || !buildResult.success) {
+        throw new Error(buildResult?.error || "Build failed");
       }
 
       if (await isDeploymentCancelled(deploymentId)) {

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -10,8 +10,8 @@ import { decrypt } from "./crypto";
 import { db } from "./db";
 import type { Environments, Projects, Registries, Services } from "./db-types";
 import {
-  buildImage,
   type BuildResult,
+  buildImage,
   createNetwork,
   dockerLogin,
   type FileMount,
@@ -118,7 +118,9 @@ function createLogChunkAppender(deploymentId: string): {
       })
       .catch(function onQueueError(err) {
         queueError =
-          err instanceof Error ? err : new Error(String(err ?? "Unknown error"));
+          err instanceof Error
+            ? err
+            : new Error(String(err ?? "Unknown error"));
       });
   }
 

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -30,6 +30,7 @@ export interface BuildImageOptions {
   buildContext?: string;
   envVars?: Record<string, string>;
   labels?: Record<string, string>;
+  onData?: (chunk: string) => void;
 }
 
 export async function buildImage(
@@ -55,6 +56,7 @@ export async function buildImage(
     buildContext,
     envVars,
     labels,
+    onData,
   } = options;
 
   if (await imageExists(imageName)) {
@@ -84,11 +86,15 @@ export async function buildImage(
     });
 
     proc.stdout.on("data", (data) => {
-      log += data.toString();
+      const chunk = data.toString();
+      log += chunk;
+      onData?.(chunk);
     });
 
     proc.stderr.on("data", (data) => {
-      log += data.toString();
+      const chunk = data.toString();
+      log += chunk;
+      onData?.(chunk);
     });
 
     proc.on("close", (code) => {


### PR DESCRIPTION
## Summary
- stream build logs over SSE via new `/api/deployments/:id/build-logs` endpoint
- add in-memory per-deployment build-log event bus
- emit + persist `git clone` and `docker build` output incrementally from deployer
- switch deployment logs drawer to live SSE hook, with DB-log fallback

## Validation
- `bunx biome check apps/app/src/lib/build-log-stream.ts apps/app/src/lib/deployer.ts apps/app/src/lib/docker.ts apps/app/src/app/api/deployments/[id]/build-logs/route.ts apps/app/src/hooks/use-build-logs.ts apps/app/src/app/projects/[id]/_components/deployment-logs-drawer.tsx`
- `bun --cwd apps/app typecheck` *(fails in this env: TS toolchain resolves `tsc` 4.9.5; repo tsconfig expects newer moduleResolution option)*

Closes #304
