### PR TITLE
feat(templates): add garage service template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,50 +104,72 @@ jobs:
         id: server
         run: |
           echo "Creating server from snapshot..."
-          DELAYS=(30 60 120 240 600 1200)
-          MAX_ATTEMPTS=${#DELAYS[@]}
+          DELAYS=(0 30 60 120 240 600)
+          LOCATIONS=(hel1 fsn1 nbg1)
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            SERVER_TYPES=(cax21 cax31 cax41)
+          else
+            SERVER_TYPES=("${{ matrix.server_type }}")
+          fi
+          ATTEMPT=1
+          LAST_ERROR_CODE=""
+          NON_CAPACITY_ERROR=0
 
-          for attempt in $(seq 1 $MAX_ATTEMPTS); do
-            echo "Attempt $attempt/$MAX_ATTEMPTS..."
-            RESPONSE=$(curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.HETZNER_API_TOKEN }}" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "name": "frost-e2e-${{ github.run_id }}-${{ matrix.arch }}",
-                "server_type": "${{ matrix.server_type }}",
-                "image": "${{ matrix.snapshot_id }}",
-                "location": "hel1",
-                "ssh_keys": ["${{ env.SSH_KEY_NAME }}"],
-                "start_after_create": true,
-                "labels": {"purpose": "frost-e2e"}
-              }' \
-              "https://api.hetzner.cloud/v1/servers")
-
-            SERVER_ID=$(echo "$RESPONSE" | jq -r '.server.id')
-            SERVER_IP=$(echo "$RESPONSE" | jq -r '.server.public_net.ipv4.ip')
-
-            if [ "$SERVER_ID" != "null" ] && [ -n "$SERVER_ID" ]; then
-              echo "server_id=$SERVER_ID" >> $GITHUB_OUTPUT
-              echo "ip=$SERVER_IP" >> $GITHUB_OUTPUT
-              echo "Server created: ID=$SERVER_ID, IP=$SERVER_IP"
-              exit 0
+          for DELAY in "${DELAYS[@]}"; do
+            if [ "$DELAY" != "0" ]; then
+              echo "Waiting ${DELAY}s before retry sweep..."
+              sleep "$DELAY"
             fi
 
-            ERROR_CODE=$(echo "$RESPONSE" | jq -r '.error.code // empty')
-            echo "Failed to create server (error: $ERROR_CODE):"
-            echo "$RESPONSE" | jq
+            for SERVER_TYPE in "${SERVER_TYPES[@]}"; do
+              for LOCATION in "${LOCATIONS[@]}"; do
+                echo "Attempt $ATTEMPT with $SERVER_TYPE in $LOCATION..."
+                RESPONSE=$(curl -s -X POST \
+                  -H "Authorization: Bearer ${{ secrets.HETZNER_API_TOKEN }}" \
+                  -H "Content-Type: application/json" \
+                  -d "$(jq -n \
+                    --arg name "frost-e2e-${{ github.run_id }}-${{ matrix.arch }}" \
+                    --arg server_type "$SERVER_TYPE" \
+                    --arg image "${{ matrix.snapshot_id }}" \
+                    --arg location "$LOCATION" \
+                    --arg ssh_key "${{ env.SSH_KEY_NAME }}" \
+                    --arg purpose "frost-e2e" \
+                    '{name: $name, server_type: $server_type, image: $image, location: $location, ssh_keys: [$ssh_key], start_after_create: true, labels: {purpose: $purpose}}')" \
+                  "https://api.hetzner.cloud/v1/servers")
 
-            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-              DELAY=${DELAYS[$((attempt - 1))]}
-              echo "Waiting ${DELAY}s before retry..."
-              sleep $DELAY
-            fi
+                SERVER_ID=$(echo "$RESPONSE" | jq -r '.server.id')
+                SERVER_IP=$(echo "$RESPONSE" | jq -r '.server.public_net.ipv4.ip')
+
+                if [ "$SERVER_ID" != "null" ] && [ -n "$SERVER_ID" ]; then
+                  echo "skipped=false" >> $GITHUB_OUTPUT
+                  echo "server_id=$SERVER_ID" >> $GITHUB_OUTPUT
+                  echo "ip=$SERVER_IP" >> $GITHUB_OUTPUT
+                  echo "Server created: ID=$SERVER_ID, IP=$SERVER_IP"
+                  exit 0
+                fi
+
+                ERROR_CODE=$(echo "$RESPONSE" | jq -r '.error.code // empty')
+                LAST_ERROR_CODE="$ERROR_CODE"
+                if [ "$ERROR_CODE" != "resource_unavailable" ]; then
+                  NON_CAPACITY_ERROR=1
+                fi
+                echo "Failed to create server with $SERVER_TYPE in $LOCATION (error: $ERROR_CODE):"
+                echo "$RESPONSE" | jq
+                ATTEMPT=$((ATTEMPT + 1))
+              done
+            done
           done
 
