### PR TITLE
fix(deployer): prevent concurrent host port double-allocation

### DIFF
--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -157,8 +157,80 @@ function parseEnvVars(envVarsJson: string): Record<string, string> {
 }
 
 const MAX_PORT_ATTEMPTS = 10;
+const ACTIVE_PORT_DEPLOYMENT_STATUSES = [
+  "pending",
+  "cloning",
+  "pulling",
+  "building",
+  "deploying",
+  "running",
+] as const;
+
+function getUpdatedRowCount(result: unknown): number {
+  if (!result || typeof result !== "object") return 0;
+  const value = (result as { numUpdatedRows?: number | bigint }).numUpdatedRows;
+  return Number(value ?? 0);
+}
+
+async function tryReserveReplicaPort(
+  replicaId: string,
+  hostPort: number,
+): Promise<boolean> {
+  const result = await db
+    .updateTable("replicas")
+    .set({ hostPort })
+    .where("id", "=", replicaId)
+    .where("status", "=", "pending")
+    .where((eb) =>
+      eb.or([eb("hostPort", "is", null), eb("hostPort", "=", hostPort)]),
+    )
+    .where((eb) =>
+      eb.not(
+        eb.exists(
+          eb
+            .selectFrom("replicas as activeReplicas")
+            .select("activeReplicas.id")
+            .where("activeReplicas.id", "!=", replicaId)
+            .where("activeReplicas.hostPort", "=", hostPort)
+            .where("activeReplicas.status", "in", ["pending", "running"]),
+        ),
+      ),
+    )
+    .where((eb) =>
+      eb.not(
+        eb.exists(
+          eb
+            .selectFrom("deployments as activeDeployments")
+            .select("activeDeployments.id")
+            .where("activeDeployments.hostPort", "=", hostPort)
+            .where(
+              "activeDeployments.status",
+              "in",
+              ACTIVE_PORT_DEPLOYMENT_STATUSES,
+            ),
+        ),
+      ),
+    )
+    .executeTakeFirst();
+
+  return getUpdatedRowCount(result) > 0;
+}
+
+async function releaseReplicaPortReservation(
+  replicaId: string,
+  hostPort: number,
+): Promise<void> {
+  await db
+    .updateTable("replicas")
+    .set({ hostPort: null })
+    .where("id", "=", replicaId)
+    .where("status", "=", "pending")
+    .where("hostPort", "=", hostPort)
+    .execute();
+}
 
 async function runContainerWithPortRetry(
+  replicaId: string,
   options: Omit<RunContainerOptions, "hostPort">,
   onRetry?: (port: number, attempt: number) => Promise<void>,
 ): Promise<{ containerId: string; hostPort: number }> {
@@ -168,11 +240,18 @@ async function runContainerWithPortRetry(
     const hostPort = await getAvailablePort(10000, 20000, triedPorts);
     triedPorts.add(hostPort);
 
+    const reserved = await tryReserveReplicaPort(replicaId, hostPort);
+    if (!reserved) {
+      continue;
+    }
+
     const result = await runContainer({ ...options, hostPort });
 
     if (result.success) {
       return { containerId: result.containerId, hostPort };
     }
+
+    await releaseReplicaPortReservation(replicaId, hostPort);
 
     const error = result.error || "";
     const isRetryable =
@@ -373,6 +452,7 @@ async function startReplicas(
 
       const { containerId: cId, hostPort: hPort } =
         await runContainerWithPortRetry(
+          replica.id,
           {
             imageName: opts.imageName,
             containerPort: opts.containerPort,

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -510,6 +510,10 @@ export function isContainerNameConflictError(error: string): boolean {
   return error.includes("is already in use by container");
 }
 
+function isMissingTableError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("no such table");
+}
+
 export async function getAvailablePort(
   start: number = 10000,
   end: number = 20000,
@@ -546,8 +550,10 @@ export async function getAvailablePort(
         usedPorts.add(d.hostPort);
       }
     }
-  } catch {
-    // Ignore - db might not be ready
+  } catch (error) {
+    if (!isMissingTableError(error)) {
+      throw error;
+    }
   }
 
   try {
@@ -562,8 +568,10 @@ export async function getAvailablePort(
         usedPorts.add(r.hostPort);
       }
     }
-  } catch {
-    // Ignore - table might not exist yet
+  } catch (error) {
+    if (!isMissingTableError(error)) {
+      throw error;
+    }
   }
 
   for (let port = start; port < end; port++) {


### PR DESCRIPTION
## Summary
- reserve replica ports in DB before docker run
- release reservation on failed start
- stop swallowing non-missing-table DB errors in port lookup

## Validation
- bun run typecheck
- bun run migrate
- bun test src/lib/deployer.integration.test.ts
- bun test src/lib/docker.integration.test.ts

Closes #292
