### PR TITLE
fix(mcp): harden oauth tokens and mcp validation

### DIFF
--- a/apps/app/scripts/e2e/group-29-mcp.sh
+++ b/apps/app/scripts/e2e/group-29-mcp.sh
@@ -78,10 +78,12 @@ MCP_VIA_KEY=$(curl -s -X POST "$BASE_URL/api/mcp" \
   -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-test","version":"1.0.0"}}}')
 
-if echo "$MCP_VIA_KEY" | grep -q '"error"' && ! echo "$MCP_VIA_KEY" | grep -q '"serverInfo"'; then
-  log "Note: MCP via API key returned error (expected if session issue), but auth passed"
-else
+if echo "$MCP_VIA_KEY" | grep -q '"serverInfo"'; then
   log "MCP via x-frost-token works"
+elif echo "$MCP_VIA_KEY" | grep -q '"result"'; then
+  log "MCP via x-frost-token works"
+else
+  fail "MCP initialize via API key failed: $MCP_VIA_KEY"
 fi
 
 rm -f /tmp/frost-mcp-cookies.txt

--- a/apps/app/src/app/api/oauth/register/route.ts
+++ b/apps/app/src/app/api/oauth/register/route.ts
@@ -3,7 +3,31 @@ import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 
+const REGISTER_WINDOW_MS = 60 * 1000;
+const REGISTER_MAX_REQUESTS = 20;
+const MAX_REDIRECT_URIS = 10;
+const MAX_CLIENT_NAME_LENGTH = 120;
+
+const g = globalThis as typeof globalThis & {
+  __oauthRegisterLimit?: Map<string, { count: number; resetAt: number }>;
+};
+if (!g.__oauthRegisterLimit) {
+  g.__oauthRegisterLimit = new Map();
+}
+const registerLimit = g.__oauthRegisterLimit;
+
 export async function POST(request: Request) {
+  const clientAddress = getClientAddress(request);
+  if (isRateLimited(clientAddress)) {
+    return NextResponse.json(
+      {
+        error: "slow_down",
+        error_description: "Too many registration requests",
+      },
+      { status: 429 },
+    );
+  }
+
   let body: Record<string, unknown>;
   try {
     body = await request.json();
@@ -16,12 +40,43 @@ export async function POST(request: Request) {
   const redirectUris = Array.isArray(body.redirect_uris)
     ? body.redirect_uris.filter((u): u is string => typeof u === "string")
     : [];
+  const uniqueRedirectUris = [...new Set(redirectUris)];
 
-  if (redirectUris.length === 0) {
+  if (clientName && clientName.length > MAX_CLIENT_NAME_LENGTH) {
+    return NextResponse.json(
+      {
+        error: "invalid_client_metadata",
+        error_description: "client_name too long",
+      },
+      { status: 400 },
+    );
+  }
+
+  if (uniqueRedirectUris.length === 0) {
     return NextResponse.json(
       {
         error: "invalid_client_metadata",
         error_description: "redirect_uris required",
+      },
+      { status: 400 },
+    );
+  }
+
+  if (uniqueRedirectUris.length > MAX_REDIRECT_URIS) {
+    return NextResponse.json(
+      {
+        error: "invalid_client_metadata",
+        error_description: "too many redirect_uris",
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!uniqueRedirectUris.every(isValidRedirectUri)) {
+    return NextResponse.json(
+      {
+        error: "invalid_client_metadata",
+        error_description: "redirect_uris must be valid http/https URLs",
       },
       { status: 400 },
     );
@@ -36,7 +91,7 @@ export async function POST(request: Request) {
       id,
       clientId,
       clientName,
-      redirectUris: JSON.stringify(redirectUris),
+      redirectUris: JSON.stringify(uniqueRedirectUris),
     })
     .execute();
 
@@ -44,11 +99,54 @@ export async function POST(request: Request) {
     {
       client_id: clientId,
       client_name: clientName,
-      redirect_uris: redirectUris,
+      redirect_uris: uniqueRedirectUris,
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",
     },
     { status: 201 },
   );
+}
+
+function getClientAddress(request: Request): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const first = forwardedFor.split(",")[0]?.trim();
+    if (first) return first;
+  }
+
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) return realIp;
+
+  return "unknown";
+}
+
+function isRateLimited(clientAddress: string): boolean {
+  const now = Date.now();
+  const entry = registerLimit.get(clientAddress);
+
+  if (!entry || entry.resetAt <= now) {
+    registerLimit.set(clientAddress, {
+      count: 1,
+      resetAt: now + REGISTER_WINDOW_MS,
+    });
+    return false;
+  }
+
+  if (entry.count >= REGISTER_MAX_REQUESTS) return true;
+
+  registerLimit.set(clientAddress, {
+    count: entry.count + 1,
+    resetAt: entry.resetAt,
+  });
+  return false;
+}
+
+function isValidRedirectUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
 }

--- a/apps/app/src/lib/mcp/mcp-tools.test.ts
+++ b/apps/app/src/lib/mcp/mcp-tools.test.ts
@@ -527,6 +527,31 @@ describe("MCP service configuration completeness", () => {
     expect(result.content[0]?.text).toBe("Cannot use replicas with volumes");
   });
 
+  test("update_service rejects setting volumes on replicated service", async () => {
+    const serviceId = await insertService({ replicaCount: 2, volumes: "[]" });
+
+    const result = await callTool("update_service", {
+      serviceId,
+      volumes: [{ name: "data", path: "/data" }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe("Cannot use replicas with volumes");
+  });
+
+  test("update_service rejects replicas with volumes in same request", async () => {
+    const serviceId = await insertService({ replicaCount: 1, volumes: "[]" });
+
+    const result = await callTool("update_service", {
+      serviceId,
+      replicaCount: 2,
+      volumes: [{ name: "data", path: "/data" }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe("Cannot use replicas with volumes");
+  });
+
   test("update_service maps autoDeployEnabled to service autoDeploy", async () => {
     const serviceId = await insertService({
       deployType: "repo",

--- a/apps/app/src/lib/oauth.test.ts
+++ b/apps/app/src/lib/oauth.test.ts
@@ -4,6 +4,8 @@ import {
   generateAccessToken,
   generateCode,
   generateRefreshToken,
+  getAccessTokenExpiry,
+  getAccessTokenTtlSeconds,
   hashOAuthToken,
   verifyPKCE,
 } from "./oauth";
@@ -39,6 +41,18 @@ describe("oauth", () => {
     test("has frost_rt_ prefix", () => {
       const token = generateRefreshToken();
       expect(token.startsWith("frost_rt_")).toBe(true);
+    });
+  });
+
+  describe("access token ttl", () => {
+    test("returns positive ttl seconds", () => {
+      const ttlSeconds = getAccessTokenTtlSeconds();
+      expect(ttlSeconds).toBeGreaterThan(0);
+    });
+
+    test("expiry is in the future", () => {
+      const expiryMs = new Date(getAccessTokenExpiry()).getTime();
+      expect(expiryMs).toBeGreaterThan(Date.now());
     });
   });
 

--- a/apps/app/src/lib/oauth.ts
+++ b/apps/app/src/lib/oauth.ts
@@ -3,6 +3,7 @@ import { db } from "./db";
 import { getRequiredJwtSecret } from "./jwt-secret";
 
 const AUTH_CODE_EXPIRY_MS = 10 * 60 * 1000;
+const DEFAULT_ACCESS_TOKEN_TTL_DAYS = 30;
 
 export function generateCode(): string {
   return randomBytes(32).toString("hex");
@@ -34,15 +35,26 @@ export async function verifyOAuthToken(token: string): Promise<boolean> {
   const hash = hashOAuthToken(token);
   const record = await db
     .selectFrom("oauthTokens")
-    .select("id")
+    .select(["id", "expiresAt"])
     .where("accessTokenHash", "=", hash)
     .executeTakeFirst();
 
-  return !!record;
+  if (!record) return false;
+
+  if (new Date(record.expiresAt).getTime() <= Date.now()) {
+    await db.deleteFrom("oauthTokens").where("id", "=", record.id).execute();
+    return false;
+  }
+
+  return true;
 }
 
 export function getAccessTokenExpiry(): string {
-  return new Date("9999-12-31T23:59:59.999Z").toISOString();
+  return new Date(Date.now() + getAccessTokenTtlMs()).toISOString();
+}
+
+export function getAccessTokenTtlSeconds(): number {
+  return Math.floor(getAccessTokenTtlMs() / 1000);
 }
 
 export function getAuthCodeExpiry(): string {
@@ -64,4 +76,15 @@ export async function parseOAuthBody(
   } catch {
     return null;
   }
+}
+
+function getAccessTokenTtlMs(): number {
+  const ttlDays = Number(
+    process.env.FROST_OAUTH_ACCESS_TOKEN_TTL_DAYS ??
+      String(DEFAULT_ACCESS_TOKEN_TTL_DAYS),
+  );
+  if (!Number.isFinite(ttlDays) || ttlDays <= 0) {
+    return DEFAULT_ACCESS_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
+  }
+  return Math.floor(ttlDays * 24 * 60 * 60 * 1000);
 }

--- a/apps/marketing/src/app/docs/guides/mcp/page.mdx
+++ b/apps/marketing/src/app/docs/guides/mcp/page.mdx
@@ -80,7 +80,7 @@ Frost uses OAuth 2.1 with PKCE for MCP authentication:
 5. Agent gets an access token, stores it locally
 6. All subsequent requests include the Bearer token
 
-Tokens don't expire. You can view and revoke active tokens in **Settings → MCP Tokens**.
+Access tokens expire (default: 30 days). You can view and revoke active tokens in **Settings → MCP Tokens**.
 
 For programmatic/CI access, you can also use `x-frost-token` header with an API key from Settings.
 


### PR DESCRIPTION
## Summary
- fix `update_service` validation to reject replicas+volumes based on effective next state
- add regression tests for both update paths
- add OAuth access token TTL (default 30d), expiry checks, and `expires_in` response
- add basic rate limiting + redirect URI validation to dynamic OAuth client registration
- make MCP API-key e2e fail hard on bad initialize response
- update MCP docs to reflect token expiry

## Validation
- `bun run typecheck`
- `bun run build`
- `bun test src/lib/oauth.test.ts`
- `bun test src/lib/mcp/mcp-tools.test.ts`
