### PR TITLE
fix(ci): cap e2e server placement retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,11 @@ jobs:
 
       - name: Create server from snapshot
         id: server
+        timeout-minutes: 10
         run: |
           echo "Creating server from snapshot..."
-          DELAYS=(30 60 120 240 600 1200)
-          MAX_ATTEMPTS=${#DELAYS[@]}
+          MAX_ATTEMPTS=5
+          DELAYS=(30 60 120 240)
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "Attempt $attempt/$MAX_ATTEMPTS..."
@@ -417,10 +418,11 @@ jobs:
       - name: Create server from snapshot
         if: steps.release.outputs.skip != 'true'
         id: server
+        timeout-minutes: 10
         run: |
           echo "Creating server from snapshot..."
-          DELAYS=(30 60 120 240 600 1200)
-          MAX_ATTEMPTS=${#DELAYS[@]}
+          MAX_ATTEMPTS=5
+          DELAYS=(30 60 120 240)
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "Attempt $attempt/$MAX_ATTEMPTS..."


### PR DESCRIPTION
## Summary
- cap Hetzner snapshot server creation at 5 attempts in both VPS and upgrade E2E jobs
- add a 10-minute step timeout to prevent long placement stalls on both amd64 and arm64

## Context
The post-merge main run for #386 was green on fast checks and amd64 E2E, but both arm64 jobs failed before Frost installed because Hetzner returned resource_unavailable / error during placement for every server creation attempt. A failed-job rerun repeated the same placement-only failure.

The create-server step is shared by the architecture matrix, so this cap applies to amd64 and arm64 for both e2e-vps and e2e-upgrade.

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'

No old queued or in-progress GitHub Actions runs remained to cancel when checked.