### PR TITLE
fix(ui): replace native confirm dialogs

### DIFF
--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/danger-zone-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/danger-zone-card.tsx
@@ -2,7 +2,9 @@
 
 import { Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { toast } from "sonner";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
 import { useDeleteService } from "@/hooks/use-services";
@@ -20,45 +22,58 @@ export function DangerZoneCard({
 }: DangerZoneCardProps) {
   const router = useRouter();
   const deleteMutation = useDeleteService(environmentId);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   async function handleDelete() {
-    if (!confirm("Delete this service? This cannot be undone.")) return;
     try {
       await deleteMutation.mutateAsync(serviceId);
       toast.success("Service deleted");
       router.push(`/projects/${projectId}/environments/${environmentId}`);
+      setShowDeleteDialog(false);
     } catch {
       toast.error("Failed to delete service");
     }
   }
 
   return (
-    <SettingCard
-      variant="danger"
-      title="Danger Zone"
-      description="Irreversible actions for this service."
-    >
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm text-neutral-300">Delete Service</p>
-          <p className="text-xs text-neutral-500">
-            Permanently delete this service and all its deployments
-          </p>
+    <>
+      <SettingCard
+        variant="danger"
+        title="Danger Zone"
+        description="Irreversible actions for this service."
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-neutral-300">Delete Service</p>
+            <p className="text-xs text-neutral-500">
+              Permanently delete this service and all its deployments
+            </p>
+          </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setShowDeleteDialog(true)}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="mr-1 h-4 w-4" />
+            )}
+            Delete Service
+          </Button>
         </div>
-        <Button
-          variant="destructive"
-          size="sm"
-          onClick={handleDelete}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? (
-            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-          ) : (
-            <Trash2 className="mr-1 h-4 w-4" />
-          )}
-          Delete Service
-        </Button>
-      </div>
-    </SettingCard>
+      </SettingCard>
+      <ConfirmDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        title="Delete service"
+        description="This cannot be undone."
+        confirmLabel="Delete"
+        variant="destructive"
+        loading={deleteMutation.isPending}
+        onConfirm={handleDelete}
+      />
+    </>
   );
 }

--- a/apps/app/src/app/projects/[id]/settings/_components/delete-project-card.tsx
+++ b/apps/app/src/app/projects/[id]/settings/_components/delete-project-card.tsx
@@ -2,7 +2,9 @@
 
 import { Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { toast } from "sonner";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
 import { useDeleteProject } from "@/hooks/use-projects";
@@ -14,48 +16,56 @@ interface DeleteProjectCardProps {
 export function DeleteProjectCard({ projectId }: DeleteProjectCardProps) {
   const router = useRouter();
   const deleteMutation = useDeleteProject();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   async function handleDelete() {
-    if (
-      !confirm(
-        "Delete this project and all its services? This cannot be undone.",
-      )
-    )
-      return;
     try {
       await deleteMutation.mutateAsync(projectId);
       toast.success("Project deleted");
       router.push("/");
+      setShowDeleteDialog(false);
     } catch {
       toast.error("Failed to delete project");
     }
   }
 
   return (
-    <SettingCard
-      variant="danger"
-      title="Delete Project"
-      description="Permanently delete this project and all its services, deployments, and environment variables. This action cannot be undone."
-      footerRight={
-        <Button
-          variant="destructive"
-          size="sm"
-          onClick={handleDelete}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? (
-            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-          ) : (
-            <Trash2 className="mr-1 h-4 w-4" />
-          )}
-          Delete Project
-        </Button>
-      }
-    >
-      <p className="text-sm text-neutral-400">
-        Once deleted, this project and all associated data will be permanently
-        removed from Frost.
-      </p>
-    </SettingCard>
+    <>
+      <SettingCard
+        variant="danger"
+        title="Delete Project"
+        description="Permanently delete this project and all its services, deployments, and environment variables. This action cannot be undone."
+        footerRight={
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setShowDeleteDialog(true)}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="mr-1 h-4 w-4" />
+            )}
+            Delete Project
+          </Button>
+        }
+      >
+        <p className="text-sm text-neutral-400">
+          Once deleted, this project and all associated data will be permanently
+          removed from Frost.
+        </p>
+      </SettingCard>
+      <ConfirmDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        title="Delete project"
+        description="Delete this project and all its services? This cannot be undone."
+        confirmLabel="Delete"
+        variant="destructive"
+        loading={deleteMutation.isPending}
+        onConfirm={handleDelete}
+      />
+    </>
   );
 }

