### PR TITLE
fix(templates): correct minio startup command

### DIFF
--- a/apps/app/src/lib/container-command.test.ts
+++ b/apps/app/src/lib/container-command.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { buildContainerCommandOptions } from "./container-command";
+
+describe("buildContainerCommandOptions", () => {
+  test("does not override image defaults without a custom command", () => {
+    expect(buildContainerCommandOptions(null)).toEqual({});
+    expect(buildContainerCommandOptions(undefined)).toEqual({});
+  });
+
+  test("runs custom commands through a shell entrypoint", () => {
+    expect(buildContainerCommandOptions("echo hello && echo done")).toEqual({
+      entrypoint: "/bin/sh",
+      command: ["-c", "echo hello && echo done"],
+    });
+  });
+});

--- a/apps/app/src/lib/container-command.ts
+++ b/apps/app/src/lib/container-command.ts
@@ -1,0 +1,17 @@
+export interface ContainerCommandOptions {
+  entrypoint?: string;
+  command?: string[];
+}
+
+export function buildContainerCommandOptions(
+  command: string | null | undefined,
+): ContainerCommandOptions {
+  if (!command) {
+    return {};
+  }
+
+  return {
+    entrypoint: "/bin/sh",
+    command: ["-c", command],
+  };
+}

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import type { Selectable } from "kysely";
 import { getSetting } from "./auth";
 import { emitBuildLogChunk } from "./build-log-stream";
+import { buildContainerCommandOptions } from "./container-command";
 import { decrypt } from "./crypto";
 import { db } from "./db";
 import type { Environments, Projects, Registries, Services } from "./db-types";
@@ -1490,12 +1491,9 @@ async function runServiceDeployment(
     }
 
     let fileMounts: FileMount[] | undefined;
-    let entrypoint: string | undefined;
-    let command: string[] | undefined;
-
-    if (service.command) {
-      command = ["sh", "-c", service.command];
-    }
+    const commandOptions = buildContainerCommandOptions(service.command);
+    let entrypoint = commandOptions.entrypoint;
+    const command = commandOptions.command;
 
     const isPostgres = service.imageUrl?.includes("postgres") ?? false;
     if (service.serviceType === "database" && isPostgres && !service.command) {

--- a/apps/app/src/lib/templates.test.ts
+++ b/apps/app/src/lib/templates.test.ts
@@ -279,6 +279,19 @@ describe("resolveTemplateServices", () => {
     const resolved = resolveTemplateServices(template!);
     expect(resolved[0].icon).toBe("nginx");
   });
+
+  it("starts minio through the minio binary", () => {
+    const template = getTemplate("minio");
+    expect(template).toBeDefined();
+    if (!template) {
+      throw new Error("minio template not found");
+    }
+
+    const resolved = resolveTemplateServices(template);
+    expect(resolved[0].command).toBe(
+      'minio server /data --console-address ":9001"',
+    );
+  });
 });
 
 describe("buildConnectionString", () => {

--- a/apps/app/templates/README.md
+++ b/apps/app/templates/README.md
@@ -33,7 +33,7 @@ services:
     port: 8080                    # container port
     main: true                    # (projects only) gets domain, shown first
     type: database                # optional: marks as database service
-    command: /bin/sh -c "..."     # optional: custom startup command
+    command: echo "starting"      # optional: runs as /bin/sh -c
     environment:
       STATIC_VAR: value
       GENERATED_VAR:

--- a/apps/app/templates/services/minio.yaml
+++ b/apps/app/templates/services/minio.yaml
@@ -8,7 +8,7 @@ services:
     image: minio/minio:RELEASE.2025-01-20T14-49-07Z
     port: 9000
     icon: minio
-    command: server /data --console-address ":9001"
+    command: minio server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: admin
       MINIO_ROOT_PASSWORD:


### PR DESCRIPTION
## What changed

- Run Frost service custom commands through `/bin/sh -c` by overriding the container entrypoint instead of appending `sh -c` to the image command.
- Update the MinIO template to call `minio server ...` explicitly.
- Add focused tests for command option building and the MinIO template command.
- Clarify template docs that `command` is already run by `/bin/sh -c`.

## Why

MinIO images use `minio` as their entrypoint. Frost was appending `sh -c ...` after the image name, which made the container execute `minio sh -c ...` and fail with `‘sh’ is not a minio sub-command`.

## Validation

- `bun test src/lib/container-command.test.ts src/lib/templates.test.ts`
- `bun run typecheck`
- `bun run lint` exits successfully; it still reports 5 existing warnings in `apps/app/src/lib/mcp/mcp-tools.test.ts`.
- Real MinIO image sanity check: `/minio/health/live` passed with the new entrypoint/command shape.
