### PR TITLE
fix(domains): validate domain names

### DIFF
--- a/apps/app/src/app/(workspace)/projects/[id]/services/[serviceId]/_components/domains-section.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/services/[serviceId]/_components/domains-section.tsx
@@ -39,6 +39,10 @@ import {
 } from "@/hooks/use-domains";
 import type { Domain } from "@/lib/api";
 import { extractSubdomain } from "@/lib/domain-utils";
+import {
+  getDomainNameValidationError,
+  normalizeDomainName,
+} from "@/lib/domain-validation";
 
 interface VerificationState {
   isChecking: boolean;
@@ -95,6 +99,7 @@ export function DomainsSection({
   const customDomains = domains?.filter((d) => !d.isSystem) || [];
   const hasOtherVerifiedDomains =
     customDomains.filter((d) => d.dnsVerified).length > 0;
+  const newDomainError = getDomainNameValidationError(newDomain);
 
   const unverifiedDomainIds = useMemo(
     () => domains?.filter((d) => !d.dnsVerified).map((d) => d.id) || [],
@@ -179,9 +184,14 @@ export function DomainsSection({
   async function handleAddDomain() {
     if (!newDomain) return;
 
+    if (newDomainError) {
+      toast.error(newDomainError);
+      return;
+    }
+
     try {
       await addMutation.mutateAsync({
-        domain: newDomain,
+        domain: normalizeDomainName(newDomain),
         type: domainType,
         redirectTarget: domainType === "redirect" ? redirectTarget : undefined,
         redirectCode:
@@ -311,9 +321,13 @@ export function DomainsSection({
                 value={newDomain}
                 onChange={(e) => setNewDomain(e.target.value)}
                 placeholder="example.com"
+                aria-invalid={Boolean(newDomainError)}
                 className="h-10 pl-9 border-neutral-700 bg-neutral-900 text-white placeholder:text-neutral-500"
               />
             </div>
+            {newDomainError && (
+              <p className="mt-2 text-sm text-red-400">{newDomainError}</p>
+            )}
 
             <div className="mt-4 space-y-3 rounded-md border border-neutral-800 p-4">
               <label className="flex cursor-pointer items-start gap-3">
@@ -407,6 +421,7 @@ export function DomainsSection({
                 disabled={
                   addMutation.isPending ||
                   !newDomain ||
+                  Boolean(newDomainError) ||
                   (domainType === "redirect" && !redirectTarget)
                 }
               >

--- a/apps/app/src/app/(workspace)/settings/_components/ssl-section.tsx
+++ b/apps/app/src/app/(workspace)/settings/_components/ssl-section.tsx
@@ -10,6 +10,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useDemoMode } from "@/hooks/use-demo-mode";
+import {
+  getDomainNameValidationError,
+  normalizeDomainName,
+} from "@/lib/domain-validation";
 import { orpc } from "@/lib/orpc-client";
 
 interface DnsStatus {
@@ -32,6 +36,7 @@ export function SslSection() {
   const [pollingTimedOut, setPollingTimedOut] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState("");
+  const domainError = getDomainNameValidationError(domain);
 
   const { data: settings } = useQuery(orpc.settings.get.queryOptions());
 
@@ -102,7 +107,7 @@ export function SslSection() {
   const enableSslMutation = useMutation(
     orpc.settings.enableSsl.mutationOptions({
       onSuccess: () => {
-        setCurrentDomain(domain);
+        setCurrentDomain(normalizeDomainName(domain));
         setSslStatus("pending");
       },
       onError: (err) => {
@@ -114,17 +119,26 @@ export function SslSection() {
   async function handleVerifyDns() {
     if (demoMode) return;
     if (!domain) return;
+    if (domainError) {
+      setError(domainError);
+      return;
+    }
     setError("");
     setDnsStatus(null);
-    verifyDnsMutation.mutate({ domain });
+    verifyDnsMutation.mutate({ domain: normalizeDomainName(domain) });
   }
 
   async function handleEnableSsl() {
     if (demoMode) return;
     if (!domain || !email || !dnsStatus?.valid) return;
+    if (domainError) {
+      setError(domainError);
+      return;
+    }
+    const normalizedDomain = normalizeDomainName(domain);
     setError("");
     setPollingTimedOut(false);
-    enableSslMutation.mutate({ domain, email, staging });
+    enableSslMutation.mutate({ domain: normalizedDomain, email, staging });
   }
 
   const enabling = enableSslMutation.isPending;
@@ -142,6 +156,7 @@ export function SslSection() {
           disabled={
             demoMode ||
             !domain ||
+            Boolean(domainError) ||
             !email ||
             !dnsStatus?.valid ||
             enabling ||
@@ -228,13 +243,16 @@ export function SslSection() {
                 setDnsStatus(null);
               }}
               placeholder="frost.example.com"
+              aria-invalid={Boolean(domainError)}
               disabled={demoMode}
               className="h-10 border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600 focus-visible:ring-neutral-700"
             />
             <Button
               variant="secondary"
               onClick={handleVerifyDns}
-              disabled={demoMode || !domain || verifying}
+              disabled={
+                demoMode || !domain || Boolean(domainError) || verifying
+              }
             >
               {verifying ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -243,6 +261,7 @@ export function SslSection() {
               )}
             </Button>
           </div>
+          {domainError && <p className="text-sm text-red-400">{domainError}</p>}
         </div>
 
         {dnsStatus && (

--- a/apps/app/src/app/(workspace)/settings/_components/wildcard-section.tsx
+++ b/apps/app/src/app/(workspace)/settings/_components/wildcard-section.tsx
@@ -18,6 +18,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useDemoMode } from "@/hooks/use-demo-mode";
+import {
+  getDomainNameValidationError,
+  normalizeDomainName,
+} from "@/lib/domain-validation";
 import { orpc } from "@/lib/orpc-client";
 
 export function WildcardSection() {
@@ -29,6 +33,7 @@ export function WildcardSection() {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [showInstructions, setShowInstructions] = useState(false);
+  const domainError = getDomainNameValidationError(domain);
 
   const { data: config } = useQuery(orpc.settings.wildcard.get.queryOptions());
   const { data: settings } = useQuery(orpc.settings.get.queryOptions());
@@ -117,10 +122,14 @@ export function WildcardSection() {
   async function handleSave() {
     if (demoMode) return;
     if (!domain || !apiToken) return;
+    if (domainError) {
+      setError(domainError);
+      return;
+    }
     setError("");
     setSuccess(false);
     saveMutation.mutate({
-      wildcardDomain: domain,
+      wildcardDomain: normalizeDomainName(domain),
       dnsProvider: "cloudflare",
       dnsApiToken: apiToken,
     });
@@ -155,7 +164,9 @@ export function WildcardSection() {
         ) : (
           <Button
             type="submit"
-            disabled={demoMode || !domain || !apiToken || saving}
+            disabled={
+              demoMode || !domain || Boolean(domainError) || !apiToken || saving
+            }
           >
             {saving ? (
               <>
@@ -222,9 +233,11 @@ export function WildcardSection() {
             value={domain}
             onChange={(e) => setDomain(e.target.value.replace(/^\*\./, ""))}
             placeholder="apps.example.com"
+            aria-invalid={Boolean(domainError)}
             disabled={demoMode || Boolean(config?.configured)}
             className="h-10 border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600 focus-visible:ring-neutral-700"
           />
+          {domainError && <p className="text-sm text-red-400">{domainError}</p>}
           <p className="text-xs text-neutral-500">
             Services get subdomains like: api-myproject.
             {domain || "apps.example.com"}

--- a/apps/app/src/contracts/domain-schemas.test.ts
+++ b/apps/app/src/contracts/domain-schemas.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { DOMAIN_NAME_ERROR } from "@/lib/domain-validation";
+import { domainNameSchema, wildcardDomainNameSchema } from "./domain-schemas";
+
+describe("domain schemas", () => {
+  test("normalizes valid domain names", () => {
+    expect(domainNameSchema.parse(" VattenSvar.SE. ")).toBe("vattensvar.se");
+  });
+
+  test("rejects invalid domain names", () => {
+    expect(function parseInvalidDomain() {
+      domainNameSchema.parse("vattensvar");
+    }).toThrow(DOMAIN_NAME_ERROR);
+  });
+
+  test("normalizes wildcard domains", () => {
+    expect(wildcardDomainNameSchema.parse(" *.Apps.Example.COM. ")).toBe(
+      "apps.example.com",
+    );
+  });
+});

--- a/apps/app/src/contracts/domain-schemas.ts
+++ b/apps/app/src/contracts/domain-schemas.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import {
+  DOMAIN_NAME_ERROR,
+  isValidDomainName,
+  normalizeDomainName,
+} from "@/lib/domain-validation";
+
+function normalizeWildcardDomainName(domain: string): string {
+  const normalized = normalizeDomainName(domain);
+  return normalized.replace(/^\*\./, "");
+}
+
+function createDomainNameSchema(normalize: (domain: string) => string) {
+  return z
+    .string()
+    .min(1, DOMAIN_NAME_ERROR)
+    .transform(normalize)
+    .refine(isValidDomainName, { message: DOMAIN_NAME_ERROR });
+}
+
+export const domainNameSchema = createDomainNameSchema(normalizeDomainName);
+
+export const wildcardDomainNameSchema = createDomainNameSchema(
+  normalizeWildcardDomainName,
+);

--- a/apps/app/src/contracts/domains.ts
+++ b/apps/app/src/contracts/domains.ts
@@ -1,5 +1,6 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
+import { domainNameSchema } from "@/contracts/domain-schemas";
 import { domainsSchema } from "@/lib/db-schemas";
 
 const dnsVerifyResultSchema = z.object({
@@ -41,7 +42,7 @@ export const domainsContract = {
     .input(
       z.object({
         serviceId: z.string(),
-        domain: z.string().min(1),
+        domain: domainNameSchema,
         type: z.enum(["proxy", "redirect"]).default("proxy"),
         redirectTarget: z.string().optional(),
         redirectCode: z.union([z.literal(301), z.literal(307)]).optional(),

--- a/apps/app/src/contracts/settings.ts
+++ b/apps/app/src/contracts/settings.ts
@@ -1,5 +1,9 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
+import {
+  domainNameSchema,
+  wildcardDomainNameSchema,
+} from "@/contracts/domain-schemas";
 
 export const settingsContract = {
   get: oc.route({ method: "GET", path: "/settings" }).output(
@@ -14,7 +18,7 @@ export const settingsContract = {
 
   verifyDns: oc
     .route({ method: "POST", path: "/settings/verify-dns" })
-    .input(z.object({ domain: z.string() }))
+    .input(z.object({ domain: domainNameSchema }))
     .output(
       z.object({
         valid: z.boolean(),
@@ -26,7 +30,7 @@ export const settingsContract = {
 
   verifySsl: oc
     .route({ method: "POST", path: "/settings/verify-ssl" })
-    .input(z.object({ domain: z.string() }))
+    .input(z.object({ domain: domainNameSchema }))
     .output(
       z.object({
         working: z.boolean(),
@@ -38,7 +42,7 @@ export const settingsContract = {
     .route({ method: "POST", path: "/settings/enable-ssl" })
     .input(
       z.object({
-        domain: z.string(),
+        domain: domainNameSchema,
         email: z.string(),
         staging: z.boolean().optional(),
       }),
@@ -117,7 +121,7 @@ export const settingsContract = {
       .route({ method: "POST", path: "/settings/wildcard" })
       .input(
         z.object({
-          wildcardDomain: z.string(),
+          wildcardDomain: wildcardDomainNameSchema,
           dnsProvider: z.string(),
           dnsApiToken: z.string(),
         }),

--- a/apps/app/src/lib/domain-validation.test.ts
+++ b/apps/app/src/lib/domain-validation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DOMAIN_NAME_ERROR,
+  getDomainNameValidationError,
+  isValidDomainName,
+  normalizeDomainName,
+  parseDomainName,
+} from "./domain-validation";
+
+describe("domain validation", () => {
+  test("normalizes user-entered domains", () => {
+    expect(normalizeDomainName(" VattenSvar.SE. ")).toBe("vattensvar.se");
+  });
+
+  test("accepts valid public domain names", () => {
+    expect(isValidDomainName("vattensvar.se")).toBe(true);
+    expect(isValidDomainName("www.vattensvar.se")).toBe(true);
+    expect(isValidDomainName("my-app.example.com")).toBe(true);
+  });
+
+  test("rejects non-domain hostnames and malformed hostnames", () => {
+    expect(isValidDomainName("vattensvar")).toBe(false);
+    expect(isValidDomainName("localhost")).toBe(false);
+    expect(isValidDomainName("com")).toBe(false);
+    expect(isValidDomainName("http://vattensvar.se")).toBe(false);
+    expect(isValidDomainName("vattensvar.se/path")).toBe(false);
+    expect(isValidDomainName("vattensvar.se:443")).toBe(false);
+    expect(isValidDomainName("*.vattensvar.se")).toBe(false);
+    expect(isValidDomainName("foo_bar.example.com")).toBe(false);
+    expect(isValidDomainName("-foo.example.com")).toBe(false);
+    expect(isValidDomainName("foo-.example.com")).toBe(false);
+  });
+
+  test("returns user-facing validation message for invalid values", () => {
+    expect(getDomainNameValidationError("vattensvar")).toBe(DOMAIN_NAME_ERROR);
+    expect(getDomainNameValidationError("")).toBeNull();
+  });
+
+  test("parses valid domains to their normalized form", () => {
+    expect(parseDomainName(" VattenSvar.SE. ")).toBe("vattensvar.se");
+    expect(function parseInvalidDomain() {
+      parseDomainName("vattensvar");
+    }).toThrow(DOMAIN_NAME_ERROR);
+  });
+});

--- a/apps/app/src/lib/domain-validation.ts
+++ b/apps/app/src/lib/domain-validation.ts
@@ -1,0 +1,38 @@
+import psl from "psl";
+
+export const DOMAIN_NAME_ERROR = "Enter a valid domain like vattensvar.se.";
+
+const DNS_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export function normalizeDomainName(domain: string): string {
+  return domain.trim().toLowerCase().replace(/\.+$/, "");
+}
+
+export function isValidDomainName(domain: string): boolean {
+  const normalized = normalizeDomainName(domain);
+  const labels = normalized.split(".");
+
+  return (
+    psl.isValid(normalized) &&
+    labels.length >= 2 &&
+    labels.every(function isValidDnsLabel(label) {
+      return DNS_LABEL_PATTERN.test(label);
+    })
+  );
+}
+
+export function getDomainNameValidationError(domain: string): string | null {
+  if (domain.length === 0) {
+    return null;
+  }
+
+  return isValidDomainName(domain) ? null : DOMAIN_NAME_ERROR;
+}
+
+export function parseDomainName(domain: string): string {
+  const normalized = normalizeDomainName(domain);
+  if (!isValidDomainName(normalized)) {
+    throw new Error(DOMAIN_NAME_ERROR);
+  }
+  return normalized;
+}

--- a/apps/app/src/lib/domains.ts
+++ b/apps/app/src/lib/domains.ts
@@ -2,6 +2,7 @@ import { promises as dns } from "node:dns";
 import { getSetting } from "./auth";
 import { acmeIssuer, type DnsConfig, dnsAcmeIssuer } from "./caddy";
 import { db } from "./db";
+import { normalizeDomainName, parseDomainName } from "./domain-validation";
 import { newDomainId } from "./id";
 
 const CADDY_ADMIN = "http://localhost:2019";
@@ -27,6 +28,7 @@ export async function addDomain(
   input: DomainInput,
 ) {
   const { domain, type = "proxy", redirectTarget, redirectCode = 301 } = input;
+  const normalizedDomain = parseDomainName(domain);
 
   const id = newDomainId();
   const now = Date.now();
@@ -37,7 +39,7 @@ export async function addDomain(
       id,
       serviceId: serviceId,
       environmentId: environmentId,
-      domain: domain.toLowerCase(),
+      domain: normalizedDomain,
       type,
       redirectTarget: type === "redirect" ? redirectTarget : null,
       redirectCode: type === "redirect" ? redirectCode : null,
@@ -66,7 +68,7 @@ export async function getDomainByName(domain: string) {
   return db
     .selectFrom("domains")
     .selectAll()
-    .where("domain", "=", domain.toLowerCase())
+    .where("domain", "=", normalizeDomainName(domain))
     .executeTakeFirst();
 }
 

--- a/apps/app/src/server/settings.ts
+++ b/apps/app/src/server/settings.ts
@@ -307,22 +307,16 @@ export const settings = {
         });
       }
 
-      const domainWithoutWildcard = wildcardDomain.replace(/^\*\./, "");
-
       let dnsWarning: string | undefined;
       try {
         const serverIp = await getServerIp();
-        await createWildcardARecord(
-          dnsApiToken,
-          domainWithoutWildcard,
-          serverIp,
-        );
+        await createWildcardARecord(dnsApiToken, wildcardDomain, serverIp);
       } catch (error) {
         dnsWarning =
           error instanceof Error ? error.message : "DNS record creation failed";
       }
 
-      await setSetting("wildcard_domain", domainWithoutWildcard);
+      await setSetting("wildcard_domain", wildcardDomain);
       await setSetting("dns_provider", dnsProvider);
       await setSetting("dns_api_token", dnsApiToken);
 

--- a/apps/marketing/Dockerfile
+++ b/apps/marketing/Dockerfile
@@ -13,6 +13,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/app/node_modules ./apps/app/node_modules
 COPY apps/app/src/contracts ./apps/app/src/contracts
 COPY apps/app/src/lib/db-schemas.ts ./apps/app/src/lib/db-schemas.ts
+COPY apps/app/src/lib/domain-validation.ts ./apps/app/src/lib/domain-validation.ts
 COPY apps/app/scripts/generate-openapi.ts ./apps/app/scripts/
 COPY apps/app/tsconfig.json ./apps/app/
 WORKDIR /app/apps/app


### PR DESCRIPTION
## Summary
- add shared public domain validation and normalization helpers
- apply the domain policy to service domains, SSL settings, and wildcard settings
- add focused tests for validation and contract schemas
- include the domain validator in the marketing Docker OpenAPI generation stage

## Why
Single-label values like `vattensvar` could be entered where Frost expects a real public domain such as `vattensvar.se`. The API now normalizes and rejects invalid domain names consistently, while the UI gives immediate feedback.

The marketing Docker build generates OpenAPI from a minimal contract-only stage, so it now explicitly copies the shared domain validator required by the contract schemas.

## Validation
- `bun test ./src/lib/domain-validation.test.ts ./src/contracts/domain-schemas.test.ts ./src/lib/domains.test.ts`
- `bun test ./src/lib/mcp/mcp-tools.test.ts`
- `bun run typecheck`
- `bun run lint`
- `docker build -f apps/marketing/Dockerfile --target openapi-gen .`

Note: `bun run lint` exits 0 and still reports existing unrelated MCP arrow-function warnings.