### PR TITLE
feat(db): add real postgres branching on apfs and zfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,27 @@ jobs:
           echo "Installing from: $INSTALL_URL"
           echo "Using branch: $BRANCH"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh -b '$BRANCH' --create-api-key" 2>&1 | tee /tmp/install-output.txt
+          ssh root@${{ steps.server.outputs.ip }} "systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service >/dev/null 2>&1 || true"
 
-          API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
+          API_KEY=""
+          for attempt in 1 2 3 4; do
+            echo "Install attempt $attempt/4"
+            ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh -b '$BRANCH' --create-api-key" 2>&1 | tee /tmp/install-output.txt || true
+
+            API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
+            if [ -n "$API_KEY" ]; then
+              break
+            fi
+
+            if cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep -Eq "Could not get lock /var/lib/dpkg/lock-frontend|Unable to acquire the dpkg frontend lock|unattended-upgr"; then
+              sleep_sec=$((attempt * 10))
+              echo "dpkg lock detected, retrying in ${sleep_sec}s..."
+              sleep "$sleep_sec"
+              continue
+            fi
+
+            break
+          done
 
           if [ -z "$API_KEY" ]; then
             echo "Failed to extract API key"
@@ -476,9 +494,27 @@ jobs:
 
           echo "Installing Frost $TAG from: $INSTALL_URL"
 
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt
+          ssh root@${{ steps.server.outputs.ip }} "systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service >/dev/null 2>&1 || true"
 
-          API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
+          API_KEY=""
+          for attempt in 1 2 3 4; do
+            echo "Install attempt $attempt/4"
+            ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "curl -fsSL '$INSTALL_URL' -o /tmp/install.sh && chmod +x /tmp/install.sh && echo '${{ secrets.FROST_TEST_PASSWORD }}' | /tmp/install.sh -v '$TAG' --create-api-key" 2>&1 | tee /tmp/install-output.txt || true
+
+            API_KEY=$(cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep "API Key:" | awk '{print $3}')
+            if [ -n "$API_KEY" ]; then
+              break
+            fi
+
+            if cat /tmp/install-output.txt | sed 's/\x1b\[[0-9;]*m//g' | grep -Eq "Could not get lock /var/lib/dpkg/lock-frontend|Unable to acquire the dpkg frontend lock|unattended-upgr"; then
+              sleep_sec=$((attempt * 10))
+              echo "dpkg lock detected, retrying in ${sleep_sec}s..."
+              sleep "$sleep_sec"
+              continue
+            fi
+
+            break
+          done
 
           if [ -z "$API_KEY" ]; then
             echo "Failed to extract API key"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,68 @@ jobs:
           ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 50" || true
           exit 1
 
+      - name: Setup ZFS branching backend
+        run: |
+          ssh root@${{ steps.server.outputs.ip }} '
+            set -euo pipefail
+
+            if ! command -v zfs >/dev/null 2>&1 || ! command -v zpool >/dev/null 2>&1; then
+              apt-get update -qq
+              apt-get install -y -qq zfsutils-linux
+            fi
+
+            LOOPBACK_FILE=/opt/frost/data/zfs-loopback.img
+            POOL_NAME=frostpool
+            DATASET_BASE=frost/databases
+            MOUNT_BASE=/opt/frost/data/postgres/zfs
+
+            mkdir -p /opt/frost/data
+            mkdir -p "$MOUNT_BASE"
+
+            if [ ! -f "$LOOPBACK_FILE" ]; then
+              truncate -s 8G "$LOOPBACK_FILE"
+            fi
+
+            if ! zpool list -H -o name "$POOL_NAME" >/dev/null 2>&1; then
+              zpool create -f "$POOL_NAME" "$LOOPBACK_FILE"
+            fi
+
+            if ! zfs list -H "$POOL_NAME/$DATASET_BASE" >/dev/null 2>&1; then
+              zfs create -p "$POOL_NAME/$DATASET_BASE"
+            fi
+
+            if grep -q "^FROST_POSTGRES_ZFS_POOL=" /opt/frost/.env; then
+              sed -i "s|^FROST_POSTGRES_ZFS_POOL=.*|FROST_POSTGRES_ZFS_POOL=$POOL_NAME|" /opt/frost/.env
+            else
+              echo "FROST_POSTGRES_ZFS_POOL=$POOL_NAME" >> /opt/frost/.env
+            fi
+
+            if grep -q "^FROST_POSTGRES_ZFS_DATASET_BASE=" /opt/frost/.env; then
+              sed -i "s|^FROST_POSTGRES_ZFS_DATASET_BASE=.*|FROST_POSTGRES_ZFS_DATASET_BASE=$DATASET_BASE|" /opt/frost/.env
+            else
+              echo "FROST_POSTGRES_ZFS_DATASET_BASE=$DATASET_BASE" >> /opt/frost/.env
+            fi
+
+            if grep -q "^FROST_POSTGRES_ZFS_MOUNT_BASE=" /opt/frost/.env; then
+              sed -i "s|^FROST_POSTGRES_ZFS_MOUNT_BASE=.*|FROST_POSTGRES_ZFS_MOUNT_BASE=$MOUNT_BASE|" /opt/frost/.env
+            else
+              echo "FROST_POSTGRES_ZFS_MOUNT_BASE=$MOUNT_BASE" >> /opt/frost/.env
+            fi
+
+            systemctl restart frost
+          '
+
+          echo "Waiting for Frost after ZFS setup..."
+          for i in {1..12}; do
+            if curl -sk -o /dev/null -w "%{http_code}" "https://${{ steps.server.outputs.ip }}/api/health" | grep -q "200"; then
+              echo "Frost is ready after ZFS setup"
+              exit 0
+            fi
+            sleep 5
+          done
+          ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 80" || true
+          exit 1
+
       - name: Run E2E tests
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/apps/app/scripts/e2e/group-30-postgres-zfs-branching.sh
+++ b/apps/app/scripts/e2e/group-30-postgres-zfs-branching.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log "=== Postgres ZFS branching ==="
+
+if [ "${E2E_LOCAL:-}" = "1" ]; then
+  log "Skipping: remote Linux ZFS group"
+  pass
+  exit 0
+fi
+
+provider_ref_field() {
+  local provider_ref_json="$1"
+  local field="$2"
+  echo "$provider_ref_json" | jq -r --arg field "$field" '
+    def decode:
+      if type=="string" then (try (fromjson | decode) catch .) else . end;
+    (decode[$field] // empty)
+  '
+}
+
+run_target_sql() {
+  local target_id="$1"
+  local sql="$2"
+  local body
+  body=$(jq -nc --arg sql "$sql" '{sql: $sql}')
+  api -X POST "$BASE_URL/api/database-targets/$target_id/sql" -d "$body"
+}
+
+ZFS_POOL=$(remote '. /opt/frost/.env; echo ${FROST_POSTGRES_ZFS_POOL:-}')
+ZFS_DATASET_BASE=$(remote '. /opt/frost/.env; echo ${FROST_POSTGRES_ZFS_DATASET_BASE:-}')
+[ -z "$ZFS_POOL" ] && fail "FROST_POSTGRES_ZFS_POOL is missing"
+[ -z "$ZFS_DATASET_BASE" ] && fail "FROST_POSTGRES_ZFS_DATASET_BASE is missing"
+
+PROJECT=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-postgres-zfs-branching"}')
+PROJECT_ID=$(require_field "$PROJECT" '.id' "create project") || fail "Failed to create project: $PROJECT"
+
+DB_CREATE=$(api -X POST "$BASE_URL/api/projects/$PROJECT_ID/databases" \
+  -d '{"name":"postgreszfs","engine":"postgres"}')
+DB_ID=$(require_field "$DB_CREATE" '.database.id' "create database") || fail "Failed to create database: $DB_CREATE"
+MAIN_TARGET_ID=$(require_field "$DB_CREATE" '.target.id' "main target") || fail "Missing main target: $DB_CREATE"
+
+MAIN_RUNTIME=$(api "$BASE_URL/api/database-targets/$MAIN_TARGET_ID/runtime")
+MAIN_BACKEND=$(json_get "$MAIN_RUNTIME" '.storageBackend')
+[ "$MAIN_BACKEND" = "zfs" ] || fail "Expected zfs backend for main, got: $MAIN_BACKEND"
+
+MAIN_PROVIDER_REF_JSON=$(json_get "$DB_CREATE" '.target.providerRefJson')
+MAIN_STORAGE_BACKEND=$(provider_ref_field "$MAIN_PROVIDER_REF_JSON" "storageBackend")
+MAIN_STORAGE_REF=$(provider_ref_field "$MAIN_PROVIDER_REF_JSON" "storageRef")
+[ "$MAIN_STORAGE_BACKEND" = "zfs" ] || fail "Expected zfs provider storage backend, got: $MAIN_STORAGE_BACKEND"
+[ -z "$MAIN_STORAGE_REF" ] && fail "Missing main storageRef"
+
+run_target_sql "$MAIN_TARGET_ID" "CREATE TABLE IF NOT EXISTS frost_branch_test (id SERIAL PRIMARY KEY, value TEXT NOT NULL);" > /dev/null
+run_target_sql "$MAIN_TARGET_ID" "INSERT INTO frost_branch_test (value) VALUES ('seed');" > /dev/null
+
+BRANCH_TARGET=$(api -X POST "$BASE_URL/api/databases/$DB_ID/targets" \
+  -d '{"name":"dev","sourceTargetName":"main"}')
+BRANCH_TARGET_ID=$(require_field "$BRANCH_TARGET" '.id' "branch target") || fail "Failed to create branch: $BRANCH_TARGET"
+
+BRANCH_RUNTIME=$(api "$BASE_URL/api/database-targets/$BRANCH_TARGET_ID/runtime")
+BRANCH_BACKEND=$(json_get "$BRANCH_RUNTIME" '.storageBackend')
+[ "$BRANCH_BACKEND" = "zfs" ] || fail "Expected zfs backend for branch, got: $BRANCH_BACKEND"
+
+BRANCH_PROVIDER_REF_JSON=$(json_get "$BRANCH_TARGET" '.providerRefJson')
+BRANCH_CONTAINER_NAME=$(provider_ref_field "$BRANCH_PROVIDER_REF_JSON" "containerName")
+BRANCH_STORAGE_BACKEND=$(provider_ref_field "$BRANCH_PROVIDER_REF_JSON" "storageBackend")
+BRANCH_STORAGE_REF=$(provider_ref_field "$BRANCH_PROVIDER_REF_JSON" "storageRef")
+[ "$BRANCH_STORAGE_BACKEND" = "zfs" ] || fail "Expected zfs branch storage backend, got: $BRANCH_STORAGE_BACKEND"
+[ -z "$BRANCH_STORAGE_REF" ] && fail "Missing branch storageRef"
+[ -z "$BRANCH_CONTAINER_NAME" ] && fail "Missing branch container name"
+
+run_target_sql "$BRANCH_TARGET_ID" "INSERT INTO frost_branch_test (value) VALUES ('branch-only');" > /dev/null
+run_target_sql "$MAIN_TARGET_ID" "INSERT INTO frost_branch_test (value) VALUES ('main-only');" > /dev/null
+
+MAIN_COUNT=$(json_get "$(run_target_sql "$MAIN_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+BRANCH_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+BRANCH_HAS_MAIN_ONLY=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test WHERE value = 'main-only';")" '.rows[0][0]')
+
+[ "$MAIN_COUNT" = "2" ] || fail "Expected main count 2, got: $MAIN_COUNT"
+[ "$BRANCH_COUNT" = "2" ] || fail "Expected branch count 2, got: $BRANCH_COUNT"
+[ "$BRANCH_HAS_MAIN_ONLY" = "0" ] || fail "Branch should not include main-only row before reset"
+
+api -X POST "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID/reset" \
+  -d '{"sourceTargetName":"main"}' > /dev/null
+
+BRANCH_AFTER_RESET_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+BRANCH_HAS_MAIN_ONLY=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test WHERE value = 'main-only';")" '.rows[0][0]')
+BRANCH_HAS_BRANCH_ONLY=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test WHERE value = 'branch-only';")" '.rows[0][0]')
+
+[ "$BRANCH_AFTER_RESET_COUNT" = "2" ] || fail "Expected branch count 2 after reset, got: $BRANCH_AFTER_RESET_COUNT"
+[ "$BRANCH_HAS_MAIN_ONLY" = "1" ] || fail "Expected main-only row after reset"
+[ "$BRANCH_HAS_BRANCH_ONLY" = "0" ] || fail "branch-only row should be removed after reset"
+
+api -X POST "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID/stop" -d '{}' > /dev/null
+api -X POST "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID/start" -d '{}' > /dev/null
+
+BRANCH_AFTER_START_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+[ "$BRANCH_AFTER_START_COUNT" = "2" ] || fail "Expected branch count 2 after start, got: $BRANCH_AFTER_START_COUNT"
+
+DEPLOY_RESULT=$(api -X POST "$BASE_URL/api/database-targets/$BRANCH_TARGET_ID/deploy" -d '{}')
+DEPLOY_STATUS=$(json_get "$DEPLOY_RESULT" '.status')
+[ "$DEPLOY_STATUS" = "running" ] || fail "Expected deploy status running, got: $DEPLOY_STATUS"
+
+BRANCH_AFTER_DEPLOY_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+[ "$BRANCH_AFTER_DEPLOY_COUNT" = "2" ] || fail "Expected branch count 2 after deploy, got: $BRANCH_AFTER_DEPLOY_COUNT"
+
+api -X DELETE "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID" > /dev/null
+
+TARGETS_AFTER_DELETE=$(api "$BASE_URL/api/databases/$DB_ID/targets")
+TARGET_EXISTS=$(json_get "$TARGETS_AFTER_DELETE" '.[] | select(.id == "'"$BRANCH_TARGET_ID"'") | .id')
+[ -n "$TARGET_EXISTS" ] && fail "Branch target still exists after delete"
+
+CONTAINER_EXISTS=$(remote "docker ps -a --format '{{.Names}}' | grep -x '$BRANCH_CONTAINER_NAME' >/dev/null && echo yes || echo no")
+[ "$CONTAINER_EXISTS" = "no" ] || fail "Branch container still exists after delete"
+
+BRANCH_DATASET="$ZFS_POOL/$ZFS_DATASET_BASE/$BRANCH_STORAGE_REF"
+DATASET_EXISTS=$(remote "zfs list -H '$BRANCH_DATASET' >/dev/null 2>&1 && echo yes || echo no")
+[ "$DATASET_EXISTS" = "no" ] || fail "Branch dataset still exists after delete: $BRANCH_DATASET"
+
+api -X DELETE "$BASE_URL/api/databases/$DB_ID" > /dev/null
+api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
+
+pass