--- a/apps/app/src/app/settings/_components/github-section.tsx
+++ b/apps/app/src/app/settings/_components/github-section.tsx
@@ -13,6 +13,7 @@ import {
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
 import { orpc } from "@/lib/orpc-client";
@@ -23,6 +24,7 @@ export function GitHubSection() {
   const formRef = useRef<HTMLFormElement>(null);
   const [manifest, setManifest] = useState<string>("");
   const [error, setError] = useState("");
+  const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
 
   const successParam = searchParams.get("success");
   const errorParam = searchParams.get("error");
@@ -55,14 +57,8 @@ export function GitHubSection() {
     }),
   );
 
-  async function handleDisconnect() {
-    if (
-      !confirm(
-        "Disconnect GitHub? You'll need to set up a new GitHub App to reconnect.",
-      )
-    ) {
-      return;
-    }
+  function handleDisconnect() {
+    setShowDisconnectDialog(false);
     disconnectMutation.mutate({});
   }
 
@@ -94,7 +90,7 @@ export function GitHubSection() {
         status?.connected && status?.installed ? (
           <Button
             variant="destructive"
-            onClick={handleDisconnect}
+            onClick={() => setShowDisconnectDialog(true)}
             disabled={disconnectMutation.isPending}
           >
             {disconnectMutation.isPending ? (
@@ -233,6 +229,16 @@ export function GitHubSection() {
           </div>
         )}
       </div>
+      <ConfirmDialog
+        open={showDisconnectDialog}
+        onOpenChange={setShowDisconnectDialog}
+        title="Disconnect GitHub"
+        description="You'll need to set up a new GitHub App to reconnect."
+        confirmLabel="Disconnect"
+        variant="destructive"
+        loading={disconnectMutation.isPending}
+        onConfirm={handleDisconnect}
+      />
     </SettingCard>
   );
 }

--- a/apps/app/src/app/settings/_components/system-section.tsx
+++ b/apps/app/src/app/settings/_components/system-section.tsx
@@ -11,6 +11,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { useState } from "react";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
 import { orpc } from "@/lib/orpc-client";
@@ -23,6 +24,7 @@ export function SystemSection() {
   const [previousVersion, setPreviousVersion] = useState<string | null>(null);
   const [showLog, setShowLog] = useState(false);
   const [error, setError] = useState("");
+  const [showApplyDialog, setShowApplyDialog] = useState(false);
 
   const { data: status } = useQuery(orpc.updates.get.queryOptions());
 
@@ -110,15 +112,12 @@ export function SystemSection() {
     checkMutation.mutate({});
   }
 
-  async function handleApply() {
-    if (!confirm("This will restart Frost to apply the update. Continue?")) {
-      return;
-    }
-
+  function handleApply() {
     setPreviousVersion(status?.currentVersion || null);
     setUpdateState("preparing");
     setError("");
     setShowLog(false);
+    setShowApplyDialog(false);
 
     applyMutation.mutate({});
   }
@@ -154,7 +153,10 @@ export function SystemSection() {
             Dismiss
           </Button>
         ) : status?.updateAvailable ? (
-          <Button onClick={handleApply} disabled={isUpdating}>
+          <Button
+            onClick={() => setShowApplyDialog(true)}
+            disabled={isUpdating}
+          >
             {isUpdating ? (
               <>
                 <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
@@ -323,6 +325,15 @@ export function SystemSection() {
           </>
         )}
       </div>
+      <ConfirmDialog
+        open={showApplyDialog}
+        onOpenChange={setShowApplyDialog}
+        title="Apply update"
+        description="This will restart Frost to apply the update. Continue?"
+        confirmLabel="Update and restart"
+        loading={applyMutation.isPending || updateState === "preparing"}
+        onConfirm={handleApply}
+      />
     </SettingCard>
   );
 }

--- a/apps/app/src/app/settings/api-keys/_components/api-keys-section.tsx
+++ b/apps/app/src/app/settings/api-keys/_components/api-keys-section.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, Copy, Loader2, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,6 +16,7 @@ export function ApiKeysSection() {
     null,
   );
   const [copied, setCopied] = useState(false);
+  const [deletingKeyId, setDeletingKeyId] = useState<string | null>(null);
 
   const { data: keys = [], isLoading: loading } = useQuery(
     orpc.apiKeys.list.queryOptions(),
@@ -43,8 +45,10 @@ export function ApiKeysSection() {
     createMutation.mutate({ name: newKeyName });
   }
 
-  async function handleDelete(id: string) {
-    if (!confirm("Delete this API key? This cannot be undone.")) return;
+  function handleDelete() {
+    if (!deletingKeyId) return;
+    const id = deletingKeyId;
+    setDeletingKeyId(null);
     deleteMutation.mutate({ id });
     if (newKey?.id === id) setNewKey(null);
   }
@@ -149,7 +153,7 @@ export function ApiKeysSection() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => handleDelete(key.id)}
+                          onClick={() => setDeletingKeyId(key.id)}
                           className="text-red-400 hover:text-red-300"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -190,6 +194,18 @@ export function ApiKeysSection() {
           </div>
         </div>
       )}
+      <ConfirmDialog
+        open={deletingKeyId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletingKeyId(null);
+        }}
+        title="Delete API key"
+        description="This cannot be undone."
+        confirmLabel="Delete"
+        variant="destructive"
+        loading={deleteMutation.isPending}
+        onConfirm={handleDelete}
+      />
     </SettingCard>
   );
 }

--- a/apps/app/src/app/settings/registries/_components/registries-section.tsx
+++ b/apps/app/src/app/settings/registries/_components/registries-section.tsx
@@ -3,6 +3,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,6 +27,10 @@ export function RegistriesSection() {
   const queryClient = useQueryClient();
   const [showForm, setShowForm] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [deletingRegistry, setDeletingRegistry] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   const [formData, setFormData] = useState({
     name: "",
@@ -69,7 +75,9 @@ export function RegistriesSection() {
         });
       },
       onError: (err) => {
-        alert(err instanceof Error ? err.message : "Failed to delete registry");
+        toast.error(
+          err instanceof Error ? err.message : "Failed to delete registry",
+        );
       },
     }),
   );
