### PR TITLE
fix(app): stop service containers on delete

### DIFF
--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -398,6 +398,21 @@ export async function stopContainer(name: string): Promise<void> {
   }
 }
 
+export async function stopContainersByLabel(
+  labelName: string,
+  labelValue: string,
+): Promise<void> {
+  try {
+    const { stdout } = await execAsync(
+      `docker ps -aq --filter ${shellEscape(`label=${labelName}=${labelValue}`)} --filter status=running`,
+    );
+    const containerIds = stdout.trim().split(/\s+/).filter(Boolean);
+    for (const containerId of containerIds) {
+      await stopContainer(containerId);
+    }
+  } catch {}
+}
+
 export async function gracefulStopContainer(
   name: string,
   timeout: number = 30,

--- a/apps/app/src/lib/lifecycle.ts
+++ b/apps/app/src/lib/lifecycle.ts
@@ -1,5 +1,5 @@
 import { db } from "./db";
-import { removeNetwork, stopContainer } from "./docker";
+import { removeNetwork, stopContainer, stopContainersByLabel } from "./docker";
 import { syncCaddyConfig } from "./domains";
 import { removeSSLCerts } from "./ssl";
 import { buildVolumeName, removeVolume } from "./volumes";
@@ -29,6 +29,8 @@ async function cleanupServiceResources(
 }
 
 async function stopServiceContainers(serviceId: string): Promise<void> {
+  await stopContainersByLabel("frost.service.id", serviceId);
+
   const deployments = await db
     .selectFrom("deployments")
     .select(["id", "containerId"])


### PR DESCRIPTION
## Summary
- stop all containers labeled with the target service id before deleting service records
- keep existing DB-driven cleanup as a fallback for containers without labels
- add an integration test covering label-based container stop behavior

## Why
Deleting a service can leave running containers if container rows are missing or already stale.
This change ensures runtime cleanup removes any still-running containers tied to the service label before DB deletion.

## References
- Closes #295
