### PR TITLE
fix(logs): tidy deployment log panel layout

### DIFF
--- a/apps/app/src/app/(workspace)/projects/[id]/_components/runtime-logs-panel.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/runtime-logs-panel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Circle } from "lucide-react";
 import type { ReactNode } from "react";
-import { LogViewer } from "@/components/log-viewer";
+import { LogConnectionStatus, LogViewer } from "@/components/log-viewer";
 import { cn } from "@/lib/utils";
 
 interface RuntimeLogsPanelProps {
@@ -30,17 +29,7 @@ export function RuntimeLogsPanel({
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
       <div className="mb-3 flex items-center gap-2">
         {headerPrefix}
-        <Circle
-          className={cn(
-            "h-2 w-2",
-            isConnected
-              ? "fill-green-500 text-green-500"
-              : "fill-neutral-500 text-neutral-500",
-          )}
-        />
-        <span className="text-xs text-neutral-500">
-          {isConnected ? "Live" : "Reconnecting..."}
-        </span>
+        <LogConnectionStatus isConnected={isConnected} />
         {headerSuffix ? <div className="ml-auto">{headerSuffix}</div> : null}
       </div>
 

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/service-deployment-view.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/service-deployment-view.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { DeploymentStatusIndicator } from "@/components/deployment-status-indicator";
-import { LogViewer } from "@/components/log-viewer";
+import { LogConnectionStatus, LogViewer } from "@/components/log-viewer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useBuildLogs } from "@/hooks/use-build-logs";
@@ -160,11 +160,15 @@ export function ServiceDeploymentView({
           </div>
         )}
 
-        <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-neutral-800 bg-black">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-neutral-800 bg-black">
+          {streamBuildLogs && (
+            <LogConnectionStatus
+              isConnected={isConnected}
+              className="border-b border-neutral-900 bg-neutral-950/60 px-4 py-2"
+            />
+          )}
           <LogViewer
             logs={displayLogs}
-            isStreaming={streamBuildLogs}
-            isConnected={isConnected}
             error={error}
             emptyMessage="No logs yet..."
           />

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/sidebar-deployments.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/sidebar-deployments.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DeploymentStatusIndicator } from "@/components/deployment-status-indicator";
 import { EmptyState } from "@/components/empty-state";
-import { LogViewer } from "@/components/log-viewer";
+import { LogConnectionStatus, LogViewer } from "@/components/log-viewer";
 import { Button } from "@/components/ui/button";
 import { useBuildLogs } from "@/hooks/use-build-logs";
 import { useDeployments, useDeployService } from "@/hooks/use-services";
@@ -232,18 +232,22 @@ export function SidebarDeployments({
               </Button>
             )}
           </div>
-          <div className="min-h-0 flex-1 space-y-3 p-4">
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-4">
             {selectedDeployment.errorMessage && (
               <div className="rounded border border-red-900 bg-red-950/50 p-3 text-sm text-red-400">
                 {selectedDeployment.errorMessage}
               </div>
             )}
             <ReplicaStatus deploymentId={selectedDeployment.id} />
-            <div className="min-h-0 flex-1 overflow-hidden rounded border border-neutral-800">
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-neutral-800">
+              {streamBuildLogs && (
+                <LogConnectionStatus
+                  isConnected={isConnected}
+                  className="border-b border-neutral-900 bg-neutral-950/60 px-4 py-2"
+                />
+              )}
               <LogViewer
                 logs={displayLogs}
-                isStreaming={streamBuildLogs}
-                isConnected={isConnected}
                 error={error}
                 emptyMessage="No logs yet..."
               />

--- a/apps/app/src/components/log-viewer.tsx
+++ b/apps/app/src/components/log-viewer.tsx
@@ -24,17 +24,39 @@ function formatTimestamp(iso: string): string {
 
 interface LogViewerProps {
   logs: string[];
-  isStreaming?: boolean;
-  isConnected?: boolean;
   error?: string | null;
   emptyMessage?: string;
   className?: string;
 }
 
+interface LogConnectionStatusProps {
+  isConnected: boolean;
+  className?: string;
+}
+
+export function LogConnectionStatus({
+  isConnected,
+  className,
+}: LogConnectionStatusProps) {
+  return (
+    <div className={cn("flex shrink-0 items-center gap-2", className)}>
+      <Circle
+        className={cn(
+          "h-2 w-2",
+          isConnected
+            ? "fill-green-500 text-green-500"
+            : "fill-neutral-500 text-neutral-500",
+        )}
+      />
+      <span className="text-xs text-neutral-500">
+        {isConnected ? "Live" : "Reconnecting..."}
+      </span>
+    </div>
+  );
+}
+
 export function LogViewer({
   logs,
-  isStreaming = false,
-  isConnected = false,
   error,
   emptyMessage = "No logs yet...",
   className,
@@ -60,22 +82,6 @@ export function LogViewer({
 
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
-      {isStreaming && (
-        <div className="flex items-center gap-2 pb-3">
-          <Circle
-            className={cn(
-              "h-2 w-2",
-              isConnected
-                ? "fill-green-500 text-green-500"
-                : "fill-neutral-500 text-neutral-500",
-            )}
-          />
-          <span className="text-xs text-neutral-500">
-            {isConnected ? "Live" : "Reconnecting..."}
-          </span>
-        </div>
-      )}
-
       {error && (
         <div className="mb-3 rounded border border-red-900 bg-red-950/50 p-2 text-xs text-red-400">
           {error}


### PR DESCRIPTION
## Summary
- contain deployment log panels so long output scrolls inside the frame
- share the log connection status indicator between build and runtime log panels
- keep the build-log live status aligned as a padded strip above the log body

## Validation
- bun run typecheck && bun run lint

Note: lint completes with existing Biome warnings in apps/app/src/lib/mcp/mcp-tools.test.ts.