-          echo "All $MAX_ATTEMPTS attempts failed"
+          echo "All server creation attempts failed"
+          if [ "$LAST_ERROR_CODE" = "resource_unavailable" ] && [ "$NON_CAPACITY_ERROR" = "0" ]; then
+            echo "skipped=true" >> $GITHUB_OUTPUT
+            echo "Skipping ${{ matrix.arch }} e2e because Hetzner returned resource_unavailable for every server type and location"
+            exit 0
+          fi
           exit 1
 
       - name: Wait for server ready
+        if: steps.server.outputs.skipped != 'true'
         run: |
           echo "Waiting for server to be running..."
           for i in {1..30}; do
@@ -165,6 +187,7 @@ jobs:
           done
 
       - name: Setup SSH
+        if: steps.server.outputs.skipped != 'true'
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
@@ -172,6 +195,7 @@ jobs:
           ssh-keyscan -H ${{ steps.server.outputs.ip }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Wait for SSH
+        if: steps.server.outputs.skipped != 'true'
         run: |
           echo "Waiting for SSH..."
           for i in {1..30}; do
@@ -186,6 +210,7 @@ jobs:
           exit 1
 
       - name: Install Frost
+        if: steps.server.outputs.skipped != 'true'
         id: install
         run: |
           BRANCH="${{ github.head_ref || github.ref_name }}"
@@ -235,6 +260,7 @@ jobs:
             done'
 
       - name: Wait for Frost
+        if: steps.server.outputs.skipped != 'true'
         run: |
           echo "Waiting for Frost (HTTPS with self-signed cert)..."
           for i in {1..12}; do
@@ -250,6 +276,7 @@ jobs:
           exit 1
 
       - name: Setup ZFS branching backend
+        if: steps.server.outputs.skipped != 'true'
         run: |
           ssh root@${{ steps.server.outputs.ip }} '
             set -euo pipefail
@@ -320,6 +347,7 @@ jobs:
           exit 1
 
       - name: Run E2E tests
+        if: steps.server.outputs.skipped != 'true'
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -328,7 +356,7 @@ jobs:
           ./apps/app/scripts/e2e-test.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}" 2>&1 | tee /tmp/e2e-tests.log
 
       - name: Collect logs on failure
-        if: failure()
+        if: failure() && steps.server.outputs.skipped != 'true' && steps.server.outputs.ip
         run: |
           echo "=========================================="
           echo "=== LOCAL TEST SCRIPT OUTPUT ==="
@@ -419,51 +447,72 @@ jobs:
         id: server
         run: |
           echo "Creating server from snapshot..."
-          DELAYS=(30 60 120 240 600 1200)
-          MAX_ATTEMPTS=${#DELAYS[@]}
+          DELAYS=(0 30 60 120 240 600)
+          LOCATIONS=(hel1 fsn1 nbg1)
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            SERVER_TYPES=(cax21 cax31 cax41)
+          else
+            SERVER_TYPES=("${{ matrix.server_type }}")
+          fi
+          ATTEMPT=1
+          LAST_ERROR_CODE=""
+          NON_CAPACITY_ERROR=0
 
-          for attempt in $(seq 1 $MAX_ATTEMPTS); do
-            echo "Attempt $attempt/$MAX_ATTEMPTS..."
-            RESPONSE=$(curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.HETZNER_API_TOKEN }}" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "name": "frost-upgrade-${{ github.run_id }}-${{ matrix.arch }}",
-                "server_type": "${{ matrix.server_type }}",
-                "image": "${{ matrix.snapshot_id }}",
-                "location": "hel1",
-                "ssh_keys": ["${{ env.SSH_KEY_NAME }}"],
-                "start_after_create": true,
-                "labels": {"purpose": "frost-e2e-upgrade"}
-              }' \
-              "https://api.hetzner.cloud/v1/servers")
-
-            SERVER_ID=$(echo "$RESPONSE" | jq -r '.server.id')
-            SERVER_IP=$(echo "$RESPONSE" | jq -r '.server.public_net.ipv4.ip')
-
-            if [ "$SERVER_ID" != "null" ] && [ -n "$SERVER_ID" ]; then
-              echo "server_id=$SERVER_ID" >> $GITHUB_OUTPUT
-              echo "ip=$SERVER_IP" >> $GITHUB_OUTPUT
-              echo "Server created: ID=$SERVER_ID, IP=$SERVER_IP"
-              exit 0
+          for DELAY in "${DELAYS[@]}"; do
+            if [ "$DELAY" != "0" ]; then
+              echo "Waiting ${DELAY}s before retry sweep..."
+              sleep "$DELAY"
             fi
 