--- a/apps/app/scripts/e2e/group-31-postgres-apfs-branching.sh
+++ b/apps/app/scripts/e2e/group-31-postgres-apfs-branching.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+log "=== Postgres APFS branching ==="
+
+if [ "${E2E_LOCAL:-}" != "1" ]; then
+  log "Skipping: local macOS APFS group"
+  pass
+  exit 0
+fi
+
+if [ "$(uname)" != "Darwin" ]; then
+  log "Skipping: APFS group only runs on macOS"
+  pass
+  exit 0
+fi
+
+provider_ref_field() {
+  local provider_ref_json="$1"
+  local field="$2"
+  echo "$provider_ref_json" | jq -r --arg field "$field" '
+    def decode:
+      if type=="string" then (try (fromjson | decode) catch .) else . end;
+    (decode[$field] // empty)
+  '
+}
+
+run_target_sql() {
+  local target_id="$1"
+  local sql="$2"
+  local body
+  body=$(jq -nc --arg sql "$sql" '{sql: $sql}')
+  api -X POST "$BASE_URL/api/database-targets/$target_id/sql" -d "$body"
+}
+
+PROJECT=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-postgres-apfs-branching"}')
+PROJECT_ID=$(require_field "$PROJECT" '.id' "create project") || fail "Failed to create project: $PROJECT"
+
+DB_CREATE=$(api -X POST "$BASE_URL/api/projects/$PROJECT_ID/databases" \
+  -d '{"name":"postgresapfs","engine":"postgres"}')
+DB_ID=$(require_field "$DB_CREATE" '.database.id' "create database") || fail "Failed to create database: $DB_CREATE"
+MAIN_TARGET_ID=$(require_field "$DB_CREATE" '.target.id' "main target") || fail "Missing main target: $DB_CREATE"
+
+MAIN_RUNTIME=$(api "$BASE_URL/api/database-targets/$MAIN_TARGET_ID/runtime")
+MAIN_BACKEND=$(json_get "$MAIN_RUNTIME" '.storageBackend')
+[ "$MAIN_BACKEND" = "apfs" ] || fail "Expected apfs backend for main, got: $MAIN_BACKEND"
+
+run_target_sql "$MAIN_TARGET_ID" "CREATE TABLE IF NOT EXISTS frost_branch_test (id SERIAL PRIMARY KEY, value TEXT NOT NULL);" > /dev/null
+run_target_sql "$MAIN_TARGET_ID" "INSERT INTO frost_branch_test (value) VALUES ('seed');" > /dev/null
+
+BRANCH_TARGET=$(api -X POST "$BASE_URL/api/databases/$DB_ID/targets" \
+  -d '{"name":"dev","sourceTargetName":"main"}')
+BRANCH_TARGET_ID=$(require_field "$BRANCH_TARGET" '.id' "branch target") || fail "Failed to create branch: $BRANCH_TARGET"
+
+BRANCH_RUNTIME=$(api "$BASE_URL/api/database-targets/$BRANCH_TARGET_ID/runtime")
+BRANCH_BACKEND=$(json_get "$BRANCH_RUNTIME" '.storageBackend')
+[ "$BRANCH_BACKEND" = "apfs" ] || fail "Expected apfs backend for branch, got: $BRANCH_BACKEND"
+
+BRANCH_PROVIDER_REF_JSON=$(json_get "$BRANCH_TARGET" '.providerRefJson')
+BRANCH_CONTAINER_NAME=$(provider_ref_field "$BRANCH_PROVIDER_REF_JSON" "containerName")
+BRANCH_STORAGE_BACKEND=$(provider_ref_field "$BRANCH_PROVIDER_REF_JSON" "storageBackend")
+BRANCH_STORAGE_REF=$(provider_ref_field "$BRANCH_PROVIDER_REF_JSON" "storageRef")
+[ "$BRANCH_STORAGE_BACKEND" = "apfs" ] || fail "Expected apfs branch storage backend, got: $BRANCH_STORAGE_BACKEND"
+[ -z "$BRANCH_STORAGE_REF" ] && fail "Missing branch storageRef"
+[ -z "$BRANCH_CONTAINER_NAME" ] && fail "Missing branch container name"
+
+run_target_sql "$BRANCH_TARGET_ID" "INSERT INTO frost_branch_test (value) VALUES ('branch-only');" > /dev/null
+run_target_sql "$MAIN_TARGET_ID" "INSERT INTO frost_branch_test (value) VALUES ('main-only');" > /dev/null
+
+MAIN_COUNT=$(json_get "$(run_target_sql "$MAIN_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+BRANCH_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+BRANCH_HAS_MAIN_ONLY=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test WHERE value = 'main-only';")" '.rows[0][0]')
+
+[ "$MAIN_COUNT" = "2" ] || fail "Expected main count 2, got: $MAIN_COUNT"
+[ "$BRANCH_COUNT" = "2" ] || fail "Expected branch count 2, got: $BRANCH_COUNT"
+[ "$BRANCH_HAS_MAIN_ONLY" = "0" ] || fail "Branch should not include main-only row before reset"
+
+api -X POST "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID/reset" \
+  -d '{"sourceTargetName":"main"}' > /dev/null
+
+BRANCH_AFTER_RESET_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+BRANCH_HAS_MAIN_ONLY=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test WHERE value = 'main-only';")" '.rows[0][0]')
+BRANCH_HAS_BRANCH_ONLY=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test WHERE value = 'branch-only';")" '.rows[0][0]')
+
+[ "$BRANCH_AFTER_RESET_COUNT" = "2" ] || fail "Expected branch count 2 after reset, got: $BRANCH_AFTER_RESET_COUNT"
+[ "$BRANCH_HAS_MAIN_ONLY" = "1" ] || fail "Expected main-only row after reset"
+[ "$BRANCH_HAS_BRANCH_ONLY" = "0" ] || fail "branch-only row should be removed after reset"
+
+api -X POST "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID/stop" -d '{}' > /dev/null
+api -X POST "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID/start" -d '{}' > /dev/null
+
+BRANCH_AFTER_START_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+[ "$BRANCH_AFTER_START_COUNT" = "2" ] || fail "Expected branch count 2 after start, got: $BRANCH_AFTER_START_COUNT"
+
+DEPLOY_RESULT=$(api -X POST "$BASE_URL/api/database-targets/$BRANCH_TARGET_ID/deploy" -d '{}')
+DEPLOY_STATUS=$(json_get "$DEPLOY_RESULT" '.status')
+[ "$DEPLOY_STATUS" = "running" ] || fail "Expected deploy status running, got: $DEPLOY_STATUS"
+
+BRANCH_AFTER_DEPLOY_COUNT=$(json_get "$(run_target_sql "$BRANCH_TARGET_ID" "SELECT COUNT(*) FROM frost_branch_test;")" '.rows[0][0]')
+[ "$BRANCH_AFTER_DEPLOY_COUNT" = "2" ] || fail "Expected branch count 2 after deploy, got: $BRANCH_AFTER_DEPLOY_COUNT"
+
+APFS_BASE="${FROST_POSTGRES_APFS_BASE:-$FROST_DATA_DIR/postgres/apfs}"
+BRANCH_STORAGE_PATH="$APFS_BASE/$BRANCH_STORAGE_REF"
+
+api -X DELETE "$BASE_URL/api/databases/$DB_ID/targets/$BRANCH_TARGET_ID" > /dev/null
+
+TARGETS_AFTER_DELETE=$(api "$BASE_URL/api/databases/$DB_ID/targets")
+TARGET_EXISTS=$(json_get "$TARGETS_AFTER_DELETE" '.[] | select(.id == "'"$BRANCH_TARGET_ID"'") | .id')
+[ -n "$TARGET_EXISTS" ] && fail "Branch target still exists after delete"
+
+CONTAINER_EXISTS=$(docker ps -a --format '{{.Names}}' | grep -x "$BRANCH_CONTAINER_NAME" >/dev/null && echo yes || echo no)
+[ "$CONTAINER_EXISTS" = "no" ] || fail "Branch container still exists after delete"
+
+[ -d "$BRANCH_STORAGE_PATH" ] && fail "Branch storage path still exists after delete: $BRANCH_STORAGE_PATH"
+
+api -X DELETE "$BASE_URL/api/databases/$DB_ID" > /dev/null
+api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
+
+pass

--- a/apps/app/src/contracts/databases.ts
+++ b/apps/app/src/contracts/databases.ts
@@ -6,6 +6,7 @@ const databaseProviderSchema = z.enum(["velo", "mysql-docker"]);
 const databaseTargetKindSchema = z.enum(["branch", "instance"]);
 const databaseTargetLifecycleSchema = z.enum(["active", "stopped", "expired"]);
 const attachmentModeSchema = z.enum(["managed", "manual"]);