@@ -98,8 +106,10 @@ export function RegistriesSection() {
     });
   }
 
-  async function handleDelete(id: string) {
-    if (!confirm("Delete this registry?")) return;
+  function handleDelete() {
+    if (!deletingRegistry) return;
+    const { id } = deletingRegistry;
+    setDeletingRegistry(null);
     deleteMutation.mutate({ id });
   }
 
@@ -167,7 +177,12 @@ export function RegistriesSection() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => handleDelete(registry.id)}
+                          onClick={() =>
+                            setDeletingRegistry({
+                              id: registry.id,
+                              name: registry.name,
+                            })
+                          }
                           className="text-red-400 hover:text-red-300"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -318,6 +333,18 @@ export function RegistriesSection() {
           )}
         </div>
       )}
+      <ConfirmDialog
+        open={deletingRegistry !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletingRegistry(null);
+        }}
+        title="Delete registry"
+        description={`Delete "${deletingRegistry?.name}"?`}
+        confirmLabel="Delete"
+        variant="destructive"
+        loading={deleteMutation.isPending}
+        onConfirm={handleDelete}
+      />
     </SettingCard>
   );
 }


### PR DESCRIPTION
Fixes #302

## Summary
- replace native `confirm()` usage with shared `ConfirmDialog` across settings and project flows
- replace remaining native `alert()` in registries with toast
- align destructive actions with app UX patterns

## Validation
- `bunx @biomejs/biome check` on touched files
- `rg "\\b(confirm|alert)\\s*\\("` returns no matches