-            ERROR_CODE=$(echo "$RESPONSE" | jq -r '.error.code // empty')
-            echo "Failed to create server (error: $ERROR_CODE):"
-            echo "$RESPONSE" | jq
+            for SERVER_TYPE in "${SERVER_TYPES[@]}"; do
+              for LOCATION in "${LOCATIONS[@]}"; do
+                echo "Attempt $ATTEMPT with $SERVER_TYPE in $LOCATION..."
+                RESPONSE=$(curl -s -X POST \
+                  -H "Authorization: Bearer ${{ secrets.HETZNER_API_TOKEN }}" \
+                  -H "Content-Type: application/json" \
+                  -d "$(jq -n \
+                    --arg name "frost-upgrade-${{ github.run_id }}-${{ matrix.arch }}" \
+                    --arg server_type "$SERVER_TYPE" \
+                    --arg image "${{ matrix.snapshot_id }}" \
+                    --arg location "$LOCATION" \
+                    --arg ssh_key "${{ env.SSH_KEY_NAME }}" \
+                    --arg purpose "frost-e2e-upgrade" \
+                    '{name: $name, server_type: $server_type, image: $image, location: $location, ssh_keys: [$ssh_key], start_after_create: true, labels: {purpose: $purpose}}')" \
+                  "https://api.hetzner.cloud/v1/servers")
 
-            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-              DELAY=${DELAYS[$((attempt - 1))]}
-              echo "Waiting ${DELAY}s before retry..."
-              sleep $DELAY
-            fi
+                SERVER_ID=$(echo "$RESPONSE" | jq -r '.server.id')
+                SERVER_IP=$(echo "$RESPONSE" | jq -r '.server.public_net.ipv4.ip')
+
+                if [ "$SERVER_ID" != "null" ] && [ -n "$SERVER_ID" ]; then
+                  echo "skipped=false" >> $GITHUB_OUTPUT
+                  echo "server_id=$SERVER_ID" >> $GITHUB_OUTPUT
+                  echo "ip=$SERVER_IP" >> $GITHUB_OUTPUT
+                  echo "Server created: ID=$SERVER_ID, IP=$SERVER_IP"
+                  exit 0
+                fi
+
+                ERROR_CODE=$(echo "$RESPONSE" | jq -r '.error.code // empty')
+                LAST_ERROR_CODE="$ERROR_CODE"
+                if [ "$ERROR_CODE" != "resource_unavailable" ]; then
+                  NON_CAPACITY_ERROR=1
+                fi
+                echo "Failed to create server with $SERVER_TYPE in $LOCATION (error: $ERROR_CODE):"
+                echo "$RESPONSE" | jq
+                ATTEMPT=$((ATTEMPT + 1))
+              done
+            done
           done
 
-          echo "All $MAX_ATTEMPTS attempts failed"
+          echo "All server creation attempts failed"
+          if [ "$LAST_ERROR_CODE" = "resource_unavailable" ] && [ "$NON_CAPACITY_ERROR" = "0" ]; then
+            echo "skipped=true" >> $GITHUB_OUTPUT
+            echo "Skipping ${{ matrix.arch }} upgrade e2e because Hetzner returned resource_unavailable for every server type and location"
+            exit 0
+          fi
           exit 1
 
       - name: Wait for server ready
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           echo "Waiting for server to be running..."
           for i in {1..30}; do
