### PR TITLE
fix(deploy): enforce platform-aware image pulls

### DIFF
--- a/apps/app/src/lib/docker-platform.test.ts
+++ b/apps/app/src/lib/docker-platform.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyPullFailure,
+  normalizeDockerArch,
+  normalizeDockerPlatform,
+} from "./docker";
+
+describe("normalizeDockerArch", () => {
+  test("normalizes amd64 variants", () => {
+    expect(normalizeDockerArch("amd64")).toBe("amd64");
+    expect(normalizeDockerArch("x86_64")).toBe("amd64");
+    expect(normalizeDockerArch("x64")).toBe("amd64");
+  });
+
+  test("normalizes arm64 variants", () => {
+    expect(normalizeDockerArch("arm64")).toBe("arm64");
+    expect(normalizeDockerArch("aarch64")).toBe("arm64");
+    expect(normalizeDockerArch("arm64/v8")).toBe("arm64");
+  });
+});
+
+describe("normalizeDockerPlatform", () => {
+  test("normalizes platform values", () => {
+    expect(normalizeDockerPlatform("linux/aarch64")).toBe("linux/arm64");
+    expect(normalizeDockerPlatform("linux/x86_64")).toBe("linux/amd64");
+  });
+});
+
+describe("classifyPullFailure", () => {
+  test("classifies platform mismatch", () => {
+    const message =
+      "no matching manifest for linux/arm64/v8 in the manifest list entries";
+    expect(classifyPullFailure(message)).toBe("image/platform-mismatch");
+  });
+
+  test("classifies image not found", () => {
+    expect(classifyPullFailure("manifest unknown")).toBe("image/not-found");
+  });
+});

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -124,14 +124,18 @@ export async function pullImage(imageName: string): Promise<BuildResult> {
     10000,
     backoffMs,
   );
