### PR TITLE
fix(ci): fallback hetzner e2e locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -29,7 +29,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -39,7 +39,7 @@ jobs:
   migrations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -48,7 +48,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [typecheck, lint, migrations, test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create server from snapshot
         id: server
@@ -406,7 +406,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get latest release tag
         id: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,23 +104,31 @@ jobs:
         id: server
         run: |
           echo "Creating server from snapshot..."
+          LOCATIONS=(fsn1 nbg1 hel1)
           DELAYS=(30 60 120 240 600 1200)
           MAX_ATTEMPTS=${#DELAYS[@]}
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
-            echo "Attempt $attempt/$MAX_ATTEMPTS..."
+            LOCATION=${LOCATIONS[$(((attempt - 1) % ${#LOCATIONS[@]}))]}
+            echo "Attempt $attempt/$MAX_ATTEMPTS in $LOCATION..."
             RESPONSE=$(curl -s -X POST \
               -H "Authorization: Bearer ${{ secrets.HETZNER_API_TOKEN }}" \
               -H "Content-Type: application/json" \
-              -d '{
-                "name": "frost-e2e-${{ github.run_id }}-${{ matrix.arch }}",
-                "server_type": "${{ matrix.server_type }}",
-                "image": "${{ matrix.snapshot_id }}",
-                "location": "hel1",
-                "ssh_keys": ["${{ env.SSH_KEY_NAME }}"],
-                "start_after_create": true,
-                "labels": {"purpose": "frost-e2e"}
-              }' \
+              -d "$(jq -n \
+                --arg name "frost-e2e-${{ github.run_id }}-${{ matrix.arch }}" \
+                --arg server_type "${{ matrix.server_type }}" \
+                --arg image "${{ matrix.snapshot_id }}" \
+                --arg location "$LOCATION" \
+                --arg ssh_key "${{ env.SSH_KEY_NAME }}" \
+                '{
+                  name: $name,
+                  server_type: $server_type,
+                  image: $image,
+                  location: $location,
+                  ssh_keys: [$ssh_key],
+                  start_after_create: true,
+                  labels: {purpose: "frost-e2e"}
+                }')" \
               "https://api.hetzner.cloud/v1/servers")
 
             SERVER_ID=$(echo "$RESPONSE" | jq -r '.server.id')
@@ -129,6 +137,7 @@ jobs:
             if [ "$SERVER_ID" != "null" ] && [ -n "$SERVER_ID" ]; then
               echo "server_id=$SERVER_ID" >> $GITHUB_OUTPUT
               echo "ip=$SERVER_IP" >> $GITHUB_OUTPUT
+              echo "location=$LOCATION" >> $GITHUB_OUTPUT
               echo "Server created: ID=$SERVER_ID, IP=$SERVER_IP"
               exit 0
             fi
@@ -419,23 +428,31 @@ jobs:
         id: server
         run: |
           echo "Creating server from snapshot..."
+          LOCATIONS=(fsn1 nbg1 hel1)
           DELAYS=(30 60 120 240 600 1200)
           MAX_ATTEMPTS=${#DELAYS[@]}
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
-            echo "Attempt $attempt/$MAX_ATTEMPTS..."
+            LOCATION=${LOCATIONS[$(((attempt - 1) % ${#LOCATIONS[@]}))]}
+            echo "Attempt $attempt/$MAX_ATTEMPTS in $LOCATION..."
             RESPONSE=$(curl -s -X POST \
               -H "Authorization: Bearer ${{ secrets.HETZNER_API_TOKEN }}" \
               -H "Content-Type: application/json" \
-              -d '{
-                "name": "frost-upgrade-${{ github.run_id }}-${{ matrix.arch }}",
-                "server_type": "${{ matrix.server_type }}",
-                "image": "${{ matrix.snapshot_id }}",
-                "location": "hel1",
-                "ssh_keys": ["${{ env.SSH_KEY_NAME }}"],
-                "start_after_create": true,
-                "labels": {"purpose": "frost-e2e-upgrade"}
-              }' \
+              -d "$(jq -n \
+                --arg name "frost-upgrade-${{ github.run_id }}-${{ matrix.arch }}" \
+                --arg server_type "${{ matrix.server_type }}" \
+                --arg image "${{ matrix.snapshot_id }}" \
+                --arg location "$LOCATION" \
+                --arg ssh_key "${{ env.SSH_KEY_NAME }}" \
+                '{
+                  name: $name,
+                  server_type: $server_type,
+                  image: $image,
+                  location: $location,
+                  ssh_keys: [$ssh_key],
+                  start_after_create: true,
+                  labels: {purpose: "frost-e2e-upgrade"}
+                }')" \
               "https://api.hetzner.cloud/v1/servers")
 
             SERVER_ID=$(echo "$RESPONSE" | jq -r '.server.id')
@@ -444,6 +461,7 @@ jobs:
             if [ "$SERVER_ID" != "null" ] && [ -n "$SERVER_ID" ]; then
               echo "server_id=$SERVER_ID" >> $GITHUB_OUTPUT
               echo "ip=$SERVER_IP" >> $GITHUB_OUTPUT
+              echo "location=$LOCATION" >> $GITHUB_OUTPUT
               echo "Server created: ID=$SERVER_ID, IP=$SERVER_IP"
               exit 0
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- try Hetzner Falkenstein (`fsn1`) before Nuremberg and Helsinki when creating E2E VPS servers
- rotate through `fsn1 -> nbg1 -> hel1` across the existing retry budget for both standard VPS and upgrade jobs
- emit the selected location as a step output for easier run inspection

## Context
Recent CI failures are happening before Frost installs: Hetzner returns `resource_unavailable` / `error during placement` while creating `cax21` arm64 servers in `hel1`. Falkenstein is Hetzner's largest data center park, and snapshots are not location-bound, so this is a small way to test whether placement improves without migrating providers.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`\n- local Bash check for the location rotation order\n