### PR TITLE
fix(env): prefer lts node for local setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -6,6 +6,15 @@ name = "frost"
 script = '''
 set -euo pipefail
 
+if command -v brew >/dev/null 2>&1; then
+  for node_formula in node@24 node@22 node@20; do
+    if node_prefix="$(brew --prefix "$node_formula" 2>/dev/null)"; then
+      export PATH="$node_prefix/bin:$PATH"
+      break
+    fi
+  done
+fi
+
 source_repo="$(cd "$(git rev-parse --git-common-dir)/.." && pwd -P)"
 git -C "$source_repo" fetch origin main
 


### PR DESCRIPTION
## Summary
- prefer Homebrew LTS Node before global Node during Codex local environment setup
- avoids native dependency builds picking unsupported Node 26

## Verification
- ran the environment setup script manually
- confirmed it selected node@24 and completed bun install
- confirmed better-sqlite3 loads under Node 24