### PR TITLE
fix(services): stop polling while editing settings

### DIFF
--- a/apps/app/src/app/projects/[id]/_components/service-sidebar.tsx
+++ b/apps/app/src/app/projects/[id]/_components/service-sidebar.tsx
@@ -23,10 +23,12 @@ export function ServiceSidebar({
   serviceId,
   onClose,
 }: ServiceSidebarProps) {
-  const { data: service } = useService(serviceId || "");
   const [activeTab, setActiveTab] = useState<
     "overview" | "deployments" | "logs" | "settings"
   >("overview");
+  const { data: service } = useService(serviceId || "", {
+    refetchInterval: activeTab === "settings" ? false : 2000,
+  });
   const [hasNestedDrawer, setHasNestedDrawer] = useState(false);
 
   const handleNestedDrawerChange = useCallback((hasDrawer: boolean) => {

--- a/apps/app/src/hooks/use-services.ts
+++ b/apps/app/src/hooks/use-services.ts
@@ -9,10 +9,14 @@ export function useServices(environmentId: string) {
   });
 }
 
-export function useService(id: string) {
+interface UseServiceOptions {
+  refetchInterval?: number | false;
+}
+
+export function useService(id: string, options?: UseServiceOptions) {
   return useQuery({
     ...orpc.services.get.queryOptions({ input: { id } }),
-    refetchInterval: 2000,
+    refetchInterval: options?.refetchInterval ?? false,
   });
 }
 


### PR DESCRIPTION
## Summary
- make `useService` opt-in for polling (no default interval)
- keep 2s polling in sidebar overview/deployments/logs
- disable polling in settings tab to prevent form reset while editing

## Testing
- `bunx biome check apps/app/src/hooks/use-services.ts apps/app/src/app/projects/[id]/_components/service-sidebar.tsx`
- `bun --cwd apps/app typecheck` *(fails in this env due existing TS config/moduleResolution mismatch)*

Closes #301
