### PR TITLE
fix(db): align replicas created_at type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Never edit existing migration files after merge; add a new forward-only migration instead.

--- a/apps/app/schema/010-replicas-created-at-integer.sql
+++ b/apps/app/schema/010-replicas-created-at-integer.sql
@@ -1,0 +1,33 @@
+CREATE TABLE replicas_new (
+    id TEXT PRIMARY KEY,
+    deployment_id TEXT NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
+    replica_index INTEGER NOT NULL,
+    container_id TEXT,
+    host_port INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER) * 1000),
+    UNIQUE(deployment_id, replica_index)
+);
+
+INSERT INTO replicas_new (
+    id,
+    deployment_id,
+    replica_index,
+    container_id,
+    host_port,
+    status,
+    created_at
+)
+SELECT
+    id,
+    deployment_id,
+    replica_index,
+    container_id,
+    host_port,
+    status,
+    CAST(created_at AS INTEGER)
+FROM replicas;
+
+DROP TABLE replicas;
+
+ALTER TABLE replicas_new RENAME TO replicas;

--- a/apps/app/src/lib/db-schemas.ts
+++ b/apps/app/src/lib/db-schemas.ts
@@ -534,7 +534,7 @@ export const replicasSchema = z.object({
   containerId: z.string().nullable(),
   hostPort: z.number().nullable(),
   status: z.string(),
-  createdAt: z.string(),
+  createdAt: z.number(),
 });
 
 export const newReplicasSchema = z.object({
@@ -544,7 +544,7 @@ export const newReplicasSchema = z.object({
   containerId: z.string().nullable(),
   hostPort: z.number().nullable(),
   status: z.string().optional(),
-  createdAt: z.string().optional(),
+  createdAt: z.number().optional(),
 });
 
 export const replicasUpdateSchema = z.object({
@@ -554,7 +554,7 @@ export const replicasUpdateSchema = z.object({
   containerId: z.string().nullable().optional(),
   hostPort: z.number().nullable().optional(),
   status: z.string().optional(),
-  createdAt: z.string().optional(),
+  createdAt: z.number().optional(),
 });
 
 export type Replicas = z.infer<typeof replicasSchema>;

--- a/apps/app/src/lib/db-types.ts
+++ b/apps/app/src/lib/db-types.ts
@@ -169,7 +169,7 @@ export interface Replicas {
   containerId: string | null;
   hostPort: number | null;
   status: Generated<string>;
-  createdAt: Generated<string>;
+  createdAt: Generated<number>;
 }
 
 export interface Services {

--- a/apps/app/src/lib/migrate.integration.test.ts
+++ b/apps/app/src/lib/migrate.integration.test.ts
@@ -172,6 +172,20 @@ describe("migrate integration", () => {
     expect(columnNames).toContain("is_system");
   });
 
+  test("replicas created_at column uses integer type", () => {
+    runMigrations({ dbPath: TEST_DB, schemaDir: PROD_SCHEMA_DIR });
+
+    const db = new Database(TEST_DB);
+    const column = db
+      .prepare("PRAGMA table_info(replicas)")
+      .all() as Array<{ name: string; type: string }>;
+    db.close();
+
+    const createdAt = column.find((c) => c.name === "created_at");
+    expect(createdAt).toBeDefined();
+    expect(createdAt?.type.toUpperCase()).toBe("INTEGER");
+  });
+
   test("foreign key constraints are enabled and work", () => {
     runMigrations({ dbPath: TEST_DB, schemaDir: PROD_SCHEMA_DIR });
 

--- a/apps/app/src/lib/migrate.integration.test.ts
+++ b/apps/app/src/lib/migrate.integration.test.ts
@@ -176,9 +176,10 @@ describe("migrate integration", () => {
     runMigrations({ dbPath: TEST_DB, schemaDir: PROD_SCHEMA_DIR });
 
     const db = new Database(TEST_DB);
-    const column = db
-      .prepare("PRAGMA table_info(replicas)")
-      .all() as Array<{ name: string; type: string }>;
+    const column = db.prepare("PRAGMA table_info(replicas)").all() as Array<{
+      name: string;
+      type: string;
+    }>;
     db.close();
 
     const createdAt = column.find((c) => c.name === "created_at");


### PR DESCRIPTION
## Summary
- change `replicas.created_at` in `008-replicas.sql` from `TEXT` to `INTEGER`
- add `010-replicas-created-at-integer.sql` to rebuild `replicas` and cast existing `created_at` values to integer
- align runtime DB schemas/types for `replicas.createdAt` to `number`
- add migration integration test asserting `replicas.created_at` is `INTEGER`

## Testing
- `cd apps/app && bun test src/lib/migrate.integration.test.ts`
- `cd apps/app && bun test src/lib/migrate.test.ts`

Closes #300