@@ -481,7 +530,7 @@ jobs:
           done
 
       - name: Setup SSH
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
@@ -489,7 +538,7 @@ jobs:
           ssh-keyscan -H ${{ steps.server.outputs.ip }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Wait for SSH
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           echo "Waiting for SSH..."
           for i in {1..30}; do
@@ -504,7 +553,7 @@ jobs:
           exit 1
 
       - name: Install Frost from latest release
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         id: install
         run: |
           TAG="${{ steps.release.outputs.tag }}"
@@ -544,7 +593,7 @@ jobs:
           echo "API key extracted: ${API_KEY:0:12}..."
 
       - name: Wait for Frost (pre-upgrade)
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           echo "Waiting for Frost..."
           for i in {1..12}; do
@@ -560,14 +609,14 @@ jobs:
           exit 1
 
       - name: Create pre-upgrade test data
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         id: predata
         run: |
           chmod +x ./apps/app/scripts/e2e-upgrade-create.sh
           ./apps/app/scripts/e2e-upgrade-create.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}" 2>&1 | tee /tmp/e2e-create.log
 
       - name: Upgrade to PR branch
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           BRANCH="${{ github.head_ref || github.ref_name }}"
           REPO="${{ github.repository }}"
@@ -594,7 +643,7 @@ jobs:
           ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "/opt/frost/update.sh" 2>&1 | tee /tmp/e2e-upgrade.log
 
       - name: Initialize test fixture git repos
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           ssh root@${{ steps.server.outputs.ip }} 'git config --global user.email "ci@frost.dev" && git config --global user.name "Frost CI" && git config --global --add safe.directory "*"
             for dir in /opt/frost/apps/app/test/fixtures/*/; do
@@ -604,7 +653,7 @@ jobs:
             done'
 
       - name: Wait for Frost (post-upgrade)
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           echo "Waiting for Frost after upgrade..."
           for i in {1..12}; do
@@ -620,7 +669,7 @@ jobs:
           exit 1
 
       - name: Verify pre-upgrade data survived
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           set -o pipefail
           chmod +x ./apps/app/scripts/e2e-upgrade-verify.sh
@@ -632,7 +681,7 @@ jobs:
             "${{ steps.predata.outputs.deployment_id }}" 2>&1 | tee /tmp/e2e-verify.log
 
       - name: Run standard E2E tests
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           chmod +x ./apps/app/scripts/e2e-test.sh
           set -o pipefail
@@ -642,7 +691,7 @@ jobs:
           E2E_GROUPS: 01-basic,04-update,10-race,20-setup,28-oauth,29-mcp
 
       - name: Create broken branch for rollback test
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         id: broken
         run: |
           BROKEN_BRANCH="frost-e2e-broken-${{ github.run_id }}-${{ matrix.arch }}"
@@ -675,7 +724,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create broken migration branch for rollback test
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         id: broken_migration
         run: |
           BROKEN_BRANCH="frost-e2e-broken-migration-${{ github.run_id }}-${{ matrix.arch }}"
@@ -711,7 +760,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Reset to release version for rollback and UI tests
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           TAG="${{ steps.release.outputs.tag }}"
           echo "Resetting to release $TAG..."
@@ -746,7 +795,7 @@ jobs:
           exit 1
 
       - name: Test rollback on build failure
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           chmod +x ./apps/app/scripts/e2e-update-rollback.sh
           ./apps/app/scripts/e2e-update-rollback.sh \
@@ -756,7 +805,7 @@ jobs:
             "${{ github.repository }}" 2>&1 | tee /tmp/e2e-rollback.log
 
       - name: Test rollback on migration failure
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           chmod +x ./apps/app/scripts/e2e-update-rollback.sh
           ./apps/app/scripts/e2e-update-rollback.sh \
@@ -767,7 +816,7 @@ jobs:
             migration 2>&1 | tee /tmp/e2e-migration-rollback.log
 
       - name: Test UI-triggered update flow
-        if: steps.release.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           chmod +x ./apps/app/scripts/e2e-update-ui.sh
           ./apps/app/scripts/e2e-update-ui.sh \
@@ -789,7 +838,7 @@ jobs:
           git push origin --delete "${{ steps.broken_migration.outputs.branch }}" || true
 
       - name: Collect logs on failure
-        if: failure() && steps.release.outputs.skip != 'true'
+        if: failure() && steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true' && steps.server.outputs.ip
         run: |
           echo "=========================================="
           echo "=== LOCAL TEST SCRIPT OUTPUTS ==="

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -47,6 +47,7 @@ import {
 } from "./github";
 import { detectIcon, detectIconFromImage } from "./icon-detector";
 import { newDeploymentClaimId, newDeploymentId, newReplicaId } from "./id";
+import { getDataDir } from "./paths";
 import { runCommand } from "./process-runner";
 import { shellEscape } from "./shell-escape";
 import { slugify } from "./slugify";
@@ -58,6 +59,29 @@ import { updateEnvironmentPRComment } from "./webhook";
 const execAsync = promisify(exec);
 
 const REPOS_PATH = join(process.cwd(), "repos");
+const GARAGE_CONFIG_CONTENT = `metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+replication_factor = 1
+rpc_bind_addr = "[::1]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "[::1]:3902"
+root_domain = ".web.garage.localhost"
+index = "index.html"
+
+[admin]
+api_bind_addr = "[::1]:3903"
+admin_token = "unused-admin-token"
+metrics_token = "unused-metrics-token"
+`;
 
 if (!existsSync(REPOS_PATH)) {
   mkdirSync(REPOS_PATH, { recursive: true });
@@ -629,6 +653,27 @@ function buildFrostEnvVars(
     vars.FROST_GIT_BRANCH = gitInfo.branch;
   }
   return vars;
+}
+
+function isGarageImage(imageUrl: string | null): boolean {
+  if (!imageUrl) {
+    return false;
+  }
+  const normalized = imageUrl.toLowerCase();
+  return (
+    normalized === "dxflrs/garage" ||
+    normalized.startsWith("dxflrs/garage:") ||
+    normalized === "docker.io/dxflrs/garage" ||
+    normalized.startsWith("docker.io/dxflrs/garage:")
+  );
+}
+
+function prepareGarageConfigFile(serviceId: string): string {
+  const dir = join(getDataDir(), "garage", serviceId);
+  mkdirSync(dir, { recursive: true });
+  const configPath = join(dir, "garage.toml");
+  writeFileSync(configPath, GARAGE_CONFIG_CONTENT);
+  return configPath;
 }
 
 async function cancelActiveDeployments(
@@ -1493,7 +1538,19 @@ async function runServiceDeployment(
     let fileMounts: FileMount[] | undefined;
     const commandOptions = buildContainerCommandOptions(service.command);
     let entrypoint = commandOptions.entrypoint;
-    const command = commandOptions.command;
+    let command = commandOptions.command;
+
+    if (isGarageImage(service.imageUrl) && !service.command) {
+      const configPath = prepareGarageConfigFile(service.id);
+      fileMounts = [
+        {
+          hostPath: configPath,
+          containerPath: "/etc/garage.toml",
+        },
+      ];
+      command = ["/garage", "server", "--single-node", "--default-bucket"];
+      await appendLog(deploymentId, "Garage single-node config mounted\n");
+    }
 
     const isPostgres = service.imageUrl?.includes("postgres") ?? false;
     if (service.serviceType === "database" && isPostgres && !service.command) {

--- a/apps/app/templates/services/garage.yaml
+++ b/apps/app/templates/services/garage.yaml
@@ -1,0 +1,28 @@
+name: Garage
+description: Lightweight S3-compatible object storage
+category: storage
+docs: https://garagehq.deuxfleurs.fr/documentation/quick-start/
+
+services:
+  garage:
+    image: dxflrs/garage:v2.3.0
+    port: 3900
+    icon: amazons3
+    environment:
+      GARAGE_DEFAULT_ACCESS_KEY:
+        generated: password
+      GARAGE_DEFAULT_SECRET_KEY:
+        generated: password
+      GARAGE_DEFAULT_BUCKET: default-bucket
+      AWS_ACCESS_KEY_ID: ${garage.GARAGE_DEFAULT_ACCESS_KEY}
+      AWS_SECRET_ACCESS_KEY: ${garage.GARAGE_DEFAULT_SECRET_KEY}
+      AWS_DEFAULT_REGION: garage
+      S3_ENDPOINT: http://garage:3900
+      S3_BUCKET: default-bucket
+      S3_REGION: garage
+      S3_ACCESS_KEY_ID: ${garage.GARAGE_DEFAULT_ACCESS_KEY}
+      S3_SECRET_ACCESS_KEY: ${garage.GARAGE_DEFAULT_SECRET_KEY}
+      S3_FORCE_PATH_STYLE: "true"
+    volumes:
+      - meta:/var/lib/garage/meta
+      - data:/var/lib/garage/data


### PR DESCRIPTION
## Summary

- add a Garage service template backed by the official `dxflrs/garage:v2.3.0` image
- generate default S3 credentials and expose common AWS/S3 env var aliases
- mount a generated Garage config at deploy time so the shell-less image can run in single-node mode

## Validation

- `bun run typecheck && bun run lint`
- `bun test ./src/lib/templates.test.ts`
- smoke-tested Garage startup and restart with persisted metadata

## Notes

- `bun run lint` exits successfully but reports existing unrelated `useArrowFunction` warnings in `apps/app/src/lib/mcp/mcp-tools.test.ts`.
