### PR TITLE
fix(forms): use onsubmit for submit actions

### DIFF
--- a/apps/app/src/app/projects/[id]/_components/create-database-dialog.tsx
+++ b/apps/app/src/app/projects/[id]/_components/create-database-dialog.tsx
@@ -37,6 +37,7 @@ export function CreateDatabaseDialog({
 }: CreateDatabaseDialogProps) {
   const router = useRouter();
   const createMutation = useCreateDatabase(projectId);
+  const isCreating = createMutation.isPending;
   const [name, setName] = useState("");
   const [engine, setEngine] = useState<"postgres" | "mysql">("postgres");
 
@@ -64,7 +65,7 @@ export function CreateDatabaseDialog({
   }
 
   function handleOpenChange(nextOpen: boolean) {
-    if (!nextOpen && createMutation.isPending) {
+    if (!nextOpen && isCreating) {
       return;
     }
     if (!nextOpen) {
@@ -74,79 +75,89 @@ export function CreateDatabaseDialog({
     onOpenChange(nextOpen);
   }
 
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleCreate();
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Create Database</DialogTitle>
-          <DialogDescription>
-            Create a database and Frost will create the main target.
-          </DialogDescription>
-        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Database</DialogTitle>
+            <DialogDescription>
+              Create a database and Frost will create the main target.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-4 py-2">
-          <div className="space-y-2">
-            <Label htmlFor="database-name">Name</Label>
-            <Input
-              id="database-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder="app-db"
-              className="border-neutral-700 bg-neutral-800 text-neutral-100"
-              disabled={createMutation.isPending}
-            />
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="database-name">Name</Label>
+              <Input
+                id="database-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="app-db"
+                className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                disabled={isCreating}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Engine</Label>
+              <Select
+                value={engine}
+                onValueChange={(value: "postgres" | "mysql") =>
+                  setEngine(value)
+                }
+                disabled={isCreating}
+              >
+                <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-neutral-700 bg-neutral-800">
+                  <SelectItem
+                    value="postgres"
+                    className="text-neutral-100 focus:bg-neutral-700"
+                  >
+                    PostgreSQL (branch targets)
+                  </SelectItem>
+                  <SelectItem
+                    value="mysql"
+                    className="text-neutral-100 focus:bg-neutral-700"
+                  >
+                    MySQL (instance targets)
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
 
-          <div className="space-y-2">
-            <Label>Engine</Label>
-            <Select
-              value={engine}
-              onValueChange={(value: "postgres" | "mysql") => setEngine(value)}
-              disabled={createMutation.isPending}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => handleOpenChange(false)}
+              disabled={isCreating}
             >
-              <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent className="border-neutral-700 bg-neutral-800">
-                <SelectItem
-                  value="postgres"
-                  className="text-neutral-100 focus:bg-neutral-700"
-                >
-                  PostgreSQL (branch targets)
-                </SelectItem>
-                <SelectItem
-                  value="mysql"
-                  className="text-neutral-100 focus:bg-neutral-700"
-                >
-                  MySQL (instance targets)
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button
-            variant="ghost"
-            onClick={() => handleOpenChange(false)}
-            disabled={createMutation.isPending}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={handleCreate}
-            disabled={createMutation.isPending || name.trim().length === 0}
-          >
-            {createMutation.isPending ? (
-              <>
-                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                Creating...
-              </>
-            ) : (
-              "Create"
-            )}
-          </Button>
-        </DialogFooter>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isCreating || name.trim().length === 0}
+            >
+              {isCreating ? (
+                <>
+                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                "Create"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/apps/app/src/app/projects/[id]/_components/database-branch-drawer.tsx
+++ b/apps/app/src/app/projects/[id]/_components/database-branch-drawer.tsx
@@ -373,6 +373,47 @@ export function DatabaseBranchDrawer({
     void handleRunSql();
   }
 
+  async function saveSettingsWithToast(
+    input: {
+      name?: string;
+      hostname?: string;
+      memoryLimit?: string;
+      cpuLimit?: number;
+    },
+    successMessage: string,
+  ) {
+    await onSaveSettings(input);
+    toast.success(successMessage);
+  }
+
+  async function handleSaveBranchName() {
+    await saveSettingsWithToast(
+      { name: nextBranchName },
+      `${runtimeUnitCapitalized} renamed`,
+    );
+  }
+
+  async function handleSaveHostname() {
+    await saveSettingsWithToast(
+      { hostname: nextHostname },
+      `${runtimeUnitCapitalized} hostname saved`,
+    );
+  }
+
+  async function handleSaveCpuLimit() {
+    await saveSettingsWithToast(
+      { cpuLimit: nextCpuLimit ?? undefined },
+      `${runtimeUnitCapitalized} CPU limit saved`,
+    );
+  }
+
+  async function handleSaveMemoryLimit() {
+    await saveSettingsWithToast(
+      { memoryLimit: nextMemoryLimit ?? undefined },
+      `${runtimeUnitCapitalized} memory limit saved`,
+    );
+  }
+
   return (
     <>
       <SideDrawer
@@ -866,17 +907,11 @@ export function DatabaseBranchDrawer({
                           <SettingCard
                             title={`${runtimeUnitCapitalized} Name`}
                             description={`Rename this ${runtimeUnit}`}
+                            onSubmit={handleSaveBranchName}
                             footerRight={
                               <Button
                                 size="sm"
-                                onClick={async () => {
-                                  await onSaveSettings({
-                                    name: nextBranchName,
-                                  });
-                                  toast.success(
-                                    `${runtimeUnitCapitalized} renamed`,
-                                  );
-                                }}
+                                type="submit"
                                 disabled={
                                   !canRename ||
                                   !canSaveBranchName ||
@@ -914,17 +949,11 @@ export function DatabaseBranchDrawer({
                           <SettingCard
                             title="Hostname"
                             description="DNS-safe identifier for this branch in the project network."
+                            onSubmit={handleSaveHostname}
                             footerRight={
                               <Button
                                 size="sm"
-                                onClick={async () => {
-                                  await onSaveSettings({
-                                    hostname: nextHostname,
-                                  });
-                                  toast.success(
-                                    `${runtimeUnitCapitalized} hostname saved`,
-                                  );
-                                }}
+                                type="submit"
                                 disabled={
                                   !canSaveHostname || isSaveSettingsPending
                                 }
@@ -1024,17 +1053,11 @@ export function DatabaseBranchDrawer({
                             description={`Maximum CPU cores this ${runtimeUnit} can use.`}
                             learnMoreUrl="https://docs.docker.com/config/containers/resource_constraints/#cpu"
                             learnMoreText="Learn more about CPU Limit"
+                            onSubmit={handleSaveCpuLimit}
                             footerRight={
                               <Button
                                 size="sm"
-                                onClick={async () => {
-                                  await onSaveSettings({
-                                    cpuLimit: nextCpuLimit ?? undefined,
-                                  });
-                                  toast.success(
-                                    `${runtimeUnitCapitalized} CPU limit saved`,
-                                  );
-                                }}
+                                type="submit"
                                 disabled={
                                   !canSaveCpuLimit || isSaveSettingsPending
                                 }
@@ -1072,17 +1095,11 @@ export function DatabaseBranchDrawer({
                             description={`Maximum memory this ${runtimeUnit} can use.`}
                             learnMoreUrl="https://docs.docker.com/config/containers/resource_constraints/#memory"
                             learnMoreText="Learn more about Memory Limit"
+                            onSubmit={handleSaveMemoryLimit}
                             footerRight={
                               <Button
                                 size="sm"
-                                onClick={async () => {
-                                  await onSaveSettings({
-                                    memoryLimit: nextMemoryLimit ?? undefined,
-                                  });
-                                  toast.success(
-                                    `${runtimeUnitCapitalized} memory limit saved`,
-                                  );
-                                }}
+                                type="submit"
                                 disabled={
                                   !canSaveMemoryLimit || isSaveSettingsPending
                                 }

--- a/apps/app/src/app/projects/[id]/_components/database-sidebar.tsx
+++ b/apps/app/src/app/projects/[id]/_components/database-sidebar.tsx
@@ -684,6 +684,16 @@ export function DatabaseSidebar({
     }
   }
 
+  function handleAttachTargetSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleAttachTarget();
+  }
+
+  function handleCreateTargetSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleCreateTarget();
+  }
+
   async function handleResetTarget(targetId: string, sourceTargetName: string) {
     try {
       await resetTargetMutation.mutateAsync({
@@ -731,6 +741,11 @@ export function DatabaseSidebar({
     } finally {
       setIsRenameBranchPending(false);
     }
+  }
+
+  function handleRenameBranchSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleRenameBranch();
   }
 
   async function handleStartTarget(targetId: string) {
@@ -1270,80 +1285,83 @@ export function DatabaseSidebar({
                   onOpenChange={handleCreateBranchOpenChange}
                 >
                   <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-md">
-                    <DialogHeader>
-                      <DialogTitle>Create branch</DialogTitle>
-                      <DialogDescription>
-                        Create a child branch from a parent branch.
-                      </DialogDescription>
-                    </DialogHeader>
+                    <form onSubmit={handleCreateTargetSubmit}>
+                      <DialogHeader>
+                        <DialogTitle>Create branch</DialogTitle>
+                        <DialogDescription>
+                          Create a child branch from a parent branch.
+                        </DialogDescription>
+                      </DialogHeader>
 
-                    <div className="space-y-4 py-2">
-                      <div className="space-y-2">
-                        <Input
-                          id="create-branch-name"
-                          aria-label="Branch name"
-                          value={newTargetName}
-                          onChange={(event) =>
-                            setNewTargetName(event.target.value)
-                          }
-                          placeholder="feature-1"
-                          className="border-neutral-700 bg-neutral-800 text-neutral-100"
-                          disabled={createTargetMutation.isPending}
-                        />
+                      <div className="space-y-4 py-2">
+                        <div className="space-y-2">
+                          <Input
+                            id="create-branch-name"
+                            aria-label="Branch name"
+                            value={newTargetName}
+                            onChange={(event) =>
+                              setNewTargetName(event.target.value)
+                            }
+                            placeholder="feature-1"
+                            className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                            disabled={createTargetMutation.isPending}
+                          />
+                        </div>
+
+                        {parentBranchOptions.length > 0 && (
+                          <div>
+                            <Select
+                              value={parentBranchName}
+                              onValueChange={setParentBranchName}
+                              disabled={createTargetMutation.isPending}
+                            >
+                              <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent className="border-neutral-700 bg-neutral-800">
+                                {parentBranchOptions.map((branchName) => (
+                                  <SelectItem
+                                    key={branchName}
+                                    value={branchName}
+                                    className="text-neutral-100 focus:bg-neutral-700"
+                                  >
+                                    {branchName}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                        )}
                       </div>
 
-                      {parentBranchOptions.length > 0 && (
-                        <div>
-                          <Select
-                            value={parentBranchName}
-                            onValueChange={setParentBranchName}
-                            disabled={createTargetMutation.isPending}
-                          >
-                            <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent className="border-neutral-700 bg-neutral-800">
-                              {parentBranchOptions.map((branchName) => (
-                                <SelectItem
-                                  key={branchName}
-                                  value={branchName}
-                                  className="text-neutral-100 focus:bg-neutral-700"
-                                >
-                                  {branchName}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      )}
-                    </div>
-
-                    <DialogFooter>
-                      <Button
-                        variant="ghost"
-                        onClick={() => handleCreateBranchOpenChange(false)}
-                        disabled={createTargetMutation.isPending}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        onClick={handleCreateTarget}
-                        disabled={
-                          createTargetMutation.isPending ||
-                          !newTargetName.trim() ||
-                          !parentBranchName
-                        }
-                      >
-                        {createTargetMutation.isPending ? (
-                          <>
-                            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                            Creating...
-                          </>
-                        ) : (
-                          "Create"
-                        )}
-                      </Button>
-                    </DialogFooter>
+                      <DialogFooter>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => handleCreateBranchOpenChange(false)}
+                          disabled={createTargetMutation.isPending}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="submit"
+                          disabled={
+                            createTargetMutation.isPending ||
+                            !newTargetName.trim() ||
+                            !parentBranchName
+                          }
+                        >
+                          {createTargetMutation.isPending ? (
+                            <>
+                              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                              Creating...
+                            </>
+                          ) : (
+                            "Create"
+                          )}
+                        </Button>
+                      </DialogFooter>
+                    </form>
                   </DialogContent>
                 </Dialog>
 
@@ -1352,53 +1370,56 @@ export function DatabaseSidebar({
                   onOpenChange={handleRenameBranchOpenChange}
                 >
                   <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-md">
-                    <DialogHeader>
-                      <DialogTitle>Rename branch</DialogTitle>
-                      <DialogDescription>
-                        Update the branch name.
-                      </DialogDescription>
-                    </DialogHeader>
+                    <form onSubmit={handleRenameBranchSubmit}>
+                      <DialogHeader>
+                        <DialogTitle>Rename branch</DialogTitle>
+                        <DialogDescription>
+                          Update the branch name.
+                        </DialogDescription>
+                      </DialogHeader>
 
-                    <div className="py-2">
-                      <Input
-                        aria-label="Branch name"
-                        value={renameBranchName}
-                        onChange={(event) =>
-                          setRenameBranchName(event.target.value)
-                        }
-                        placeholder="new-branch-name"
-                        className="border-neutral-700 bg-neutral-800 text-neutral-100"
-                        disabled={isRenameBranchPending}
-                      />
-                    </div>
+                      <div className="py-2">
+                        <Input
+                          aria-label="Branch name"
+                          value={renameBranchName}
+                          onChange={(event) =>
+                            setRenameBranchName(event.target.value)
+                          }
+                          placeholder="new-branch-name"
+                          className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                          disabled={isRenameBranchPending}
+                        />
+                      </div>
 
-                    <DialogFooter>
-                      <Button
-                        variant="ghost"
-                        onClick={() => handleRenameBranchOpenChange(false)}
-                        disabled={isRenameBranchPending}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        onClick={handleRenameBranch}
-                        disabled={
-                          isRenameBranchPending ||
-                          !renameBranchTarget ||
-                          !renameBranchName.trim() ||
-                          renameBranchName.trim() === renameBranchTarget.name
-                        }
-                      >
-                        {isRenameBranchPending ? (
-                          <>
-                            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                            Renaming...
-                          </>
-                        ) : (
-                          "Rename"
-                        )}
-                      </Button>
-                    </DialogFooter>
+                      <DialogFooter>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => handleRenameBranchOpenChange(false)}
+                          disabled={isRenameBranchPending}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="submit"
+                          disabled={
+                            isRenameBranchPending ||
+                            !renameBranchTarget ||
+                            !renameBranchName.trim() ||
+                            renameBranchName.trim() === renameBranchTarget.name
+                          }
+                        >
+                          {isRenameBranchPending ? (
+                            <>
+                              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                              Renaming...
+                            </>
+                          ) : (
+                            "Rename"
+                          )}
+                        </Button>
+                      </DialogFooter>
+                    </form>
                   </DialogContent>
                 </Dialog>
               </div>
@@ -1406,26 +1427,32 @@ export function DatabaseSidebar({
               <div className="space-y-4">
                 <Card className="border-neutral-800 bg-neutral-900">
                   <CardContent className="space-y-3 p-4">
-                    <div className="space-y-2">
-                      <Input
-                        aria-label="Instance name"
-                        value={newTargetName}
-                        onChange={(event) =>
-                          setNewTargetName(event.target.value)
-                        }
-                        placeholder="instance-2"
-                        className="border-neutral-700 bg-neutral-800 text-neutral-100"
-                      />
-                    </div>
-
-                    <Button
-                      onClick={handleCreateTarget}
-                      disabled={
-                        createTargetMutation.isPending || !newTargetName.trim()
-                      }
+                    <form
+                      onSubmit={handleCreateTargetSubmit}
+                      className="space-y-3"
                     >
-                      Create {runtimeUnit}
-                    </Button>
+                      <div className="space-y-2">
+                        <Input
+                          aria-label="Instance name"
+                          value={newTargetName}
+                          onChange={(event) =>
+                            setNewTargetName(event.target.value)
+                          }
+                          placeholder="instance-2"
+                          className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                        />
+                      </div>
+
+                      <Button
+                        type="submit"
+                        disabled={
+                          createTargetMutation.isPending ||
+                          !newTargetName.trim()
+                        }
+                      >
+                        Create {runtimeUnit}
+                      </Button>
+                    </form>
                   </CardContent>
                 </Card>
 
@@ -1435,7 +1462,10 @@ export function DatabaseSidebar({
                       Environment {runtimeUnit}:{" "}
                       {envAttachment?.targetName ?? "not attached"}
                     </div>
-                    <div className="flex flex-col gap-2 sm:flex-row">
+                    <form
+                      onSubmit={handleAttachTargetSubmit}
+                      className="flex flex-col gap-2 sm:flex-row"
+                    >
                       <Select
                         value={selectedTargetId}
                         onValueChange={setSelectedTargetId}
@@ -1456,7 +1486,7 @@ export function DatabaseSidebar({
                         </SelectContent>
                       </Select>
                       <Button
-                        onClick={handleAttachTarget}
+                        type="submit"
                         disabled={
                           !selectedTargetId || putAttachmentMutation.isPending
                         }
@@ -1464,6 +1494,7 @@ export function DatabaseSidebar({
                         Attach
                       </Button>
                       <Button
+                        type="button"
                         variant="ghost"
                         onClick={handleDetachTarget}
                         disabled={
@@ -1472,7 +1503,7 @@ export function DatabaseSidebar({
                       >
                         Detach
                       </Button>
-                    </div>
+                    </form>
                   </CardContent>
                 </Card>
 

--- a/apps/app/src/app/projects/[id]/_components/sidebar-settings.tsx
+++ b/apps/app/src/app/projects/[id]/_components/sidebar-settings.tsx
@@ -152,13 +152,21 @@ function DatabaseBindingsCard({
     }
   }
 
+  function handleCreateBindingSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleCreateBinding();
+  }
+
   return (
     <SettingCard
       title="Database bindings"
       description="Map env var keys to project databases. Frost resolves the current environment target URL at deploy time."
     >
       <div className="space-y-3">
-        <div className="flex flex-col gap-2 md:flex-row">
+        <form
+          onSubmit={handleCreateBindingSubmit}
+          className="flex flex-col gap-2 md:flex-row"
+        >
           <Input
             value={envVarKey}
             onChange={(event) => setEnvVarKey(event.target.value)}
@@ -182,7 +190,7 @@ function DatabaseBindingsCard({
             </SelectContent>
           </Select>
           <Button
-            onClick={handleCreateBinding}
+            type="submit"
             disabled={
               !envVarKey.trim() ||
               !databaseId ||
@@ -191,7 +199,7 @@ function DatabaseBindingsCard({
           >
             Save binding
           </Button>
-        </div>
+        </form>
 
         {bindings.length === 0 ? (
           <p className="text-sm text-neutral-500">No bindings configured.</p>
@@ -207,6 +215,7 @@ function DatabaseBindingsCard({
                   {binding.databaseName} ({binding.databaseEngine})
                 </div>
                 <Button
+                  type="button"
                   variant="ghost"
                   size="sm"
                   onClick={() => handleDeleteBinding(binding.id)}
@@ -277,10 +286,11 @@ function VariablesTab({
       <SettingCard
         title="Service Environment Variables"
         description="These are specific to this service (in addition to project-level vars). The PORT variable is managed by the Container Port setting in Runtime."
+        onSubmit={handleSave}
         footerRight={
           <Button
             size="sm"
-            onClick={handleSave}
+            type="submit"
             disabled={
               updateMutation.isPending || !hasChanges || hasValidationErrors
             }

--- a/apps/app/src/app/projects/[id]/databases/[databaseId]/branches/page.tsx
+++ b/apps/app/src/app/projects/[id]/databases/[databaseId]/branches/page.tsx
@@ -170,6 +170,16 @@ export default function DatabaseBranchesPage() {
     }
   }
 
+  function handleAttachTargetSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleAttachTarget();
+  }
+
+  function handleCreateTargetSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleCreateTarget();
+  }
+
   if (!database) {
     return null;
   }
@@ -189,7 +199,10 @@ export default function DatabaseBranchesPage() {
                 ? `Current target: ${envAttachment.targetName} (${envAttachment.mode})`
                 : "No target attached for this environment"}
             </div>
-            <div className="flex flex-col gap-2 sm:flex-row">
+            <form
+              onSubmit={handleAttachTargetSubmit}
+              className="flex flex-col gap-2 sm:flex-row"
+            >
               <Select
                 value={selectedTargetId}
                 onValueChange={setSelectedTargetId}
@@ -210,19 +223,20 @@ export default function DatabaseBranchesPage() {
                 </SelectContent>
               </Select>
               <Button
-                onClick={handleAttachTarget}
+                type="submit"
                 disabled={!selectedTargetId || putAttachmentMutation.isPending}
               >
                 Attach
               </Button>
               <Button
+                type="button"
                 variant="ghost"
                 onClick={handleDetachTarget}
                 disabled={!envAttachment || deleteAttachmentMutation.isPending}
               >
                 Detach
               </Button>
-            </div>
+            </form>
           </CardContent>
         </Card>
       )}
@@ -234,49 +248,53 @@ export default function DatabaseBranchesPage() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <div className="grid gap-3 md:grid-cols-3">
-            <div className="space-y-2">
-              <Label>Name</Label>
-              <Input
-                value={newTargetName}
-                onChange={(event) => setNewTargetName(event.target.value)}
-                placeholder={database.engine === "postgres" ? "dev" : "staging"}
-                className="border-neutral-700 bg-neutral-800 text-neutral-100"
-              />
+          <form onSubmit={handleCreateTargetSubmit} className="space-y-3">
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="space-y-2">
+                <Label>Name</Label>
+                <Input
+                  value={newTargetName}
+                  onChange={(event) => setNewTargetName(event.target.value)}
+                  placeholder={
+                    database.engine === "postgres" ? "dev" : "staging"
+                  }
+                  className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                />
+              </div>
+
+              {database.engine === "postgres" && (
+                <div className="space-y-2">
+                  <Label>Source</Label>
+                  <Select
+                    value={sourceTargetName}
+                    onValueChange={setSourceTargetName}
+                  >
+                    <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-neutral-700 bg-neutral-800">
+                      {sourceOptions.map((option) => (
+                        <SelectItem
+                          key={option.id}
+                          value={option.name}
+                          className="text-neutral-100 focus:bg-neutral-700"
+                        >
+                          {option.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
             </div>
 
-            {database.engine === "postgres" && (
-              <div className="space-y-2">
-                <Label>Source</Label>
-                <Select
-                  value={sourceTargetName}
-                  onValueChange={setSourceTargetName}
-                >
-                  <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent className="border-neutral-700 bg-neutral-800">
-                    {sourceOptions.map((option) => (
-                      <SelectItem
-                        key={option.id}
-                        value={option.name}
-                        className="text-neutral-100 focus:bg-neutral-700"
-                      >
-                        {option.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </div>
-
-          <Button
-            onClick={handleCreateTarget}
-            disabled={!newTargetName.trim() || createTargetMutation.isPending}
-          >
-            Create
-          </Button>
+            <Button
+              type="submit"
+              disabled={!newTargetName.trim() || createTargetMutation.isPending}
+            >
+              Create
+            </Button>
+          </form>
         </CardContent>
       </Card>
 

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/_components/domains-section.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/_components/domains-section.tsx
@@ -198,6 +198,11 @@ export function DomainsSection({
     }
   }
 
+  function handleAddDomainSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleAddDomain();
+  }
+
   async function handleVerifyDns(id: string) {
     try {
       const result = await verifyDnsMutation.mutateAsync(id);
@@ -283,7 +288,10 @@ export function DomainsSection({
         )}
 
         {showAddForm && (
-          <div className="mb-4 rounded-md border border-neutral-800 p-4">
+          <form
+            onSubmit={handleAddDomainSubmit}
+            className="mb-4 rounded-md border border-neutral-800 p-4"
+          >
             <h3 className="text-lg font-medium text-white">Add Domain</h3>
             <p className="mt-1 text-sm text-neutral-400">
               Add a domain to connect it to this service.{" "}
@@ -377,6 +385,7 @@ export function DomainsSection({
 
             <div className="mt-4 flex items-center justify-between">
               <Button
+                type="button"
                 variant="outline"
                 size="sm"
                 onClick={() => {
@@ -391,8 +400,8 @@ export function DomainsSection({
                 Cancel
               </Button>
               <Button
+                type="submit"
                 size="sm"
-                onClick={handleAddDomain}
                 disabled={
                   addMutation.isPending ||
                   !newDomain ||
@@ -405,7 +414,7 @@ export function DomainsSection({
                 Save
               </Button>
             </div>
-          </div>
+          </form>
         )}
 
         {systemDomains.length > 0 && (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/build-config-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/build-config-card.tsx
@@ -93,10 +93,11 @@ export function BuildConfigCard({ serviceId }: BuildConfigCardProps) {
     <SettingCard
       title="Build Configuration"
       description="Git branch and Dockerfile path for building this service."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/container-port-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/container-port-card.tsx
@@ -74,6 +74,7 @@ export function ContainerPortCard({ serviceId }: ContainerPortCardProps) {
     <SettingCard
       title="Container Port"
       description="The port your application listens on inside the container."
+      onSubmit={handleSave}
       footerLeft={
         <span className="text-xs text-neutral-500">
           Also sets the PORT env var so your app knows which port to bind to.
@@ -82,7 +83,7 @@ export function ContainerPortCard({ serviceId }: ContainerPortCardProps) {
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/cpu-limit-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/cpu-limit-card.tsx
@@ -91,10 +91,11 @@ export function CpuLimitCard({ serviceId }: CpuLimitCardProps) {
       description="Maximum CPU cores the container can use. A vCPU is a logical CPU (includes hyperthreading). Limits CPU-intensive workloads from affecting other services."
       learnMoreUrl="https://docs.docker.com/config/containers/resource_constraints/#cpu"
       learnMoreText="Learn more about CPU Limit"
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/drain-timeout-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/drain-timeout-card.tsx
@@ -74,10 +74,11 @@ export function DrainTimeoutCard({ serviceId }: DrainTimeoutCardProps) {
     <SettingCard
       title="Drain Timeout"
       description="Time the old container stays alive after traffic switches to the new one. Allows in-flight requests to complete before shutdown."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/health-check-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/health-check-card.tsx
@@ -81,10 +81,11 @@ export function HealthCheckCard({ serviceId }: HealthCheckCardProps) {
       description="Frost uses health checks to determine when your container is ready to receive traffic. TCP checks port connectivity, HTTP sends a GET request to the specified path."
       learnMoreUrl="https://docs.docker.com/reference/dockerfile/#healthcheck"
       learnMoreText="Learn more about Health Checks"
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/hostname-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/hostname-card.tsx
@@ -71,10 +71,11 @@ export function HostnameCard({ serviceId }: HostnameCardProps) {
     <SettingCard
       title="Hostname"
       description="DNS-safe identifier for inter-service communication within the environment network."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/image-config-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/image-config-card.tsx
@@ -81,10 +81,11 @@ export function ImageConfigCard({ serviceId }: ImageConfigCardProps) {
     <SettingCard
       title="Image Configuration"
       description="Docker image and registry for pulling this service."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/memory-limit-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/memory-limit-card.tsx
@@ -92,10 +92,11 @@ export function MemoryLimitCard({ serviceId }: MemoryLimitCardProps) {
       description="Maximum memory the container can use. If the container exceeds this limit, it will be killed and restarted. Leave unlimited for development, set limits in production."
       learnMoreUrl="https://docs.docker.com/config/containers/resource_constraints/#memory"
       learnMoreText="Learn more about Memory Limit"
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/replica-count-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/replica-count-card.tsx
@@ -98,10 +98,11 @@ export function ReplicaCountCard({ serviceId }: ReplicaCountCardProps) {
     <SettingCard
       title="Replicas"
       description="Number of container instances to run. Traffic is load-balanced across replicas using round-robin. All replicas must pass health checks."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges || hasVolumes}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/request-timeout-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/request-timeout-card.tsx
@@ -78,10 +78,11 @@ export function RequestTimeoutCard({ serviceId }: RequestTimeoutCardProps) {
       description="Maximum time allowed for HTTP requests. If exceeded, the proxy returns a 504 Gateway Timeout. Useful for long-running operations like file uploads or report generation."
       learnMoreUrl="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504"
       learnMoreText="Learn more about Request Timeout"
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/service-name-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/service-name-card.tsx
@@ -51,10 +51,11 @@ export function ServiceNameCard({ serviceId }: ServiceNameCardProps) {
     <SettingCard
       title="Service Name"
       description="Display name for this service."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/shutdown-timeout-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/shutdown-timeout-card.tsx
@@ -75,10 +75,11 @@ export function ShutdownTimeoutCard({ serviceId }: ShutdownTimeoutCardProps) {
       description="Time between sending SIGTERM and SIGKILL when stopping the container. Allows your application to gracefully shut down connections and save state."
       learnMoreUrl="https://docs.docker.com/reference/cli/docker/container/stop/"
       learnMoreText="Learn more about Shutdown Timeout"
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/volumes-card.tsx
+++ b/apps/app/src/app/projects/[id]/services/[serviceId]/settings/_components/volumes-card.tsx
@@ -106,6 +106,7 @@ export function VolumesCard({ serviceId }: VolumesCardProps) {
     <SettingCard
       title="Volumes"
       description="Persistent storage that survives redeployments. Data is stored on the host machine."
+      onSubmit={handleSave}
       footerLeft={
         <span className="text-sm text-neutral-500">
           Adding/removing volumes requires redeploy
@@ -114,7 +115,7 @@ export function VolumesCard({ serviceId }: VolumesCardProps) {
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (
@@ -181,10 +182,16 @@ export function VolumesCard({ serviceId }: VolumesCardProps) {
                 }
               }}
             />
-            <Button size="sm" variant="secondary" onClick={handleAddVolume}>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={handleAddVolume}
+            >
               Add
             </Button>
             <Button
+              type="button"
               size="sm"
               variant="ghost"
               onClick={() => {
@@ -197,6 +204,7 @@ export function VolumesCard({ serviceId }: VolumesCardProps) {
           </div>
         ) : (
           <Button
+            type="button"
             size="sm"
             variant="secondary"
             onClick={() => setIsAdding(true)}

--- a/apps/app/src/app/projects/[id]/settings/_components/project-name-card.tsx
+++ b/apps/app/src/app/projects/[id]/settings/_components/project-name-card.tsx
@@ -48,10 +48,11 @@ export function ProjectNameCard({ projectId }: ProjectNameCardProps) {
     <SettingCard
       title="Project Name"
       description="Display name for this project."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={updateMutation.isPending || !hasChanges}
         >
           {updateMutation.isPending ? (

--- a/apps/app/src/app/projects/[id]/settings/environments/page.tsx
+++ b/apps/app/src/app/projects/[id]/settings/environments/page.tsx
@@ -81,6 +81,11 @@ export default function EnvironmentsSettingsPage() {
     updateMutation.mutate({ id: editingEnv.id, name: newName.trim() });
   }
 
+  function handleRenameSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    handleRename();
+  }
+
   function handleDelete() {
     if (!deletingEnv) return;
     deleteMutation.mutate(deletingEnv.id);
@@ -143,40 +148,46 @@ export default function EnvironmentsSettingsPage() {
               Change the display name for this environment.
             </DialogDescription>
           </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="env-name" className="text-neutral-300">
-                Name
-              </Label>
-              <Input
-                id="env-name"
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="staging"
-                autoFocus
-                className="border-neutral-700 bg-neutral-800 text-neutral-100"
-              />
+          <form onSubmit={handleRenameSubmit}>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="env-name" className="text-neutral-300">
+                  Name
+                </Label>
+                <Input
+                  id="env-name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="staging"
+                  autoFocus
+                  className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                />
+              </div>
             </div>
-          </div>
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={() => setEditingEnv(null)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleRename}
-              disabled={
-                !newName.trim() ||
-                newName === editingEnv?.name ||
-                updateMutation.isPending
-              }
-            >
-              {updateMutation.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                "Save"
-              )}
-            </Button>
-          </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setEditingEnv(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  !newName.trim() ||
+                  newName === editingEnv?.name ||
+                  updateMutation.isPending
+                }
+              >
+                {updateMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  "Save"
+                )}
+              </Button>
+            </div>
+          </form>
         </DialogContent>
       </Dialog>
 

--- a/apps/app/src/app/projects/[id]/settings/variables/page.tsx
+++ b/apps/app/src/app/projects/[id]/settings/variables/page.tsx
@@ -65,10 +65,11 @@ export default function ProjectVariablesPage() {
       description="These environment variables are inherited by all services in this project."
       learnMoreUrl="/docs/guides/env-vars"
       learnMoreText="Learn more about environment variables"
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={
             updateMutation.isPending || !hasChanges || hasValidationErrors
           }

--- a/apps/app/src/app/settings/_components/password-section.tsx
+++ b/apps/app/src/app/settings/_components/password-section.tsx
@@ -46,10 +46,11 @@ export function PasswordSection() {
     <SettingCard
       title="Password"
       description="Change your login password."
+      onSubmit={handleSave}
       footerRight={
         <Button
           size="sm"
-          onClick={handleSave}
+          type="submit"
           disabled={
             demoMode || mutation.isPending || !currentPassword || !newPassword
           }

--- a/apps/app/src/app/settings/_components/wildcard-section.tsx
+++ b/apps/app/src/app/settings/_components/wildcard-section.tsx
@@ -140,9 +140,11 @@ export function WildcardSection() {
       description="Auto-generate subdomains for services with wildcard SSL. Requires DNS provider API access for certificate verification."
       learnMoreUrl="https://caddyserver.com/docs/automatic-https#dns-challenge"
       learnMoreText="Learn more about DNS-01 challenge"
+      onSubmit={config?.configured ? undefined : handleSave}
       footer={
         config?.configured ? (
           <Button
+            type="button"
             variant="destructive"
             onClick={handleRemove}
             disabled={demoMode || saving}
@@ -151,7 +153,7 @@ export function WildcardSection() {
           </Button>
         ) : (
           <Button
-            onClick={handleSave}
+            type="submit"
             disabled={demoMode || !domain || !apiToken || saving}
           >
             {saving ? (
@@ -194,6 +196,7 @@ export function WildcardSection() {
               {settings.serverIp}
             </code>
             <Button
+              type="button"
               variant="ghost"
               size="sm"
               className="h-6 w-6 p-0"
@@ -257,6 +260,7 @@ export function WildcardSection() {
                 className="h-10 border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600 focus-visible:ring-neutral-700"
               />
               <Button
+                type="button"
                 variant="secondary"
                 onClick={handleTestToken}
                 disabled={demoMode || !apiToken || testing}

--- a/apps/app/src/app/settings/api-keys/_components/api-keys-section.tsx
+++ b/apps/app/src/app/settings/api-keys/_components/api-keys-section.tsx
@@ -49,6 +49,11 @@ export function ApiKeysSection() {
     createMutation.mutate({ name: newKeyName });
   }
 
+  function handleCreateSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleCreate();
+  }
+
   function handleDelete() {
     if (demoMode) return;
     if (!deletingKeyId) return;
@@ -182,17 +187,16 @@ export function ApiKeysSection() {
             </p>
           )}
 
-          <div className="flex gap-2">
+          <form onSubmit={handleCreateSubmit} className="flex gap-2">
             <Input
               placeholder="Key name (e.g., CI/CD)"
               value={newKeyName}
               onChange={(e) => setNewKeyName(e.target.value)}
               className="max-w-xs"
               disabled={demoMode}
-              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
             />
             <Button
-              onClick={handleCreate}
+              type="submit"
               disabled={demoMode || createMutation.isPending || !newKeyName}
             >
               {createMutation.isPending ? (
@@ -202,7 +206,7 @@ export function ApiKeysSection() {
               )}
               Create key
             </Button>
-          </div>
+          </form>
         </div>
       )}
       <ConfirmDialog

--- a/apps/app/src/app/settings/registries/_components/registries-section.tsx
+++ b/apps/app/src/app/settings/registries/_components/registries-section.tsx
@@ -111,6 +111,11 @@ export function RegistriesSection() {
     });
   }
 
+  function handleCreateSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleCreate();
+  }
+
   function handleDelete() {
     if (demoMode) return;
     if (!deletingRegistry) return;
@@ -214,7 +219,10 @@ export function RegistriesSection() {
           )}
 
           {showForm ? (
-            <div className="space-y-4 rounded-md border border-neutral-800 p-4">
+            <form
+              onSubmit={handleCreateSubmit}
+              className="space-y-4 rounded-md border border-neutral-800 p-4"
+            >
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <label
@@ -320,7 +328,7 @@ export function RegistriesSection() {
 
               <div className="flex gap-2">
                 <Button
-                  onClick={handleCreate}
+                  type="submit"
                   disabled={demoMode || createMutation.isPending}
                 >
                   {createMutation.isPending ? (
@@ -331,6 +339,7 @@ export function RegistriesSection() {
                   Add Registry
                 </Button>
                 <Button
+                  type="button"
                   variant="outline"
                   onClick={() => {
                     setShowForm(false);
@@ -340,9 +349,13 @@ export function RegistriesSection() {
                   Cancel
                 </Button>
               </div>
-            </div>
+            </form>
           ) : (
-            <Button onClick={() => setShowForm(true)} disabled={demoMode}>
+            <Button
+              type="button"
+              onClick={() => setShowForm(true)}
+              disabled={demoMode}
+            >
               <Plus className="mr-2 h-4 w-4" />
               Add Registry
             </Button>

--- a/apps/app/src/components/setting-card.tsx
+++ b/apps/app/src/components/setting-card.tsx
@@ -33,7 +33,8 @@ import { ExternalLink } from "lucide-react";
  *   description="Maximum time allowed for HTTP requests before returning 504."
  *   learnMoreUrl="https://docs.example.com/timeouts"
  *   learnMoreText="Learn more about Request Timeout"
- *   footerRight={<Button onClick={handleSave}>Save</Button>}
+ *   onSubmit={handleSave}
+ *   footerRight={<Button type="submit">Save</Button>}
  * >
  *   <Select value={timeout} onValueChange={setTimeout}>...</Select>
  * </SettingCard>
@@ -50,6 +51,7 @@ interface SettingCardProps {
   learnMoreUrl?: string;
   learnMoreText?: string;
   variant?: "default" | "danger";
+  onSubmit?: () => void | Promise<void>;
   children: React.ReactNode;
 }
 
@@ -63,17 +65,21 @@ export function SettingCard({
   learnMoreUrl,
   learnMoreText,
   variant = "default",
+  onSubmit,
   children,
 }: SettingCardProps) {
   const rightContent = footerRight ?? footer;
   const isDanger = variant === "danger";
+  const hasFooter = Boolean(footerLeft || rightContent || learnMoreUrl);
+  const className = `rounded-lg border ${isDanger ? "border-red-900/50" : "border-neutral-800"} border-t-neutral-700 bg-neutral-900 shadow-lg shadow-black/25`;
 
-  const hasFooter = footerLeft || rightContent || learnMoreUrl;
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void onSubmit?.();
+  }
 
-  return (
-    <div
-      className={`rounded-lg border ${isDanger ? "border-red-900/50" : "border-neutral-800"} border-t-neutral-700 bg-neutral-900 shadow-lg shadow-black/25`}
-    >
+  const cardContent = (
+    <>
       <div className="p-6">
         <div className="flex items-start justify-between">
           <div>
@@ -110,6 +116,16 @@ export function SettingCard({
           {rightContent && <div>{rightContent}</div>}
         </div>
       )}
-    </div>
+    </>
   );
+
+  if (onSubmit) {
+    return (
+      <form onSubmit={handleSubmit} className={className}>
+        {cardContent}
+      </form>
+    );
+  }
+
+  return <div className={className}>{cardContent}</div>;
 }


### PR DESCRIPTION
## Summary
- switch submit flows from button `onClick` to `form` `onSubmit`
- add `onSubmit` support to `SettingCard` so settings cards submit consistently
- convert related dialogs and inline create/rename forms to proper submit buttons (`type="submit"`)
- keep non-submit actions as `type="button"`
- simplify repeated save handlers in `database-branch-drawer`

## Validation
- `bunx -y @biomejs/biome check` on all changed files
- full repo `bun run typecheck` / `bun run lint` blocked in this env (toolchain/deps mismatch)
