### PR TITLE
fix(deployer): serialize same-service deployment start

### DIFF
--- a/apps/app/src/lib/deployer-lock.test.ts
+++ b/apps/app/src/lib/deployer-lock.test.ts
@@ -31,30 +31,27 @@ describe("withServiceDeploymentLock", function describeLock() {
     ]);
   });
 
-  test(
-    "allows parallel tasks for different services",
-    async function testParallel() {
-      let running = 0;
-      let peak = 0;
+  test("allows parallel tasks for different services", async function testParallel() {
+    let running = 0;
+    let peak = 0;
 
-      await Promise.all([
-        withServiceDeploymentLock("service-a", async function taskA() {
-          running += 1;
-          peak = Math.max(peak, running);
-          await sleep(40);
-          running -= 1;
-        }),
-        withServiceDeploymentLock("service-b", async function taskB() {
-          running += 1;
-          peak = Math.max(peak, running);
-          await sleep(40);
-          running -= 1;
-        }),
-      ]);
+    await Promise.all([
+      withServiceDeploymentLock("service-a", async function taskA() {
+        running += 1;
+        peak = Math.max(peak, running);
+        await sleep(40);
+        running -= 1;
+      }),
+      withServiceDeploymentLock("service-b", async function taskB() {
+        running += 1;
+        peak = Math.max(peak, running);
+        await sleep(40);
+        running -= 1;
+      }),
+    ]);
 
-      expect(peak).toBe(2);
-    },
-  );
+    expect(peak).toBe(2);
+  });
 
   test("releases lock after failure", async function testFailure() {
     await expect(

--- a/apps/app/src/lib/deployer-lock.test.ts
+++ b/apps/app/src/lib/deployer-lock.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { withServiceDeploymentLock } from "./deployer";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(function onCreate(resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+describe("withServiceDeploymentLock", function describeLock() {
+  test("serializes tasks for same service", async function testSerialize() {
+    const events: string[] = [];
+
+    await Promise.all([
+      withServiceDeploymentLock("service-a", async function firstTask() {
+        events.push("first:start");
+        await sleep(40);
+        events.push("first:end");
+      }),
+      withServiceDeploymentLock("service-a", async function secondTask() {
+        events.push("second:start");
+        events.push("second:end");
+      }),
+    ]);
+
+    expect(events).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+    ]);
+  });
+
+  test(
+    "allows parallel tasks for different services",
+    async function testParallel() {
+      let running = 0;
+      let peak = 0;
+
+      await Promise.all([
+        withServiceDeploymentLock("service-a", async function taskA() {
+          running += 1;
+          peak = Math.max(peak, running);
+          await sleep(40);
+          running -= 1;
+        }),
+        withServiceDeploymentLock("service-b", async function taskB() {
+          running += 1;
+          peak = Math.max(peak, running);
+          await sleep(40);
+          running -= 1;
+        }),
+      ]);
+
+      expect(peak).toBe(2);
+    },
+  );
+
+  test("releases lock after failure", async function testFailure() {
+    await expect(
+      withServiceDeploymentLock("service-a", async function failingTask() {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    let ran = false;
+    await withServiceDeploymentLock("service-a", async function nextTask() {
+      ran = true;
+    });
+
+    expect(ran).toBe(true);
+  });
+});

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -65,6 +65,35 @@ export type DeploymentStatus =
   | "stopped"
   | "cancelled";
 
+const serviceDeploymentLocks = new Map<string, Promise<void>>();
+
+export async function withServiceDeploymentLock<T>(
+  serviceId: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  const previous = serviceDeploymentLocks.get(serviceId) ?? Promise.resolve();
+  let release = function noop(): void {};
+  const current = new Promise<void>(function onCreate(resolve) {
+    release = function releaseCurrent(): void {
+      resolve();
+    };
+  });
+  const chain = previous.then(function onPreviousDone() {
+    return current;
+  });
+  serviceDeploymentLocks.set(serviceId, chain);
+  await previous;
+
+  try {
+    return await task();
+  } finally {
+    release();
+    if (serviceDeploymentLocks.get(serviceId) === chain) {
+      serviceDeploymentLocks.delete(serviceId);
+    }
+  }
+}
+
 async function updateDeployment(
   id: string,
   updates: {
@@ -683,7 +712,7 @@ export async function deployProject(projectId: string): Promise<string[]> {
   return results.flat();
 }
 
-export async function deployService(
+async function deployServiceUnlocked(
   serviceId: string,
   options?: DeployOptions,
 ): Promise<string> {
@@ -749,6 +778,15 @@ export async function deployService(
   });
 
   return deploymentId;
+}
+
+export async function deployService(
+  serviceId: string,
+  options?: DeployOptions,
+): Promise<string> {
+  return withServiceDeploymentLock(serviceId, function deployServiceTask() {
+    return deployServiceUnlocked(serviceId, options);
+  });
 }
 
 async function runServiceDeployment(
@@ -1354,25 +1392,27 @@ export async function rollbackDeployment(
     throw new Error("Image no longer available");
   }
 
-  await cancelActiveDeployments(service.id, deploymentId);
+  return withServiceDeploymentLock(service.id, async function rollbackTask() {
+    await cancelActiveDeployments(service.id, deploymentId);
 
-  await db
-    .updateTable("deployments")
-    .set({ status: "deploying", trigger: "rollback" })
-    .where("id", "=", deploymentId)
-    .execute();
+    await db
+      .updateTable("deployments")
+      .set({ status: "deploying", trigger: "rollback" })
+      .where("id", "=", deploymentId)
+      .execute();
 
-  runRollbackDeployment(
-    deploymentId,
-    targetDeployment,
-    service,
-    environment,
-    project,
-  ).catch((err) => {
-    console.error("Rollback deployment failed:", err);
+    runRollbackDeployment(
+      deploymentId,
+      targetDeployment,
+      service,
+      environment,
+      project,
+    ).catch((err) => {
+      console.error("Rollback deployment failed:", err);
+    });
+
+    return deploymentId;
   });
-
-  return deploymentId;
 }
 
 async function runRollbackDeployment(


### PR DESCRIPTION
fixes #290

## summary
- add per-service deployment mutex in deployer
- serialize `deployService` start path and rollback start path per service
- add lock unit tests for serialize/parallel/error-release behavior

## validation
- bun test src/lib/deployer-lock.test.ts
- bun run typecheck