+const databaseStorageBackendSchema = z.enum(["apfs", "zfs"]);
 
 export const databaseSchema = z.object({
   id: z.string(),
@@ -63,6 +64,7 @@ const databaseTargetRuntimeSchema = z.object({
   hostPort: z.number(),
   image: z.string(),
   port: z.number(),
+  storageBackend: databaseStorageBackendSchema.nullable(),
   memoryLimit: z.string().nullable(),
   cpuLimit: z.number().nullable(),
   createdAt: z.number(),

--- a/apps/app/src/lib/database-runtime.ts
+++ b/apps/app/src/lib/database-runtime.ts
@@ -19,10 +19,22 @@ import {
   getAvailablePort,
   isPortConflictError,
   runContainer,
-  startContainer,
   stopContainer,
   waitForHealthy,
 } from "./docker";
+import type { BranchStorageBackendName } from "./postgres-branching/branch-storage-backend";
+import {
+  assertPostgresBranchingReady,
+  buildResetTempStorageRef,
+  checkpointPostgresTargetIfRunning,
+  clonePostgresStorageForTarget,
+  createPostgresPrimaryStorage,
+  createRollbackStack,
+  getPostgresStorageMetadata,
+  removePostgresStorage,
+  resolvePostgresStorageMountPath,
+  swapPostgresStorageFromStaged,
+} from "./postgres-branching/postgres-branch-runtime";
 import { shellEscape } from "./shell-escape";
 import { slugify } from "./slugify";
 
@@ -52,6 +64,8 @@ interface ProviderRef {
   port: number;
   memoryLimit: string | null;
   cpuLimit: number | null;
+  storageBackend?: BranchStorageBackendName;
+  storageRef?: string;
 }
 
 export interface RuntimeConnection {
@@ -77,6 +91,7 @@ export interface DatabaseTargetRuntimeInfo {
   hostPort: number;
   image: string;
   port: number;
+  storageBackend: BranchStorageBackendName | null;
   memoryLimit: string | null;
   cpuLimit: number | null;
   createdAt: number;
@@ -183,6 +198,21 @@ async function assertVeloHostReady(): Promise<void> {
 
 function parseProviderRef(json: string): ProviderRef {
   const value = JSON.parse(json) as Partial<ProviderRef>;
+  const hasStorageBackend = typeof value.storageBackend === "string";
+  const hasStorageRef = typeof value.storageRef === "string";
+
+  if (hasStorageBackend !== hasStorageRef) {
+    throw new Error("Invalid provider reference");
+  }
+
+  if (
+    hasStorageBackend &&
+    value.storageBackend !== "apfs" &&
+    value.storageBackend !== "zfs"
+  ) {
+    throw new Error("Invalid provider reference");
+  }
+
   if (
     !value ||
     typeof value.containerName !== "string" ||
@@ -208,11 +238,24 @@ function parseProviderRef(json: string): ProviderRef {
     memoryLimit:
       typeof value.memoryLimit === "string" ? value.memoryLimit : null,
     cpuLimit: typeof value.cpuLimit === "number" ? value.cpuLimit : null,
+    storageBackend: hasStorageBackend ? value.storageBackend : undefined,
+    storageRef: hasStorageRef ? value.storageRef : undefined,
   };
 }
 
 function toProviderRefJson(value: ProviderRef): string {
   return JSON.stringify(value);
+}
+
+function applyProviderRefStorage(
+  providerRef: ProviderRef,
+  storage: {
+    storageBackend: BranchStorageBackendName;
+    storageRef: string;
+  },
+): void {
+  providerRef.storageBackend = storage.storageBackend;
+  providerRef.storageRef = storage.storageRef;
 }
 
 async function recordTargetDeployment(input: {
@@ -248,22 +291,6 @@ async function recordTargetDeployment(input: {
   }
 
   return deployment;
-}
-
-async function runPostgresClone(
-  source: ProviderRef,
-  target: ProviderRef,
-): Promise<void> {
-  await waitForPostgresReady(source);
-  await waitForPostgresReady(target);
-
-  const command =
-    `docker exec ${shellEscape(source.containerName)} ` +
-    `pg_dump -h 127.0.0.1 -U ${shellEscape(source.username)} -d ${shellEscape(source.database)} ` +
-    "--clean --if-exists --no-owner --no-privileges | " +
-    `docker exec -i ${shellEscape(target.containerName)} ` +
-    `psql -v ON_ERROR_STOP=1 -h 127.0.0.1 -U ${shellEscape(target.username)} -d ${shellEscape(target.database)}`;
-  await execAsync(command);
 }
 
 async function waitForPostgresReady(providerRef: ProviderRef): Promise<void> {
@@ -388,12 +415,12 @@ async function createTargetRuntime(input: {
   engine: DatabaseEngine;
   memoryLimit?: string | null;
   cpuLimit?: number | null;
-  sourceRef?: ProviderRef;
   templateRef?: ProviderRef;
-  cloneFromSource?: boolean;
+  fixedHostPort?: number;
+  storageMountPath?: string;
 }): Promise<ProviderRef> {
-  const image = getDefaultImage(input.engine);
-  const port = getDefaultPort(input.engine);
+  const image = input.templateRef?.image ?? getDefaultImage(input.engine);
+  const port = input.templateRef?.port ?? getDefaultPort(input.engine);
   const username = input.templateRef?.username ?? "frost";
   const password = input.templateRef?.password ?? randomSecret();
   const database =
@@ -409,29 +436,40 @@ async function createTargetRuntime(input: {
     input.memoryLimit ?? input.templateRef?.memoryLimit ?? null;
   const cpuLimit = input.cpuLimit ?? input.templateRef?.cpuLimit ?? null;
   const triedPorts = new Set<number>();
+  const hostPortsToTry: number[] = [];
 
   await stopContainer(containerName);
 
-  let envVars: Record<string, string>;
-  if (input.engine === "postgres") {
-    envVars = {
-      POSTGRES_USER: username,
-      POSTGRES_PASSWORD: password,
-      POSTGRES_DB: database,
-    };
+  if (input.engine === "postgres" && !input.storageMountPath) {
+    throw new Error("Postgres target is missing storage mount path");
+  }
+
+  const envVars: Record<string, string> =
+    input.engine === "postgres"
+      ? {
+          POSTGRES_USER: username,
+          POSTGRES_PASSWORD: password,
+          POSTGRES_DB: database,
+        }
+      : {
+          MYSQL_DATABASE: database,
+          MYSQL_USER: username,
+          MYSQL_PASSWORD: password,
+          MYSQL_ROOT_PASSWORD: randomSecret(),
+        };
+
+  if (input.fixedHostPort !== undefined) {
+    hostPortsToTry.push(input.fixedHostPort);
   } else {
-    envVars = {
-      MYSQL_DATABASE: database,
-      MYSQL_USER: username,
-      MYSQL_PASSWORD: password,
-      MYSQL_ROOT_PASSWORD: randomSecret(),
-    };
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      const hostPort = await getAvailablePort(10000, 20000, triedPorts);
+      triedPorts.add(hostPort);
+      hostPortsToTry.push(hostPort);
+    }
   }
 
   let lastPortConflictError = "";
-  for (let attempt = 0; attempt < 12; attempt++) {
-    const hostPort = await getAvailablePort(10000, 20000, triedPorts);
-    triedPorts.add(hostPort);
+  for (const hostPort of hostPortsToTry) {
     const runResult = await runContainer({
       imageName: image,
       hostPort,
@@ -440,6 +478,10 @@ async function createTargetRuntime(input: {
       envVars,
       memoryLimit: memoryLimit ?? undefined,
       cpuLimit: cpuLimit ?? undefined,
+      volumes:
+        input.engine === "postgres" && input.storageMountPath
+          ? [{ name: input.storageMountPath, path: "/var/lib/postgresql/data" }]
+          : undefined,
       labels: {
         "frost.managed": "true",
         "frost.service.id": input.runtimeServiceId,
@@ -482,19 +524,6 @@ async function createTargetRuntime(input: {
       cpuLimit,
     };
 
-    if (
-      input.engine === "postgres" &&
-      input.cloneFromSource &&
-      input.sourceRef !== undefined
-    ) {
-      try {
-        await runPostgresClone(input.sourceRef, providerRef);
-      } catch (error) {
-        await stopContainer(containerName);
-        throw error;
-      }
-    }
-
     return providerRef;
   }
 
@@ -502,6 +531,37 @@ async function createTargetRuntime(input: {
     lastPortConflictError ||
       "Failed to start database target after port retries",
   );
+}
+
+async function recreateTargetRuntime(input: {
+  database: Selectable<Databases>;
+  target: Selectable<DatabaseTargets>;
+  providerRef: ProviderRef;
+}): Promise<ProviderRef> {
+  const storage =
+    input.database.engine === "postgres"
+      ? getPostgresStorageMetadata(input.providerRef)
+      : undefined;
+  const storageMountPath = storage
+    ? await resolvePostgresStorageMountPath(storage)
+    : undefined;
+
+  const nextRef = await createTargetRuntime({
+    databaseId: input.database.id,
+    databaseName: input.database.name,
+    targetName: input.target.name,
+    runtimeServiceId: input.target.runtimeServiceId,
+    engine: input.database.engine as DatabaseEngine,
+    templateRef: input.providerRef,
+    fixedHostPort: input.providerRef.hostPort,
+    storageMountPath,
+  });
+
+  if (storage) {
+    applyProviderRefStorage(nextRef, storage);
+  }
+
+  return nextRef;
 }
 
 async function resolveDatabaseWithTargetById(
@@ -707,6 +767,7 @@ export async function createDatabase(input: {
 
   if (input.engine === "postgres") {
     await assertVeloHostReady();
+    await assertPostgresBranchingReady();
   }
 
   const existing = await db
@@ -739,14 +800,50 @@ export async function createDatabase(input: {
     })
     .execute();
 
+  const rollback = createRollbackStack();
+
   try {
+    let storageMountPath: string | undefined;
+    let postgresStorageHandle:
+      | {
+          storageBackend: BranchStorageBackendName;
+          storageRef: string;
+        }
+      | undefined;
+
+    if (input.engine === "postgres") {
+      const storageHandle = await createPostgresPrimaryStorage({
+        databaseId,
+        targetId,
+      });
+      storageMountPath = storageHandle.mountPath;
+      postgresStorageHandle = {
+        storageBackend: storageHandle.storageBackend,
+        storageRef: storageHandle.storageRef,
+      };
+      rollback.add(async () => {
+        await removePostgresStorage({
+          storageBackend: storageHandle.storageBackend,
+          storageRef: storageHandle.storageRef,
+        });
+      });
+    }
+
     const providerRef = await createTargetRuntime({
       databaseId,
       databaseName: input.name,
       targetName: "main",
       runtimeServiceId,
       engine: input.engine,
+      storageMountPath,
     });
+    rollback.add(async () => {
+      await stopContainer(providerRef.containerName);
+    });
+
+    if (postgresStorageHandle) {
+      applyProviderRefStorage(providerRef, postgresStorageHandle);
+    }
 
     await db
       .insertInto("databaseTargets")
@@ -799,7 +896,10 @@ export async function createDatabase(input: {
         });
       }
     }
+
+    rollback.clear();
   } catch (error) {
+    await rollback.run();
     await db.deleteFrom("databases").where("id", "=", databaseId).execute();
     throw error;
   }
@@ -838,41 +938,89 @@ export async function createDatabaseTarget(input: {
   const createdAt = Date.now();
   const targetId = nanoid();
   const runtimeServiceId = nanoid();
-  const sourceRef = sourceTarget
-    ? parseProviderRef(sourceTarget.providerRefJson)
-    : undefined;
-  const providerRef = await createTargetRuntime({
-    databaseId: database.id,
-    databaseName: database.name,
-    targetName: input.name,
-    runtimeServiceId,
-    engine: database.engine as DatabaseEngine,
-    sourceRef,
-    cloneFromSource: database.engine === "postgres",
-  });
+  const rollback = createRollbackStack();
 
-  await db
-    .insertInto("databaseTargets")
-    .values({
-      id: targetId,
-      databaseId: database.id,
-      name: input.name,
-      hostname: input.name,
-      kind: getTargetKind(database.engine as DatabaseEngine),
-      sourceTargetId: sourceTarget?.id ?? null,
-      runtimeServiceId,
-      lifecycleStatus: "active",
-      providerRefJson: toProviderRefJson(providerRef),
-      createdAt,
-    })
-    .execute();
+  try {
+    let providerRef: ProviderRef;
 
-  await recordTargetDeployment({
-    targetId,
-    action: "create",
-    status: "running",
-    message: "Target created",
-  });
+    if (database.engine === "postgres") {
+      if (!sourceTarget) {
+        throw new Error("Source target is required for Postgres branching");
+      }
+
+      const sourceRef = parseProviderRef(sourceTarget.providerRefJson);
+      const sourceStorage = getPostgresStorageMetadata(sourceRef);
+
+      await checkpointPostgresTargetIfRunning({
+        lifecycleStatus: sourceTarget.lifecycleStatus,
+        providerRef: sourceRef,
+      });
+
+      const clonedStorage = await clonePostgresStorageForTarget({
+        sourceStorage,
+        databaseId: database.id,
+        targetId,
+      });
+
+      rollback.add(async () => {
+        await removePostgresStorage({
+          storageBackend: clonedStorage.storageBackend,
+          storageRef: clonedStorage.storageRef,
+        });
+      });
+
+      providerRef = await createTargetRuntime({
+        databaseId: database.id,
+        databaseName: database.name,
+        targetName: input.name,
+        runtimeServiceId,
+        engine: "postgres",
+        templateRef: sourceRef,
+        storageMountPath: clonedStorage.mountPath,
+      });
+      applyProviderRefStorage(providerRef, clonedStorage);
+    } else {
+      providerRef = await createTargetRuntime({
+        databaseId: database.id,
+        databaseName: database.name,
+        targetName: input.name,
+        runtimeServiceId,
+        engine: database.engine as DatabaseEngine,
+      });
+    }
+
+    rollback.add(async () => {
+      await stopContainer(providerRef.containerName);
+    });
+
+    await db
+      .insertInto("databaseTargets")
+      .values({
+        id: targetId,
+        databaseId: database.id,
+        name: input.name,
+        hostname: input.name,
+        kind: getTargetKind(database.engine as DatabaseEngine),
+        sourceTargetId: sourceTarget?.id ?? null,
+        runtimeServiceId,
+        lifecycleStatus: "active",
+        providerRefJson: toProviderRefJson(providerRef),
+        createdAt,
+      })
+      .execute();
+
+    await recordTargetDeployment({
+      targetId,
+      action: "create",
+      status: "running",
+      message: "Target created",
+    });
+
+    rollback.clear();
+  } catch (error) {
+    await rollback.run();
+    throw error;
+  }
 
   const target = await getTargetById(targetId);
   if (database.engine === "postgres") {
@@ -933,19 +1081,83 @@ export async function resetDatabaseTarget(input: {
   );
   const sourceRef = parseProviderRef(sourceTarget.providerRefJson);
   const currentRef = parseProviderRef(target.providerRefJson);
+  const sourceStorage = getPostgresStorageMetadata(sourceRef);
+  const currentStorage = getPostgresStorageMetadata(currentRef);
+  const rollback = createRollbackStack();
+
+  await checkpointPostgresTargetIfRunning({
+    lifecycleStatus: sourceTarget.lifecycleStatus,
+    providerRef: sourceRef,
+  });
+
+  const stagedStorageRef = buildResetTempStorageRef(database.id, target.id);
+  const stagedStorage = await clonePostgresStorageForTarget({
+    sourceStorage,
+    databaseId: database.id,
+    targetId: target.id,
+    targetStorageRef: stagedStorageRef,
+  });
+  const stagedStorageMetadata = {
+    storageBackend: stagedStorage.storageBackend,
+    storageRef: stagedStorage.storageRef,
+  };
+
+  rollback.add(async () => {
+    await removePostgresStorage(stagedStorageMetadata);
+  });
 
   await stopContainer(currentRef.containerName);
 
-  const nextRef = await createTargetRuntime({
-    databaseId: database.id,
-    databaseName: database.name,
-    targetName: target.name,
-    runtimeServiceId: target.runtimeServiceId,
-    engine: "postgres",
-    sourceRef,
-    templateRef: currentRef,
-    cloneFromSource: true,
-  });
+  try {
+    await swapPostgresStorageFromStaged({
+      liveStorage: currentStorage,
+      stagedStorage: stagedStorageMetadata,
+    });
+    rollback.clear();
+  } catch (error) {
+    await rollback.run();
+    throw error;
+  }
+
+  const liveMountPath = await resolvePostgresStorageMountPath(currentStorage);
+  const templateRef: ProviderRef = {
+    ...sourceRef,
+    image: currentRef.image,
+    port: currentRef.port,
+    memoryLimit: currentRef.memoryLimit,
+    cpuLimit: currentRef.cpuLimit,
+  };
+
+  let nextRef: ProviderRef;
+  try {
+    nextRef = await createTargetRuntime({
+      databaseId: database.id,
+      databaseName: database.name,
+      targetName: target.name,
+      runtimeServiceId: target.runtimeServiceId,
+      engine: "postgres",
+      templateRef,
+      fixedHostPort: currentRef.hostPort,
+      storageMountPath: liveMountPath,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Reset failed while starting";
+    await db
+      .updateTable("databaseTargets")
+      .set({ lifecycleStatus: "stopped" })
+      .where("id", "=", target.id)
+      .execute();
+    await recordTargetDeployment({
+      targetId: target.id,
+      action: "reset",
+      status: "failed",
+      message,
+    });
+    throw error;
+  }
+
+  applyProviderRefStorage(nextRef, currentStorage);
 
   await db
     .updateTable("databaseTargets")
@@ -978,21 +1190,18 @@ export async function startDatabaseTarget(input: {
     input.targetId,
   );
   const providerRef = parseProviderRef(target.providerRefJson);
-  await startContainer(providerRef.containerName);
-
-  const healthy = await waitForHealthy({
-    containerId: providerRef.containerName,
-    port: providerRef.hostPort,
-    timeoutSeconds: 60,
+  const nextRef = await recreateTargetRuntime({
+    database,
+    target,
+    providerRef,
   });
-
-  if (!healthy) {
-    throw new Error("Target failed to start");
-  }
 
   await db
     .updateTable("databaseTargets")
-    .set({ lifecycleStatus: "active" })
+    .set({
+      lifecycleStatus: "active",
+      providerRefJson: toProviderRefJson(nextRef),
+    })
     .where("id", "=", target.id)
     .execute();
 
@@ -1039,7 +1248,7 @@ export async function deleteDatabaseTarget(input: {
   databaseId: string;
   targetId: string;
 }): Promise<void> {
-  const { target } = await resolveDatabaseWithTargetById(
+  const { database, target } = await resolveDatabaseWithTargetById(
     input.databaseId,
     input.targetId,
   );
@@ -1060,6 +1269,9 @@ export async function deleteDatabaseTarget(input: {
 
   const providerRef = parseProviderRef(target.providerRefJson);
   await stopContainer(providerRef.containerName);
+  if (database.engine === "postgres") {
+    await removePostgresStorage(getPostgresStorageMetadata(providerRef));
+  }
   await db.deleteFrom("databaseTargets").where("id", "=", target.id).execute();
 }
 
@@ -1074,6 +1286,9 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
   for (const target of targets) {
     const providerRef = parseProviderRef(target.providerRefJson);
     await stopContainer(providerRef.containerName);
+    if (database.engine === "postgres") {
+      await removePostgresStorage(getPostgresStorageMetadata(providerRef));
+    }
   }
 
   await db.deleteFrom("databases").where("id", "=", database.id).execute();
@@ -1241,6 +1456,7 @@ export async function deleteEnvironmentAttachment(input: {
 
     const providerRef = parseProviderRef(target.providerRefJson);
     await stopContainer(providerRef.containerName);
+    await removePostgresStorage(getPostgresStorageMetadata(providerRef));
     await db
       .deleteFrom("databaseTargets")
       .where("id", "=", target.id)
@@ -1373,21 +1589,34 @@ export async function deployDatabaseTarget(
   targetId: string,
 ): Promise<Selectable<DatabaseTargetDeployments>> {
   const target = await getTargetById(targetId);
+  const database = await getDatabaseById(target.databaseId);
   const providerRef = parseProviderRef(target.providerRefJson);
 
   try {
-    await stopContainer(providerRef.containerName);
-  } catch {}
+    const nextRef = await recreateTargetRuntime({
+      database,
+      target,
+      providerRef,
+    });
 
-  await startContainer(providerRef.containerName);
+    await db
+      .updateTable("databaseTargets")
+      .set({
+        lifecycleStatus: "active",
+        providerRefJson: toProviderRefJson(nextRef),
+      })
+      .where("id", "=", target.id)
+      .execute();
 
-  const healthy = await waitForHealthy({
-    containerId: providerRef.containerName,
-    port: providerRef.hostPort,
-    timeoutSeconds: 60,
-  });
-
-  if (!healthy) {
+    return recordTargetDeployment({
+      targetId: target.id,
+      action: "deploy",
+      status: "running",
+      message: "Target redeployed",
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Target failed to redeploy";
     await db
       .updateTable("databaseTargets")
       .set({ lifecycleStatus: "stopped" })
@@ -1398,22 +1627,9 @@ export async function deployDatabaseTarget(
       targetId: target.id,
       action: "deploy",
       status: "failed",
-      message: "Target failed health check",
+      message,
     });
   }
-
-  await db
-    .updateTable("databaseTargets")
-    .set({ lifecycleStatus: "active" })
-    .where("id", "=", target.id)
-    .execute();
-
-  return recordTargetDeployment({
-    targetId: target.id,
-    action: "deploy",
-    status: "running",
-    message: "Target redeployed",
-  });
 }
 
 export async function getDatabaseTargetRuntime(
@@ -1432,6 +1648,7 @@ export async function getDatabaseTargetRuntime(
     hostPort: providerRef.hostPort,
     image: providerRef.image,
     port: providerRef.port,
+    storageBackend: providerRef.storageBackend ?? null,
     memoryLimit: providerRef.memoryLimit,
     cpuLimit: providerRef.cpuLimit,
     createdAt: target.createdAt,
@@ -1770,17 +1987,16 @@ export async function resolveServiceDatabaseEnvVars(input: {
       throw new Error("Failed to resolve database default target");
     }
 
-    const target = await getTargetById(attachment.targetId);
-    const providerRef = parseProviderRef(target.providerRefJson);
+    let target = await getTargetById(attachment.targetId);
 
     if (target.lifecycleStatus !== "active") {
-      await startContainer(providerRef.containerName);
-      await db
-        .updateTable("databaseTargets")
-        .set({ lifecycleStatus: "active" })
-        .where("id", "=", target.id)
-        .execute();
+      target = await startDatabaseTarget({
+        databaseId: database.id,
+        targetId: target.id,
+      });
     }
+
+    const providerRef = parseProviderRef(target.providerRefJson);
 
     if (database.engine === "postgres") {
       await ensurePostgresDatabaseNetworkAttachment({
@@ -1792,10 +2008,7 @@ export async function resolveServiceDatabaseEnvVars(input: {
       await ensureTargetNetworkAttachment({
         environment,
         database,
-        target: {
-          ...target,
-          lifecycleStatus: "active",
-        },
+        target,
       });
     }
 

--- a/apps/app/src/lib/deployer.integration.test.ts
+++ b/apps/app/src/lib/deployer.integration.test.ts
@@ -1,8 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { nanoid } from "nanoid";
-import { getSetting, setSetting } from "./auth";
 import { db } from "./db";
-import { deployService } from "./deployer";
+import {
+  deployService,
+  resetSyncCaddyConfigForTests,
+  setSyncCaddyConfigForTests,
+} from "./deployer";
 import { getContainerStatus, removeNetwork, stopContainer } from "./docker";
 
 const TEST_PROJECT_ID = `test-${nanoid(8)}`;
@@ -343,10 +346,6 @@ describe("zero-downtime deploy", () => {
       .where("serviceId", "=", ZD_SERVICE_ID)
       .execute();
 
-    const previousEmail = await getSetting("email");
-    const previousDomain = await getSetting("domain");
-    const originalFetch = globalThis.fetch;
-
     try {
       const deploy1Id = await deployService(ZD_SERVICE_ID);
       const status1 = await waitForDeploymentStatus(deploy1Id, [
@@ -361,14 +360,9 @@ describe("zero-downtime deploy", () => {
         .where("id", "=", deploy1Id)
         .executeTakeFirst();
 
-      await setSetting("email", "sync-fail@test.invalid");
-      await setSetting("domain", "frost-sync-fail.test");
-      globalThis.fetch = async function mockFetchFailure(
-        _input: Parameters<typeof fetch>[0],
-        _init?: Parameters<typeof fetch>[1],
-      ): Promise<Response> {
+      setSyncCaddyConfigForTests(async function failCaddySync() {
         throw new Error("forced-caddy-sync-failure");
-      } as typeof fetch;
+      });
 
       const deploy2Id = await deployService(ZD_SERVICE_ID);
       const status2 = await waitForDeploymentStatus(deploy2Id, [
@@ -389,9 +383,7 @@ describe("zero-downtime deploy", () => {
         expect(containerStatus).toBe("running");
       }
     } finally {
-      globalThis.fetch = originalFetch;
-      await setSetting("email", previousEmail ?? "");
-      await setSetting("domain", previousDomain ?? "");
+      resetSyncCaddyConfigForTests();
     }
   }, 180000);
 });

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -23,6 +23,7 @@ import {
   imageExists,
   isContainerNameConflictError,
   isPortConflictError,
+  isTransientContainerStartError,
   pullImage,
   type RunContainerOptions,
   runContainer,
@@ -433,7 +434,11 @@ async function releaseReplicaPortReservation(
 async function runContainerWithPortRetry(
   replicaId: string,
   options: Omit<RunContainerOptions, "hostPort">,
-  onRetry?: (port: number, attempt: number) => Promise<void>,
+  onRetry?: (input: {
+    port: number;
+    attempt: number;
+    reason: "port-conflict" | "name-conflict" | "transient";
+  }) => Promise<void>,
 ): Promise<{ containerId: string; hostPort: number }> {
   const triedPorts = new Set<number>();
 
@@ -455,19 +460,30 @@ async function runContainerWithPortRetry(
     await releaseReplicaPortReservation(replicaId, hostPort);
 
     const error = result.error || "";
-    const isRetryable =
-      isPortConflictError(error) || isContainerNameConflictError(error);
+    const isPortConflict = isPortConflictError(error);
+    const isNameConflict = isContainerNameConflictError(error);
+    const isTransient = isTransientContainerStartError(error);
+    const isRetryable = isPortConflict || isNameConflict || isTransient;
 
     if (!isRetryable) {
       throw new Error(error || "Failed to start container");
     }
 
-    if (isContainerNameConflictError(error)) {
+    if (isNameConflict) {
       await stopContainer(options.name);
     }
 
     if (onRetry) {
-      await onRetry(hostPort, attempt + 1);
+      const reason = isPortConflict
+        ? "port-conflict"
+        : isNameConflict
+          ? "name-conflict"
+          : "transient";
+      await onRetry({
+        port: hostPort,
+        attempt: attempt + 1,
+        reason,
+      });
     }
   }
 
@@ -674,10 +690,26 @@ async function startReplicas(
             cpuLimit: opts.cpuLimit,
             shutdownTimeout: opts.shutdownTimeout,
           },
-          async (port, attempt) => {
+          async ({ port, attempt, reason }) => {
+            if (reason === "port-conflict") {
+              await appendLog(
+                opts.deploymentId,
+                `Port ${port} conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
+              );
+              return;
+            }
+
+            if (reason === "name-conflict") {
+              await appendLog(
+                opts.deploymentId,
+                `Container name conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
+              );
+              return;
+            }
+
             await appendLog(
               opts.deploymentId,
-              `Port ${port} conflict, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
+              `Transient docker start error, retrying (attempt ${attempt}/${MAX_PORT_ATTEMPTS})...\n`,
             );
           },
         );

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -31,7 +31,7 @@ import {
   type VolumeMount,
   waitForHealthy,
 } from "./docker";
-import { syncCaddyConfig } from "./domains";
+import { syncCaddyConfig as syncCaddyConfigDefault } from "./domains";
 import { loadFrostConfig, mergeConfigWithService } from "./frost-config";
 import {
   createCommitStatus,
@@ -68,6 +68,18 @@ export type DeploymentStatus =
   | "cancelled";
 
 const serviceDeploymentLocks = new Map<string, Promise<void>>();
+
+let syncCaddyConfigFn = syncCaddyConfigDefault;
+
+export function setSyncCaddyConfigForTests(
+  syncFn: typeof syncCaddyConfigDefault,
+): void {
+  syncCaddyConfigFn = syncFn;
+}
+
+export function resetSyncCaddyConfigForTests(): void {
+  syncCaddyConfigFn = syncCaddyConfigDefault;
+}
 
 export async function withServiceDeploymentLock<T>(
   serviceId: string,
@@ -1517,7 +1529,7 @@ async function runServiceDeployment(
 
     try {
       await appendLog(deploymentId, "Switching traffic to new container...\n");
-      const syncResult = await syncCaddyConfig();
+      const syncResult = await syncCaddyConfigFn();
       if (syncResult.synced) {
         await appendLog(deploymentId, "Caddy config synced\n");
       }
@@ -1832,7 +1844,7 @@ async function runRollbackDeployment(
     );
 
     try {
-      const syncResult = await syncCaddyConfig();
+      const syncResult = await syncCaddyConfigFn();
       if (syncResult.synced) {
         await appendLog(deploymentId, "Caddy config synced\n");
       }

--- a/apps/app/src/lib/docker-platform.test.ts
+++ b/apps/app/src/lib/docker-platform.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   classifyPullFailure,
+  isTransientContainerStartError,
   normalizeDockerArch,
   normalizeDockerPlatform,
 } from "./docker";
@@ -36,5 +37,25 @@ describe("classifyPullFailure", () => {
 
   test("classifies image not found", () => {
     expect(classifyPullFailure("manifest unknown")).toBe("image/not-found");
+  });
+});
+
+describe("isTransientContainerStartError", () => {
+  test("detects docker daemon task create eofs", () => {
+    const message =
+      "failed to create task for container: Unavailable: error reading from server: EOF";
+    expect(isTransientContainerStartError(message)).toBe(true);
+  });
+
+  test("detects systemd message bus disconnects", () => {
+    const message =
+      "unable to start unit: Message recipient disconnected from message bus without replying";
+    expect(isTransientContainerStartError(message)).toBe(true);
+  });
+
+  test("returns false for non transient errors", () => {
+    expect(isTransientContainerStartError("invalid reference format")).toBe(
+      false,
+    );
   });
 });

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -281,6 +281,20 @@ export function classifyPullFailure(log: string, error?: string): string {
   return "unknown";
 }
 
+export function isTransientContainerStartError(error: string): boolean {
+  const full = error.toLowerCase();
+  return includesAny(full, [
+    "failed to create task for container",
+    "failed to create shim task",
+    "error reading from server: eof",
+    "message recipient disconnected from message bus without replying",
+    "connection reset by peer",
+    "transport is closing",
+    "cannot connect to the docker daemon",
+    "is the docker daemon running",
+  ]);
+}
+
 function includesAny(value: string, needles: string[]): boolean {
   for (const needle of needles) {
     if (value.includes(needle)) {

--- a/apps/app/src/lib/postgres-branching/apfs-branch-storage.test.ts
+++ b/apps/app/src/lib/postgres-branching/apfs-branch-storage.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { buildApfsCloneArgs } from "./apfs-branch-storage";
+
+describe("buildApfsCloneArgs", () => {
+  test("builds cp clone args", () => {
+    expect(buildApfsCloneArgs("/a/source", "/b/target")).toEqual([
+      "-cR",
+      "/a/source",
+      "/b/target",
+    ]);
+  });
+});

--- a/apps/app/src/lib/postgres-branching/apfs-branch-storage.ts
+++ b/apps/app/src/lib/postgres-branching/apfs-branch-storage.ts
@@ -1,0 +1,159 @@
+import { execFile } from "node:child_process";
+import { mkdir, rename, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import type {
+  BranchStorageBackend,
+  BranchStorageHandle,
+} from "./branch-storage-backend";
+
+const execFileAsync = promisify(execFile);
+
+export interface ApfsBranchStorageOptions {
+  basePath: string;
+}
+
+export function buildApfsCloneArgs(
+  sourcePath: string,
+  targetPath: string,
+): string[] {
+  return ["-cR", sourcePath, targetPath];
+}
+
+function normalizeFsType(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function parseDfDevice(dfOutput: string): string {
+  const lines = dfOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length < 2) {
+    return "";
+  }
+  const fields = lines[lines.length - 1]!.split(/\s+/);
+  return fields[0] ?? "";
+}
+
+function parseDiskutilFsType(output: string): string {
+  const bundleMatch = output.match(/Type \(Bundle\):\s*(.+)$/im);
+  if (bundleMatch?.[1]) {
+    return normalizeFsType(bundleMatch[1]);
+  }
+
+  const personalityMatch = output.match(/File System Personality:\s*(.+)$/im);
+  if (personalityMatch?.[1]) {
+    return normalizeFsType(personalityMatch[1]);
+  }
+
+  return "unknown";
+}
+
+async function detectMacFsType(path: string): Promise<string> {
+  const dfOutput = await runExecFile("df", ["-P", path]);
+  const device = parseDfDevice(dfOutput);
+  if (device.length === 0) {
+    return "unknown";
+  }
+
+  const diskutilOutput = await runExecFile("diskutil", ["info", device]);
+  return parseDiskutilFsType(diskutilOutput);
+}
+
+async function runExecFile(command: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(command, args);
+    return stdout;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${command} failed: ${message}`);
+  }
+}
+
+export class ApfsBranchStorage implements BranchStorageBackend {
+  readonly name = "apfs" as const;
+  private readonly basePath: string;
+
+  constructor(options: ApfsBranchStorageOptions) {
+    this.basePath = options.basePath;
+  }
+
+  async assertReady(): Promise<void> {
+    if (process.platform !== "darwin") {
+      throw new Error("APFS storage backend is only supported on macOS");
+    }
+
+    await mkdir(this.basePath, { recursive: true });
+    const fsType = await detectMacFsType(this.basePath);
+
+    if (!fsType.includes("apfs")) {
+      throw new Error(
+        `Postgres branching requires APFS at ${this.basePath}. Current filesystem is ${fsType || "unknown"}.`,
+      );
+    }
+  }
+
+  async createEmptyStorage(storageRef: string): Promise<BranchStorageHandle> {
+    const path = this.resolveAbsolutePath(storageRef);
+    await rm(path, { recursive: true, force: true });
+    await mkdir(path, { recursive: true });
+    return this.toHandle(storageRef);
+  }
+
+  async cloneStorage(
+    sourceStorageRef: string,
+    targetStorageRef: string,
+  ): Promise<BranchStorageHandle> {
+    const sourcePath = this.resolveAbsolutePath(sourceStorageRef);
+    const targetPath = this.resolveAbsolutePath(targetStorageRef);
+
+    await rm(targetPath, { recursive: true, force: true });
+    await mkdir(dirname(targetPath), { recursive: true });
+    await runExecFile("cp", buildApfsCloneArgs(sourcePath, targetPath));
+
+    return this.toHandle(targetStorageRef);
+  }
+
+  async swapStorage(
+    liveStorageRef: string,
+    stagedStorageRef: string,
+  ): Promise<void> {
+    const livePath = this.resolveAbsolutePath(liveStorageRef);
+    const stagedPath = this.resolveAbsolutePath(stagedStorageRef);
+    const backupPath = `${livePath}.old`;
+
+    await rm(backupPath, { recursive: true, force: true });
+    await rename(livePath, backupPath);
+
+    try {
+      await rename(stagedPath, livePath);
+    } catch (error) {
+      await rename(backupPath, livePath).catch(() => undefined);
+      throw error;
+    }
+
+    await rm(backupPath, { recursive: true, force: true });
+  }
+
+  async removeStorage(storageRef: string): Promise<void> {
+    const path = this.resolveAbsolutePath(storageRef);
+    await rm(path, { recursive: true, force: true });
+  }
+
+  async resolveMountPath(storageRef: string): Promise<string> {
+    return this.resolveAbsolutePath(storageRef);
+  }
+
+  private resolveAbsolutePath(storageRef: string): string {
+    return join(this.basePath, storageRef);
+  }
+
+  private toHandle(storageRef: string): BranchStorageHandle {
+    return {
+      storageBackend: this.name,
+      storageRef,
+      mountPath: this.resolveAbsolutePath(storageRef),
+    };
+  }
+}

--- a/apps/app/src/lib/postgres-branching/backend-factory.test.ts
+++ b/apps/app/src/lib/postgres-branching/backend-factory.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createBranchStorageBackendByName,
+  resolveApfsBasePath,
+  resolveBranchStorageBackendName,
+  resolveZfsOptions,
+} from "./backend-factory";
+
+describe("resolveBranchStorageBackendName", () => {
+  test("returns apfs on macOS", () => {
+    expect(resolveBranchStorageBackendName("darwin")).toBe("apfs");
+  });
+
+  test("returns zfs on linux", () => {
+    expect(resolveBranchStorageBackendName("linux")).toBe("zfs");
+  });
+
+  test("throws on unsupported platform", () => {
+    expect(() => resolveBranchStorageBackendName("win32")).toThrow(
+      "Postgres branching is only supported",
+    );
+  });
+});
+
+describe("resolveApfsBasePath", () => {
+  test("uses env override", () => {
+    expect(
+      resolveApfsBasePath({
+        NODE_ENV: "test",
+        FROST_POSTGRES_APFS_BASE: "/tmp/custom-apfs",
+      }),
+    ).toBe("/tmp/custom-apfs");
+  });
+});
+
+describe("resolveZfsOptions", () => {
+  test("uses defaults", () => {
+    expect(resolveZfsOptions({ NODE_ENV: "test" })).toEqual({
+      pool: "",
+      datasetBase: "frost/databases",
+      mountBase: "/opt/frost/data/postgres/zfs",
+    });
+  });
+
+  test("uses env values", () => {
+    expect(
+      resolveZfsOptions({
+        NODE_ENV: "test",
+        FROST_POSTGRES_ZFS_POOL: "tank",
+        FROST_POSTGRES_ZFS_DATASET_BASE: "frost/db",
+        FROST_POSTGRES_ZFS_MOUNT_BASE: "/data/zfs",
+      }),
+    ).toEqual({
+      pool: "tank",
+      datasetBase: "frost/db",
+      mountBase: "/data/zfs",
+    });
+  });
+});
+
+describe("createBranchStorageBackendByName", () => {
+  test("creates apfs backend", () => {
+    const backend = createBranchStorageBackendByName("apfs", {
+      NODE_ENV: "test",
+      FROST_POSTGRES_APFS_BASE: "/tmp/apfs-base",
+    });
+    expect(backend.name).toBe("apfs");
+  });
+
+  test("creates zfs backend", () => {
+    const backend = createBranchStorageBackendByName("zfs", {
+      NODE_ENV: "test",
+      FROST_POSTGRES_ZFS_POOL: "tank",
+      FROST_POSTGRES_ZFS_DATASET_BASE: "frost/db",
+      FROST_POSTGRES_ZFS_MOUNT_BASE: "/tmp/zfs",
+    });
+    expect(backend.name).toBe("zfs");
+  });
+});

--- a/apps/app/src/lib/postgres-branching/backend-factory.ts
+++ b/apps/app/src/lib/postgres-branching/backend-factory.ts
@@ -1,0 +1,69 @@
+import { join } from "node:path";
+import { getDataDir } from "../paths";
+import { ApfsBranchStorage } from "./apfs-branch-storage";
+import type {
+  BranchStorageBackend,
+  BranchStorageBackendName,
+} from "./branch-storage-backend";
+import {
+  ZfsBranchStorage,
+  type ZfsBranchStorageOptions,
+} from "./zfs-branch-storage";
+
+export function resolveBranchStorageBackendName(
+  platform: NodeJS.Platform,
+): BranchStorageBackendName {
+  if (platform === "darwin") {
+    return "apfs";
+  }
+
+  if (platform === "linux") {
+    return "zfs";
+  }
+
+  throw new Error(
+    `Postgres branching is only supported on macOS and Linux. Current platform: ${platform}`,
+  );
+}
+
+export function resolveApfsBasePath(env: NodeJS.ProcessEnv): string {
+  return env.FROST_POSTGRES_APFS_BASE ?? join(getDataDir(), "postgres", "apfs");
+}
+
+export function resolveZfsOptions(
+  env: NodeJS.ProcessEnv,
+): ZfsBranchStorageOptions {
+  return {
+    pool: env.FROST_POSTGRES_ZFS_POOL ?? "",
+    datasetBase: env.FROST_POSTGRES_ZFS_DATASET_BASE ?? "frost/databases",
+    mountBase:
+      env.FROST_POSTGRES_ZFS_MOUNT_BASE ?? "/opt/frost/data/postgres/zfs",
+  };
+}
+
+export function createBranchStorageBackendForPlatform(input: {
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+}): BranchStorageBackend {
+  const backendName = resolveBranchStorageBackendName(input.platform);
+  return createBranchStorageBackendByName(backendName, input.env);
+}
+
+export function createBranchStorageBackend(): BranchStorageBackend {
+  return createBranchStorageBackendForPlatform({
+    platform: process.platform,
+    env: process.env,
+  });
+}
+
+export function createBranchStorageBackendByName(
+  backendName: BranchStorageBackendName,
+  env: NodeJS.ProcessEnv,
+): BranchStorageBackend {
+  switch (backendName) {
+    case "apfs":
+      return new ApfsBranchStorage({ basePath: resolveApfsBasePath(env) });
+    case "zfs":
+      return new ZfsBranchStorage(resolveZfsOptions(env));
+  }
+}

--- a/apps/app/src/lib/postgres-branching/branch-storage-backend.ts
+++ b/apps/app/src/lib/postgres-branching/branch-storage-backend.ts
@@ -1,0 +1,23 @@
+export type BranchStorageBackendName = "apfs" | "zfs";
+
+export interface BranchStorageMetadata {
+  storageBackend: BranchStorageBackendName;
+  storageRef: string;
+}
+
+export interface BranchStorageHandle extends BranchStorageMetadata {
+  mountPath: string;
+}
+
+export interface BranchStorageBackend {
+  readonly name: BranchStorageBackendName;
+  assertReady(): Promise<void>;
+  createEmptyStorage(storageRef: string): Promise<BranchStorageHandle>;
+  cloneStorage(
+    sourceStorageRef: string,
+    targetStorageRef: string,
+  ): Promise<BranchStorageHandle>;
+  swapStorage(liveStorageRef: string, stagedStorageRef: string): Promise<void>;
+  removeStorage(storageRef: string): Promise<void>;
+  resolveMountPath(storageRef: string): Promise<string>;
+}

--- a/apps/app/src/lib/postgres-branching/postgres-branch-runtime.integration.test.ts
+++ b/apps/app/src/lib/postgres-branching/postgres-branch-runtime.integration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildPostgresCheckpointCommand,
+  createRollbackStack,
+} from "./postgres-branch-runtime";
+
+describe("createRollbackStack", () => {
+  test("runs rollback steps in reverse order", async () => {
+    const calls: string[] = [];
+    const rollback = createRollbackStack();
+
+    rollback.add(async () => {
+      calls.push("storage");
+    });
+    rollback.add(async () => {
+      calls.push("container");
+    });
+
+    await rollback.run();
+
+    expect(calls).toEqual(["container", "storage"]);
+  });
+
+  test("reset-like failure executes staged cleanup", async () => {
+    const calls: string[] = [];
+    const rollback = createRollbackStack();
+
+    calls.push("clone-staged");
+    rollback.add(async () => {
+      calls.push("cleanup-staged");
+    });
+
+    calls.push("stop-target");
+
+    try {
+      throw new Error("swap failed");
+    } catch {
+      await rollback.run();
+    }
+
+    expect(calls).toEqual(["clone-staged", "stop-target", "cleanup-staged"]);
+  });
+});
+
+describe("buildPostgresCheckpointCommand", () => {
+  test("builds docker exec psql checkpoint command", () => {
+    const command = buildPostgresCheckpointCommand({
+      containerName: "pg-main",
+      username: "frost",
+      password: "secret",
+      database: "frost_main",
+    });
+
+    expect(command).toContain("docker exec");
+    expect(command).toContain("CHECKPOINT;");
+    expect(command).toContain("pg-main");
+  });
+});

--- a/apps/app/src/lib/postgres-branching/postgres-branch-runtime.ts
+++ b/apps/app/src/lib/postgres-branching/postgres-branch-runtime.ts
@@ -1,0 +1,207 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { shellEscape } from "../shell-escape";
+import {
+  createBranchStorageBackend,
+  createBranchStorageBackendByName,
+} from "./backend-factory";
+import type {
+  BranchStorageBackendName,
+  BranchStorageHandle,
+  BranchStorageMetadata,
+} from "./branch-storage-backend";
+
+const execAsync = promisify(exec);
+const CHECKPOINT_MAX_ATTEMPTS = 30;
+const CHECKPOINT_RETRY_DELAY_MS = 1000;
+
+export interface PostgresProviderRefStorageLike {
+  storageBackend?: BranchStorageBackendName;
+  storageRef?: string;
+}
+
+export interface PostgresProviderRefCheckpointLike {
+  containerName: string;
+  username: string;
+  password: string;
+  database: string;
+}
+
+export interface RollbackStack {
+  add(step: () => Promise<void>): void;
+  run(): Promise<void>;
+  clear(): void;
+}
+
+export function createRollbackStack(): RollbackStack {
+  const steps: Array<() => Promise<void>> = [];
+
+  return {
+    add(step: () => Promise<void>): void {
+      steps.push(step);
+    },
+    async run(): Promise<void> {
+      for (let index = steps.length - 1; index >= 0; index -= 1) {
+        await steps[index]!().catch(() => undefined);
+      }
+      steps.length = 0;
+    },
+    clear(): void {
+      steps.length = 0;
+    },
+  };
+}
+
+export function buildLiveStorageRef(
+  databaseId: string,
+  targetId: string,
+): string {
+  return `${databaseId}/${targetId}/live`;
+}
+
+export function buildResetTempStorageRef(
+  databaseId: string,
+  targetId: string,
+): string {
+  return `${databaseId}/${targetId}/reset-temp`;
+}
+
+export function getPostgresStorageMetadata(
+  providerRef: PostgresProviderRefStorageLike,
+): BranchStorageMetadata {
+  if (!providerRef.storageBackend || !providerRef.storageRef) {
+    throw new Error(
+      "Postgres target is missing storage metadata. Recreate this target.",
+    );
+  }
+
+  return {
+    storageBackend: providerRef.storageBackend,
+    storageRef: providerRef.storageRef,
+  };
+}
+
+export function buildPostgresCheckpointCommand(
+  input: PostgresProviderRefCheckpointLike,
+): string {
+  return (
+    `docker exec -e PGPASSWORD=${shellEscape(input.password)} ${shellEscape(input.containerName)} ` +
+    `psql -X -v ON_ERROR_STOP=1 -h 127.0.0.1 -U ${shellEscape(input.username)} -d ${shellEscape(input.database)} ` +
+    "-c CHECKPOINT;"
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function shouldRetryCheckpoint(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("connection refused") ||
+    message.includes("database system is starting up")
+  );
+}
+
+export async function checkpointPostgresTargetIfRunning(input: {
+  lifecycleStatus: string;
+  providerRef: PostgresProviderRefCheckpointLike;
+}): Promise<void> {
+  if (input.lifecycleStatus !== "active") {
+    return;
+  }
+
+  const command = buildPostgresCheckpointCommand(input.providerRef);
+
+  for (let attempt = 1; attempt <= CHECKPOINT_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await execAsync(command);
+      return;
+    } catch (error) {
+      if (!shouldRetryCheckpoint(error) || attempt >= CHECKPOINT_MAX_ATTEMPTS) {
+        throw error;
+      }
+      await sleep(CHECKPOINT_RETRY_DELAY_MS);
+    }
+  }
+}
+
+async function createCheckedBackendForRuntime() {
+  const backend = createBranchStorageBackend();
+  await backend.assertReady();
+  return backend;
+}
+
+async function createCheckedBackendForStorage(
+  storageBackend: BranchStorageBackendName,
+) {
+  const backend = createBranchStorageBackendByName(storageBackend, process.env);
+  await backend.assertReady();
+  return backend;
+}
+
+export async function assertPostgresBranchingReady(): Promise<BranchStorageBackendName> {
+  const backend = await createCheckedBackendForRuntime();
+  return backend.name;
+}
+
+export async function createPostgresPrimaryStorage(input: {
+  databaseId: string;
+  targetId: string;
+}): Promise<BranchStorageHandle> {
+  const backend = await createCheckedBackendForRuntime();
+  return backend.createEmptyStorage(
+    buildLiveStorageRef(input.databaseId, input.targetId),
+  );
+}
+
+export async function clonePostgresStorageForTarget(input: {
+  sourceStorage: BranchStorageMetadata;
+  databaseId: string;
+  targetId: string;
+  targetStorageRef?: string;
+}): Promise<BranchStorageHandle> {
+  const backend = await createCheckedBackendForStorage(
+    input.sourceStorage.storageBackend,
+  );
+
+  const targetStorageRef =
+    input.targetStorageRef ??
+    buildLiveStorageRef(input.databaseId, input.targetId);
+
+  return backend.cloneStorage(input.sourceStorage.storageRef, targetStorageRef);
+}
+
+export async function swapPostgresStorageFromStaged(input: {
+  liveStorage: BranchStorageMetadata;
+  stagedStorage: BranchStorageMetadata;
+}): Promise<void> {
+  if (input.liveStorage.storageBackend !== input.stagedStorage.storageBackend) {
+    throw new Error("Postgres storage backend mismatch during reset");
+  }
+
+  const backend = await createCheckedBackendForStorage(
+    input.liveStorage.storageBackend,
+  );
+  await backend.swapStorage(
+    input.liveStorage.storageRef,
+    input.stagedStorage.storageRef,
+  );
+}
+
+export async function removePostgresStorage(
+  storage: BranchStorageMetadata,
+): Promise<void> {
+  const backend = await createCheckedBackendForStorage(storage.storageBackend);
+  await backend.removeStorage(storage.storageRef);
+}
+
+export async function resolvePostgresStorageMountPath(
+  storage: BranchStorageMetadata,
+): Promise<string> {
+  const backend = await createCheckedBackendForStorage(storage.storageBackend);
+  return backend.resolveMountPath(storage.storageRef);
+}

--- a/apps/app/src/lib/postgres-branching/zfs-branch-storage.test.ts
+++ b/apps/app/src/lib/postgres-branching/zfs-branch-storage.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildZfsCloneArgs,
+  buildZfsCreateArgs,
+  buildZfsDatasetPath,
+  buildZfsMountPath,
+  normalizeDatasetBase,
+  normalizeStorageRef,
+} from "./zfs-branch-storage";
+
+describe("normalizeDatasetBase", () => {
+  test("trims slashes", () => {
+    expect(normalizeDatasetBase("/frost/databases/")).toBe("frost/databases");
+  });
+});
+
+describe("normalizeStorageRef", () => {
+  test("trims slashes", () => {
+    expect(normalizeStorageRef("/db/target/live/")).toBe("db/target/live");
+  });
+});
+
+describe("buildZfsDatasetPath", () => {
+  test("builds dataset path", () => {
+    expect(buildZfsDatasetPath("tank", "frost/databases", "a/b/live")).toBe(
+      "tank/frost/databases/a/b/live",
+    );
+  });
+});
+
+describe("buildZfsMountPath", () => {
+  test("builds mount path", () => {
+    expect(buildZfsMountPath("/opt/frost/data/postgres/zfs", "a/b/live")).toBe(
+      "/opt/frost/data/postgres/zfs/a/b/live",
+    );
+  });
+});
+
+describe("buildZfsCreateArgs", () => {
+  test("includes tuned properties", () => {
+    expect(
+      buildZfsCreateArgs(
+        "tank/frost/databases/a/b/live",
+        "/opt/frost/data/postgres/zfs/a/b/live",
+      ),
+    ).toEqual([
+      "create",
+      "-p",
+      "-o",
+      "compression=lz4",
+      "-o",
+      "recordsize=8k",
+      "-o",
+      "atime=off",
+      "-o",
+      "mountpoint=/opt/frost/data/postgres/zfs/a/b/live",
+      "tank/frost/databases/a/b/live",
+    ]);
+  });
+});
+
+describe("buildZfsCloneArgs", () => {
+  test("includes tuned properties", () => {
+    expect(
+      buildZfsCloneArgs(
+        "tank/frost/databases/a/b/live@frost-1",
+        "tank/frost/databases/a/c/live",
+        "/opt/frost/data/postgres/zfs/a/c/live",
+      ),
+    ).toEqual([
+      "clone",
+      "-p",
+      "-o",
+      "compression=lz4",
+      "-o",
+      "recordsize=8k",
+      "-o",
+      "atime=off",
+      "-o",
+      "mountpoint=/opt/frost/data/postgres/zfs/a/c/live",
+      "tank/frost/databases/a/b/live@frost-1",
+      "tank/frost/databases/a/c/live",
+    ]);
+  });
+});

--- a/apps/app/src/lib/postgres-branching/zfs-branch-storage.ts
+++ b/apps/app/src/lib/postgres-branching/zfs-branch-storage.ts
@@ -180,14 +180,7 @@ export class ZfsBranchStorage implements BranchStorageBackend {
     await this.removeStorage(storageRef);
     await mkdir(dirname(mountPath), { recursive: true });
     await runExec("zfs", buildZfsCreateArgs(datasetPath, mountPath));
-
-    try {
-      await runExec("zfs", ["mount", datasetPath]);
-    } catch (error) {
-      if (!isAlreadyMountedError(error)) {
-        throw error;
-      }
-    }
+    await this.mountDataset(datasetPath);
 
     return this.toHandle(storageRef);
   }
@@ -220,14 +213,7 @@ export class ZfsBranchStorage implements BranchStorageBackend {
       await runExec("zfs", ["destroy", snapshotName]).catch(() => undefined);
       throw error;
     }
-
-    try {
-      await runExec("zfs", ["mount", targetDatasetPath]);
-    } catch (error) {
-      if (!isAlreadyMountedError(error)) {
-        throw error;
-      }
-    }
+    await this.mountDataset(targetDatasetPath);
 
     return this.toHandle(targetStorageRef);
   }
@@ -252,7 +238,7 @@ export class ZfsBranchStorage implements BranchStorageBackend {
         `mountpoint=${liveMountPath}`,
         liveDatasetPath,
       ]);
-      await runExec("zfs", ["mount", liveDatasetPath]);
+      await this.mountDataset(liveDatasetPath);
     } catch (error) {
       await runExec("zfs", [
         "rename",
@@ -302,6 +288,16 @@ export class ZfsBranchStorage implements BranchStorageBackend {
       await runExec("zfs", ["unmount", datasetPath]);
     } catch (error) {
       if (!isNotMountedError(error) && !isDatasetNotFound(error)) {
+        throw error;
+      }
+    }
+  }
+
+  private async mountDataset(datasetPath: string): Promise<void> {
+    try {
+      await runExec("zfs", ["mount", datasetPath]);
+    } catch (error) {
+      if (!isAlreadyMountedError(error)) {
         throw error;
       }
     }

--- a/apps/app/src/lib/postgres-branching/zfs-branch-storage.ts
+++ b/apps/app/src/lib/postgres-branching/zfs-branch-storage.ts
@@ -248,7 +248,7 @@ export class ZfsBranchStorage implements BranchStorageBackend {
       throw error;
     }
 
-    await runExec("zfs", ["destroy", "-R", backupDatasetPath]).catch(
+    await runExec("zfs", ["destroy", "-r", backupDatasetPath]).catch(
       () => undefined,
     );
   }
@@ -260,7 +260,7 @@ export class ZfsBranchStorage implements BranchStorageBackend {
     await this.unmountDataset(datasetPath);
 
     try {
-      await runExec("zfs", ["destroy", "-R", datasetPath]);
+      await runExec("zfs", ["destroy", "-r", datasetPath]);
     } catch (error) {
       if (!isDatasetNotFound(error)) {
         throw error;

--- a/apps/app/src/lib/postgres-branching/zfs-branch-storage.ts
+++ b/apps/app/src/lib/postgres-branching/zfs-branch-storage.ts
@@ -1,0 +1,332 @@
+import { execFile } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { nanoid } from "nanoid";
+import type {
+  BranchStorageBackend,
+  BranchStorageHandle,
+} from "./branch-storage-backend";
+
+const execFileAsync = promisify(execFile);
+
+export interface ZfsBranchStorageOptions {
+  pool: string;
+  datasetBase: string;
+  mountBase: string;
+}
+
+export function normalizeDatasetBase(datasetBase: string): string {
+  return datasetBase.replace(/^\/+|\/+$/g, "");
+}
+
+export function normalizeStorageRef(storageRef: string): string {
+  return storageRef.replace(/^\/+|\/+$/g, "");
+}
+
+export function buildZfsDatasetPath(
+  pool: string,
+  datasetBase: string,
+  storageRef: string,
+): string {
+  const normalizedBase = normalizeDatasetBase(datasetBase);
+  const normalizedStorageRef = normalizeStorageRef(storageRef);
+  if (normalizedBase.length === 0) {
+    return `${pool}/${normalizedStorageRef}`;
+  }
+  return `${pool}/${normalizedBase}/${normalizedStorageRef}`;
+}
+
+export function buildZfsMountPath(
+  mountBase: string,
+  storageRef: string,
+): string {
+  return join(mountBase, normalizeStorageRef(storageRef));
+}
+
+export function buildZfsCreateArgs(
+  datasetPath: string,
+  mountPath: string,
+): string[] {
+  return [
+    "create",
+    "-p",
+    "-o",
+    "compression=lz4",
+    "-o",
+    "recordsize=8k",
+    "-o",
+    "atime=off",
+    "-o",
+    `mountpoint=${mountPath}`,
+    datasetPath,
+  ];
+}
+
+export function buildZfsCloneArgs(
+  snapshotName: string,
+  targetDatasetPath: string,
+  mountPath: string,
+): string[] {
+  return [
+    "clone",
+    "-p",
+    "-o",
+    "compression=lz4",
+    "-o",
+    "recordsize=8k",
+    "-o",
+    "atime=off",
+    "-o",
+    `mountpoint=${mountPath}`,
+    snapshotName,
+    targetDatasetPath,
+  ];
+}
+
+function formatExecError(command: string, error: unknown): string {
+  if (!error || typeof error !== "object") {
+    return `${command} failed`;
+  }
+
+  const maybeError = error as {
+    message?: string;
+    stderr?: string;
+    stdout?: string;
+  };
+
+  const detail = [maybeError.stderr, maybeError.stdout, maybeError.message]
+    .filter((value) => typeof value === "string" && value.trim().length > 0)
+    .join("\n")
+    .trim();
+
+  if (detail.length === 0) {
+    return `${command} failed`;
+  }
+
+  return `${command} failed: ${detail}`;
+}
+
+function isDatasetNotFound(error: unknown): boolean {
+  const message = formatExecError("zfs", error).toLowerCase();
+  return (
+    message.includes("dataset does not exist") ||
+    message.includes("no such pool")
+  );
+}
+
+function isAlreadyMountedError(error: unknown): boolean {
+  const message = formatExecError("zfs", error).toLowerCase();
+  return message.includes("already mounted");
+}
+
+function isNotMountedError(error: unknown): boolean {
+  const message = formatExecError("zfs", error).toLowerCase();
+  return (
+    message.includes("not currently mounted") || message.includes("not mounted")
+  );
+}
+
+async function runExec(command: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(command, args);
+    return stdout;
+  } catch (error) {
+    throw new Error(formatExecError(command, error));
+  }
+}
+
+export class ZfsBranchStorage implements BranchStorageBackend {
+  readonly name = "zfs" as const;
+  private readonly pool: string;
+  private readonly datasetBase: string;
+  private readonly mountBase: string;
+
+  constructor(options: ZfsBranchStorageOptions) {
+    this.pool = options.pool.trim();
+    this.datasetBase = normalizeDatasetBase(options.datasetBase);
+    this.mountBase = options.mountBase;
+  }
+
+  async assertReady(): Promise<void> {
+    if (process.platform !== "linux") {
+      throw new Error("ZFS storage backend is only supported on Linux");
+    }
+
+    if (this.pool.length === 0) {
+      throw new Error(
+        "Postgres branching needs FROST_POSTGRES_ZFS_POOL configured. Run install.sh or update.sh and set the pool in /opt/frost/.env.",
+      );
+    }
+
+    await mkdir(this.mountBase, { recursive: true });
+
+    await runExec("zfs", ["list", "-H"]);
+    await runExec("zpool", ["list", "-H", "-o", "name", this.pool]);
+
+    const baseDataset = this.getBaseDatasetPath();
+    const exists = await this.datasetExistsByPath(baseDataset);
+    if (!exists) {
+      throw new Error(
+        `Missing ZFS dataset ${baseDataset}. Run install.sh or update.sh to prepare ZFS for Postgres branching.`,
+      );
+    }
+  }
+
+  async createEmptyStorage(storageRef: string): Promise<BranchStorageHandle> {
+    const datasetPath = this.getDatasetPath(storageRef);
+    const mountPath = this.getMountPath(storageRef);
+
+    await this.removeStorage(storageRef);
+    await mkdir(dirname(mountPath), { recursive: true });
+    await runExec("zfs", buildZfsCreateArgs(datasetPath, mountPath));
+
+    try {
+      await runExec("zfs", ["mount", datasetPath]);
+    } catch (error) {
+      if (!isAlreadyMountedError(error)) {
+        throw error;
+      }
+    }
+
+    return this.toHandle(storageRef);
+  }
+
+  async cloneStorage(
+    sourceStorageRef: string,
+    targetStorageRef: string,
+  ): Promise<BranchStorageHandle> {
+    const sourceDatasetPath = this.getDatasetPath(sourceStorageRef);
+    const targetDatasetPath = this.getDatasetPath(targetStorageRef);
+    const targetMountPath = this.getMountPath(targetStorageRef);
+
+    const sourceExists = await this.datasetExistsByPath(sourceDatasetPath);
+    if (!sourceExists) {
+      throw new Error(`Source ZFS dataset not found: ${sourceDatasetPath}`);
+    }
+
+    await this.removeStorage(targetStorageRef);
+    await mkdir(dirname(targetMountPath), { recursive: true });
+
+    const snapshotName = `${sourceDatasetPath}@frost-${Date.now()}-${nanoid(6).toLowerCase()}`;
+    await runExec("zfs", ["snapshot", snapshotName]);
+
+    try {
+      await runExec(
+        "zfs",
+        buildZfsCloneArgs(snapshotName, targetDatasetPath, targetMountPath),
+      );
+    } catch (error) {
+      await runExec("zfs", ["destroy", snapshotName]).catch(() => undefined);
+      throw error;
+    }
+
+    try {
+      await runExec("zfs", ["mount", targetDatasetPath]);
+    } catch (error) {
+      if (!isAlreadyMountedError(error)) {
+        throw error;
+      }
+    }
+
+    return this.toHandle(targetStorageRef);
+  }
+
+  async swapStorage(
+    liveStorageRef: string,
+    stagedStorageRef: string,
+  ): Promise<void> {
+    const liveDatasetPath = this.getDatasetPath(liveStorageRef);
+    const stagedDatasetPath = this.getDatasetPath(stagedStorageRef);
+    const backupDatasetPath = `${liveDatasetPath}-old-${Date.now()}`;
+    const liveMountPath = this.getMountPath(liveStorageRef);
+
+    await this.unmountDataset(liveDatasetPath);
+    await this.unmountDataset(stagedDatasetPath);
+    await runExec("zfs", ["rename", liveDatasetPath, backupDatasetPath]);
+
+    try {
+      await runExec("zfs", ["rename", stagedDatasetPath, liveDatasetPath]);
+      await runExec("zfs", [
+        "set",
+        `mountpoint=${liveMountPath}`,
+        liveDatasetPath,
+      ]);
+      await runExec("zfs", ["mount", liveDatasetPath]);
+    } catch (error) {
+      await runExec("zfs", [
+        "rename",
+        backupDatasetPath,
+        liveDatasetPath,
+      ]).catch(() => undefined);
+      throw error;
+    }
+
+    await runExec("zfs", ["destroy", "-R", backupDatasetPath]).catch(
+      () => undefined,
+    );
+  }
+
+  async removeStorage(storageRef: string): Promise<void> {
+    const datasetPath = this.getDatasetPath(storageRef);
+    const mountPath = this.getMountPath(storageRef);
+
+    await this.unmountDataset(datasetPath);
+
+    try {
+      await runExec("zfs", ["destroy", "-R", datasetPath]);
+    } catch (error) {
+      if (!isDatasetNotFound(error)) {
+        throw error;
+      }
+    }
+
+    await rm(mountPath, { recursive: true, force: true });
+  }
+
+  async resolveMountPath(storageRef: string): Promise<string> {
+    return this.getMountPath(storageRef);
+  }
+
+  private async datasetExistsByPath(datasetPath: string): Promise<boolean> {
+    try {
+      await runExec("zfs", ["list", "-H", datasetPath]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async unmountDataset(datasetPath: string): Promise<void> {
+    try {
+      await runExec("zfs", ["unmount", datasetPath]);
+    } catch (error) {
+      if (!isNotMountedError(error) && !isDatasetNotFound(error)) {
+        throw error;
+      }
+    }
+  }
+
+  private getBaseDatasetPath(): string {
+    if (this.datasetBase.length === 0) {
+      return this.pool;
+    }
+    return `${this.pool}/${this.datasetBase}`;
+  }
+
+  private getDatasetPath(storageRef: string): string {
+    return buildZfsDatasetPath(this.pool, this.datasetBase, storageRef);
+  }
+
+  private getMountPath(storageRef: string): string {
+    return buildZfsMountPath(this.mountBase, storageRef);
+  }
+
+  private toHandle(storageRef: string): BranchStorageHandle {
+    return {
+      storageBackend: this.name,
+      storageRef,
+      mountPath: this.getMountPath(storageRef),
+    };
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,12 @@ else
   timer "Build tools already installed"
 fi
 
+if ! command -v zfs &> /dev/null || ! command -v zpool &> /dev/null; then
+  timer "Installing zfsutils-linux..."
+  apt-get update -qq
+  apt-get install -y -qq zfsutils-linux > /dev/null || true
+fi
+
 # Install Docker if not present
 if ! command -v docker &> /dev/null; then
   timer "Installing Docker..."
@@ -194,6 +200,21 @@ get_public_ipv4() {
   return 1
 }
 
+detect_single_zfs_pool() {
+  if ! command -v zpool &> /dev/null; then
+    return 0
+  fi
+
+  local pools
+  local count
+  pools=$(zpool list -H -o name 2>/dev/null | awk 'NF {print}')
+  count=$(echo "$pools" | awk 'NF {c++} END {print c+0}')
+
+  if [ "$count" -eq 1 ]; then
+    echo "$pools"
+  fi
+}
+
 SERVER_IP=$(get_public_ipv4 || true)
 if ! is_valid_ipv4 "$SERVER_IP"; then
   SERVER_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '/src/ {print $7; exit}')
@@ -295,11 +316,24 @@ fi
 
 # Create data directory
 mkdir -p "$FROST_DIR/data"
+ZFS_POOL=$(detect_single_zfs_pool || true)
+ZFS_DATASET_BASE="frost/databases"
+ZFS_MOUNT_BASE="/opt/frost/data/postgres/zfs"
+
+mkdir -p "$ZFS_MOUNT_BASE"
+if [ -n "$ZFS_POOL" ] && command -v zfs &> /dev/null && command -v zpool &> /dev/null; then
+  if zpool list -H -o name "$ZFS_POOL" > /dev/null 2>&1; then
+    zfs list -H "$ZFS_POOL/$ZFS_DATASET_BASE" > /dev/null 2>&1 || zfs create -p "$ZFS_POOL/$ZFS_DATASET_BASE" > /dev/null 2>&1 || true
+  fi
+fi
 
 # Create .env file
 cat > "$FROST_DIR/.env" << EOF
 FROST_JWT_SECRET=$FROST_JWT_SECRET
 FROST_DATA_DIR=$FROST_DIR/data
+FROST_POSTGRES_ZFS_POOL=$ZFS_POOL
+FROST_POSTGRES_ZFS_DATASET_BASE=$ZFS_DATASET_BASE
+FROST_POSTGRES_ZFS_MOUNT_BASE=$ZFS_MOUNT_BASE
 NODE_ENV=production
 EOF
 

--- a/update.sh
+++ b/update.sh
@@ -33,6 +33,91 @@ success() {
   echo -e "${GREEN}$1${NC}"
 }
 
+get_env_value() {
+  local file="$1"
+  local key="$2"
+  if [ ! -f "$file" ]; then
+    return 0
+  fi
+  local line
+  line=$(grep -E "^${key}=" "$file" | tail -n 1 || true)
+  if [ -z "$line" ]; then
+    return 0
+  fi
+  echo "${line#*=}"
+}
+
+ensure_env_value() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  if [ ! -f "$file" ]; then
+    touch "$file"
+  fi
+  if grep -qE "^${key}=" "$file"; then
+    return 0
+  fi
+  echo "${key}=${value}" >> "$file"
+}
+
+detect_single_zfs_pool() {
+  if ! command -v zpool > /dev/null 2>&1; then
+    return 0
+  fi
+  local pools
+  local count
+  pools=$(zpool list -H -o name 2>/dev/null | awk 'NF {print}')
+  count=$(echo "$pools" | awk 'NF {c++} END {print c+0}')
+  if [ "$count" -eq 1 ]; then
+    echo "$pools"
+  fi
+}
+
+ensure_zfs_branching_setup() {
+  if ! command -v zfs > /dev/null 2>&1 || ! command -v zpool > /dev/null 2>&1; then
+    log "Installing zfsutils-linux..."
+    apt-get update -qq || true
+    apt-get install -y -qq zfsutils-linux > /dev/null || true
+  fi
+
+  local env_file="$FROST_DIR/.env"
+  local detected_pool
+  local pool
+  local dataset_base
+  local mount_base
+  local base_dataset
+
+  detected_pool=$(detect_single_zfs_pool || true)
+  pool=$(get_env_value "$env_file" "FROST_POSTGRES_ZFS_POOL")
+  if [ -z "$pool" ]; then
+    pool="$detected_pool"
+  fi
+
+  ensure_env_value "$env_file" "FROST_POSTGRES_ZFS_POOL" "$pool"
+  ensure_env_value "$env_file" "FROST_POSTGRES_ZFS_DATASET_BASE" "frost/databases"
+  ensure_env_value "$env_file" "FROST_POSTGRES_ZFS_MOUNT_BASE" "/opt/frost/data/postgres/zfs"
+
+  dataset_base=$(get_env_value "$env_file" "FROST_POSTGRES_ZFS_DATASET_BASE")
+  mount_base=$(get_env_value "$env_file" "FROST_POSTGRES_ZFS_MOUNT_BASE")
+
+  if [ -n "$mount_base" ]; then
+    mkdir -p "$mount_base"
+  fi
+
+  if [ -z "$pool" ] || ! command -v zfs > /dev/null 2>&1 || ! command -v zpool > /dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! zpool list -H -o name "$pool" > /dev/null 2>&1; then
+    return 0
+  fi
+
+  base_dataset="$pool/$dataset_base"
+  if ! zfs list -H "$base_dataset" > /dev/null 2>&1; then
+    zfs create -p "$base_dataset" > /dev/null 2>&1 || true
+  fi
+}
+
 cleanup_on_failure() {
   error "Update failed!"
   echo "failed" > "$UPDATE_RESULT"
@@ -98,6 +183,8 @@ fi
 if [ -d "$FROST_DIR/apps/app" ] && [ ! -L "$FROST_DIR/apps/app/.env" ]; then
   ln -sf "$FROST_DIR/.env" "$FROST_DIR/apps/app/.env"
 fi
+
+ensure_zfs_branching_setup
 
 # Ensure bun is in PATH
 export HOME="${HOME:-/root}"


### PR DESCRIPTION
## Summary
- implement real postgres branching with copy-on-write storage backends
- use APFS clone on macOS and ZFS snapshot+clone on Linux
- replace pg_dump/psql branch create+reset path with storage clone+swap runtime flow
- fix target lifecycle behavior so stop removes container and start/deploy recreates from persisted storage
- add installer/updater ZFS setup defaults and CI ZFS loopback preparation
- add dedicated branching e2e groups for Linux ZFS and local macOS APFS

## Internal Changes
- add `postgres-branching` backend abstraction + factory + runtime helpers
- persist storage metadata in `providerRefJson` (`storageBackend`, `storageRef`)
- expose `storageBackend` in target runtime response
- add rollback stack and checkpoint retry for branch create/reset safety

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun --cwd apps/app test src/lib/postgres-branching/backend-factory.test.ts src/lib/postgres-branching/apfs-branch-storage.test.ts src/lib/postgres-branching/zfs-branch-storage.test.ts src/lib/postgres-branching/postgres-branch-runtime.integration.test.ts`
- `E2E_GROUPS='07-database,31-postgres-apfs-branching' E2E_BATCH_SIZE=1 E2E_START_STAGGER_SEC=0 bun run e2e:local` (run twice, both green)