+  const hostPlatform = await getDockerHostPlatform();
 
   let combinedLog = "";
   let lastError = "Pull failed";
   let lastFailureClass = "unknown";
 
   for (let attempt = 1; attempt <= retryCount; attempt++) {
-    combinedLog += `\n[pull-attempt ${attempt}/${retryCount}] docker pull ${imageName}\n`;
-    const attemptResult = await runDockerPull(imageName);
+    const pullCmd = hostPlatform
+      ? `docker pull --platform ${hostPlatform} ${imageName}`
+      : `docker pull ${imageName}`;
+    combinedLog += `\n[pull-attempt ${attempt}/${retryCount}] ${pullCmd}\n`;
+    const attemptResult = await runDockerPull(imageName, hostPlatform);
     const failureClass = classifyPullFailure(
       attemptResult.log,
       attemptResult.error,
@@ -140,6 +144,20 @@ export async function pullImage(imageName: string): Promise<BuildResult> {
     combinedLog += attemptResult.log;
 
     if (attemptResult.success) {
+      const imagePlatform = await getImagePlatform(imageName);
+      if (hostPlatform && imagePlatform && imagePlatform !== hostPlatform) {
+        const mismatchError = `Image platform mismatch: host=${hostPlatform} image=${imagePlatform}`;
+        combinedLog += `[pull-attempt ${attempt}/${retryCount}] failed class=image/platform-mismatch error=${mismatchError}\n`;
+        return {
+          success: false,
+          imageName,
+          log: combinedLog,
+          error: mismatchError,
+          failureClass: "image/platform-mismatch",
+          attempts: attempt,
+        };
+      }
+
       return {
         success: true,
         imageName,
@@ -184,10 +202,16 @@ export async function pullImage(imageName: string): Promise<BuildResult> {
 
 function runDockerPull(
   imageName: string,
+  platform?: string | null,
 ): Promise<{ success: boolean; log: string; error?: string; code?: number }> {
   return new Promise((resolve) => {
     let log = "";
-    const proc = spawn("docker", ["pull", imageName]);
+    const args = ["pull"];
+    if (platform) {
+      args.push("--platform", platform);
+    }
+    args.push(imageName);
+    const proc = spawn("docker", args);
 
     proc.stdout.on("data", (data) => {
       log += data.toString();
@@ -216,44 +240,109 @@ function runDockerPull(
   });
 }
 
-function classifyPullFailure(log: string, error?: string): string {
+export function classifyPullFailure(log: string, error?: string): string {
   const full = `${log}\n${error ?? ""}`.toLowerCase();
 
   if (
-    full.includes("context deadline exceeded") ||
-    full.includes("i/o timeout") ||
-    full.includes("tls handshake timeout") ||
-    full.includes("proxyconnect tcp") ||
-    full.includes("dial tcp")
+    includesAny(full, [
+      "context deadline exceeded",
+      "i/o timeout",
+      "tls handshake timeout",
+      "proxyconnect tcp",
+      "dial tcp",
+    ])
   ) {
     return "infra/transient-network";
   }
 
-  if (
-    full.includes("toomanyrequests") ||
-    full.includes("rate limit") ||
-    full.includes("429")
-  ) {
+  if (includesAny(full, ["toomanyrequests", "rate limit", "429"])) {
     return "infra/rate-limit";
   }
 
   if (
-    full.includes("unauthorized") ||
-    full.includes("authentication required") ||
-    full.includes("denied")
+    includesAny(full, ["unauthorized", "authentication required", "denied"])
   ) {
     return "registry/auth";
   }
 
   if (
-    full.includes("manifest unknown") ||
-    full.includes("not found") ||
-    full.includes("name unknown")
+    includesAny(full, [
+      "no matching manifest for",
+      "requested image's platform",
+    ])
+  ) {
+    return "image/platform-mismatch";
+  }
+
+  if (
+    includesAny(full, ["manifest unknown", "not found", "name unknown"])
   ) {
     return "image/not-found";
   }
 
   return "unknown";
+}
+
+function includesAny(value: string, needles: string[]): boolean {
+  for (const needle of needles) {
+    if (value.includes(needle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const DOCKER_ARCH_ALIASES: Record<string, string> = {
+  x86_64: "amd64",
+  "x86-64": "amd64",
+  x64: "amd64",
+  aarch64: "arm64",
+  "arm64/v8": "arm64",
+  armhf: "arm/v7",
+  armv7l: "arm/v7",
+  "arm/v7": "arm/v7",
+  armel: "arm/v6",
+  armv6l: "arm/v6",
+  "arm/v6": "arm/v6",
+};
+
+export function normalizeDockerArch(arch: string): string {
+  const value = arch.trim().toLowerCase();
+  return DOCKER_ARCH_ALIASES[value] ?? value;
+}
+
+export function normalizeDockerPlatform(platform: string): string {
+  const value = platform.trim().toLowerCase();
+  const [os, ...archParts] = value.split("/");
+  if (!os || archParts.length === 0) {
+    return value;
+  }
+  const arch = normalizeDockerArch(archParts.join("/"));
+  return `${os}/${arch}`;
+}
+
+async function getDockerHostPlatform(): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync(
+      "docker version --format '{{.Server.Os}}/{{.Server.Arch}}'",
+    );
+    const platform = normalizeDockerPlatform(stdout.trim());
+    return platform.includes("/") ? platform : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getImagePlatform(imageName: string): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync(
+      `docker image inspect --format '{{.Os}}/{{.Architecture}}' ${shellEscape(imageName)}`,
+    );
+    const platform = normalizeDockerPlatform(stdout.trim());
+    return platform.includes("/") ? platform : null;
+  } catch {
+    return null;
+  }
 }
 
 function parseEnvInt(name: string, fallback: number, minimum: number): number {

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -274,9 +274,7 @@ export function classifyPullFailure(log: string, error?: string): string {
     return "image/platform-mismatch";
   }
 
-  if (
-    includesAny(full, ["manifest unknown", "not found", "name unknown"])
-  ) {
+  if (includesAny(full, ["manifest unknown", "not found", "name unknown"])) {
     return "image/not-found";
   }
 

--- a/apps/app/templates/services/hello.yaml
+++ b/apps/app/templates/services/hello.yaml
@@ -1,9 +1,9 @@
 name: Hello World
 description: Simple hello world
 category: testing
-docs: https://github.com/crccheck/docker-hello-world
+docs: https://hub.docker.com/r/nginxdemos/hello
 
 services:
   hello:
-    image: crccheck/hello-world
-    port: 8000
+    image: nginxdemos/hello:plain-text
+    port: 80


### PR DESCRIPTION
## summary
- make image deploy pulls platform-aware by detecting docker host platform at runtime
- fail fast with `image/platform-mismatch` when pulled image platform does not match host platform
- simplify platform/arch normalization helpers and add focused tests
- switch hello template to a multi-arch image so seeded demo works on arm64 and amd64

## testing
- bun test src/lib/docker-platform.test.ts src/lib/templates.test.ts
