### PR TITLE
fix(auth): enforce jwt secret at production startup

### DIFF
--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -1,5 +1,9 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { getRequiredJwtSecret } = await import("./lib/jwt-secret");
+    getRequiredJwtSecret();
+    console.log("[startup] jwt secret: ok");
+
     const { runMigrations } = await import("./lib/migrate");
     runMigrations();
     console.log("[startup] migrations: ok");

--- a/apps/app/src/lib/jwt-secret.test.ts
+++ b/apps/app/src/lib/jwt-secret.test.ts
@@ -47,7 +47,9 @@ describe("getRequiredJwtSecret", function () {
 
     expect(function () {
       getRequiredJwtSecret();
-    }).toThrow("FROST_JWT_SECRET must be set and must not use the default value");
+    }).toThrow(
+      "FROST_JWT_SECRET must be set and must not use the default value",
+    );
   });
 
   test("throws in production when default secret is set", function () {
@@ -56,7 +58,9 @@ describe("getRequiredJwtSecret", function () {
 
     expect(function () {
       getRequiredJwtSecret();
-    }).toThrow("FROST_JWT_SECRET must be set and must not use the default value");
+    }).toThrow(
+      "FROST_JWT_SECRET must be set and must not use the default value",
+    );
   });
 
   test("returns secret in production when set", function () {

--- a/apps/app/src/lib/jwt-secret.test.ts
+++ b/apps/app/src/lib/jwt-secret.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getRequiredJwtSecret } from "./jwt-secret";
+
+const env = process.env as Record<string, string | undefined>;
+const originalNodeEnv = env.NODE_ENV;
+const originalJwtSecret = env.FROST_JWT_SECRET;
+
+function setNodeEnv(value: string | undefined) {
+  if (value === undefined) {
+    delete env.NODE_ENV;
+    return;
+  }
+  env.NODE_ENV = value;
+}
+
+function setJwtSecret(value: string | undefined) {
+  if (value === undefined) {
+    delete env.FROST_JWT_SECRET;
+    return;
+  }
+  env.FROST_JWT_SECRET = value;
+}
+
+afterEach(function () {
+  setNodeEnv(originalNodeEnv);
+  setJwtSecret(originalJwtSecret);
+});
+
+describe("getRequiredJwtSecret", function () {
+  test("returns default secret in development when missing", function () {
+    setNodeEnv("development");
+    setJwtSecret(undefined);
+
+    expect(getRequiredJwtSecret()).toBe("frost-default-secret-change-me");
+  });
+
+  test("returns test secret in test when missing", function () {
+    setNodeEnv("test");
+    setJwtSecret(undefined);
+
+    expect(getRequiredJwtSecret()).toBe("frost-test-secret");
+  });
+
+  test("throws in production when missing", function () {
+    setNodeEnv("production");
+    setJwtSecret(undefined);
+
+    expect(function () {
+      getRequiredJwtSecret();
+    }).toThrow("FROST_JWT_SECRET must be set and must not use the default value");
+  });
+
+  test("throws in production when default secret is set", function () {
+    setNodeEnv("production");
+    setJwtSecret("frost-default-secret-change-me");
+
+    expect(function () {
+      getRequiredJwtSecret();
+    }).toThrow("FROST_JWT_SECRET must be set and must not use the default value");
+  });
+
+  test("returns secret in production when set", function () {
+    setNodeEnv("production");
+    setJwtSecret("production-secret");
+
+    expect(getRequiredJwtSecret()).toBe("production-secret");
+  });
+});

--- a/apps/app/src/lib/jwt-secret.ts
+++ b/apps/app/src/lib/jwt-secret.ts
@@ -1,4 +1,5 @@
 const DEFAULT_SECRET = "frost-default-secret-change-me";
+const TEST_SECRET = "frost-test-secret";
 
 const REQUIRED_SECRET_ERROR =
   "FROST_JWT_SECRET must be set and must not use the default value";
@@ -6,9 +7,12 @@ const REQUIRED_SECRET_ERROR =
 export function getRequiredJwtSecret(): string {
   const secret = process.env.FROST_JWT_SECRET;
 
-  // Keep tests deterministic without requiring per-test env setup.
   if (process.env.NODE_ENV === "test") {
-    return secret && secret !== DEFAULT_SECRET ? secret : "frost-test-secret";
+    return secret && secret !== DEFAULT_SECRET ? secret : TEST_SECRET;
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    return secret || DEFAULT_SECRET;
   }
 
   if (!secret || secret === DEFAULT_SECRET) {


### PR DESCRIPTION
## Summary
- enforce `FROST_JWT_SECRET` for non-development runtimes
- validate JWT secret during startup so prod fails fast
- add unit tests for dev/test/prod secret behavior

## Validation
- `bun --cwd apps/app test src/lib/jwt-secret.test.ts`
- `bunx biome check apps/app/src/lib/jwt-secret.ts apps/app/src/instrumentation.ts apps/app/src/lib/jwt-secret.test.ts`

Fixes #291
