### PR TITLE
fix(ci): reduce e2e idle time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,7 +702,6 @@ jobs:
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
           E2E_GROUPS: 01-basic,04-update,10-race,20-setup,28-oauth,29-mcp
-          E2E_PREPULL_IMAGES: nginx:alpine httpd:alpine
 
       - name: Create broken branch for rollback test
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,12 @@ jobs:
         id: server
         run: |
           echo "Creating server from snapshot..."
-          DELAYS=(0 30 60 120 240 600)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            read -r -a DELAYS <<< "${HETZNER_CAPACITY_RETRY_DELAYS:-0 30 60 120 240 600}"
+          else
+            read -r -a DELAYS <<< "${HETZNER_CAPACITY_RETRY_DELAYS:-0 30 60}"
+          fi
+          echo "Capacity retry delays: ${DELAYS[*]}s"
           LOCATIONS=(fsn1 nbg1 hel1)
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             SERVER_TYPES=(cax21 cax31 cax41)
@@ -448,7 +453,12 @@ jobs:
         id: server
         run: |
           echo "Creating server from snapshot..."
-          DELAYS=(0 30 60 120 240 600)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            read -r -a DELAYS <<< "${HETZNER_CAPACITY_RETRY_DELAYS:-0 30 60 120 240 600}"
+          else
+            read -r -a DELAYS <<< "${HETZNER_CAPACITY_RETRY_DELAYS:-0 30 60}"
+          fi
+          echo "Capacity retry delays: ${DELAYS[*]}s"
           LOCATIONS=(fsn1 nbg1 hel1)
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             SERVER_TYPES=(cax21 cax31 cax41)
@@ -691,6 +701,7 @@ jobs:
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
           E2E_GROUPS: 01-basic,04-update,10-race,20-setup,28-oauth,29-mcp
+          E2E_PREPULL_IMAGES: nginx:alpine httpd:alpine
 
       - name: Create broken branch for rollback test
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,7 @@ jobs:
         if: steps.server.outputs.skipped != 'true'
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
+          E2E_BATCH_SIZE: 3
         run: |
           chmod +x ./apps/app/scripts/e2e-test.sh
           set -o pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,29 +633,12 @@ jobs:
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
           set -o pipefail
-          BRANCH="${{ github.head_ref || github.ref_name }}"
-          REPO="${{ github.repository }}"
-
-          echo "Upgrading from ${{ steps.release.outputs.tag }} to branch: $BRANCH using update.sh"
-
-          curl -fsSL "https://raw.githubusercontent.com/${REPO}/${BRANCH}/update.sh" -o /tmp/update.sh
-
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "cd /opt/frost && \
-            git config --global --add safe.directory /opt/frost && \
-            if [ ! -d .git ]; then \
-              echo 'Initializing git repo (tarball installation detected)'; \
-              git init && \
-              git remote add origin https://github.com/${REPO}.git; \
-            else \
-              git remote set-url origin https://github.com/${REPO}.git; \
-            fi && \
-            git fetch origin ${BRANCH}:refs/remotes/origin/main -f" 2>&1 | tee /tmp/e2e-git-setup.log
-
-          scp /tmp/update.sh root@${{ steps.server.outputs.ip }}:/opt/frost/update.sh
-          ssh root@${{ steps.server.outputs.ip }} "chmod +x /opt/frost/update.sh && \
-            sed -i 's|git fetch origin main.*|:|' /opt/frost/update.sh"
-
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "/opt/frost/update.sh" 2>&1 | tee /tmp/e2e-upgrade.log
+          chmod +x ./apps/app/scripts/e2e-update-ui.sh
+          ./apps/app/scripts/e2e-update-ui.sh \
+            "${{ steps.server.outputs.ip }}" \
+            "${{ steps.install.outputs.api_key }}" \
+            "${{ github.head_ref || github.ref_name }}" \
+            "${{ github.repository }}" 2>&1 | tee /tmp/e2e-upgrade.log
 
       - name: Initialize test fixture git repos
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
@@ -721,42 +704,6 @@ jobs:
           echo "Using local broken migration branch: $BROKEN_BRANCH"
           echo "branch=$BROKEN_BRANCH" >> $GITHUB_OUTPUT
 
-      - name: Reset to release version for rollback and UI tests
-        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
-        run: |
-          set -o pipefail
-          TAG="${{ steps.release.outputs.tag }}"
-          echo "Resetting to release $TAG..."
-
-          ssh -o ServerAliveInterval=30 root@${{ steps.server.outputs.ip }} "cd /opt/frost && \
-            systemctl stop frost && \
-            rm -rf repos apps && \
-            git fetch origin && \
-            git checkout -f $TAG && \
-            git reset --hard $TAG && \
-            git clean -fdx -e data -e .env && \
-            export BUN_INSTALL=\"\$HOME/.bun\" && \
-            export PATH=\"\$BUN_INSTALL/bin:\$PATH\" && \
-            bun install --frozen-lockfile 2>&1 && \
-            (for attempt in 1 2 3; do if NEXT_TELEMETRY_DISABLED=1 bun run build 2>&1; then exit 0; fi; echo \"Build failed (attempt \$attempt/3), retrying...\"; rm -rf apps/app/.next; sleep 2; done; exit 1) && \
-            bun run migrate 2>&1 && \
-            sed -i 's|ExecStart=.*|ExecStart=/usr/local/bin/bun run start|' /etc/systemd/system/frost.service && \
-            systemctl daemon-reload && \
-            systemctl start frost" 2>&1 | tee /tmp/e2e-reset-release.log
-
-          echo "Waiting for Frost on port 3000..."
-          for i in {1..24}; do
-            if curl -s "http://${{ steps.server.outputs.ip }}:3000/api/health" | grep -q "ok"; then
-              echo "Frost is ready!"
-              exit 0
-            fi
-            echo "Attempt $i: Frost not ready..."
-            sleep 5
-          done
-          echo "Frost failed to start"
-          ssh root@${{ steps.server.outputs.ip }} "journalctl -u frost --no-pager -n 100" || true
-          exit 1
-
       - name: Test rollback on build failure
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
@@ -779,17 +726,6 @@ jobs:
             "${{ steps.broken_migration.outputs.branch }}" \
             "${{ github.repository }}" \
             migration 2>&1 | tee /tmp/e2e-migration-rollback.log
-
-      - name: Test UI-triggered update flow
-        if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
-        run: |
-          set -o pipefail
-          chmod +x ./apps/app/scripts/e2e-update-ui.sh
-          ./apps/app/scripts/e2e-update-ui.sh \
-            "${{ steps.server.outputs.ip }}" \
-            "${{ steps.install.outputs.api_key }}" \
-            "${{ github.head_ref || github.ref_name }}" \
-            "${{ github.repository }}" 2>&1 | tee /tmp/e2e-update-ui.log
 
       - name: Cleanup broken branch
         if: always() && steps.broken.outputs.branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,12 +625,14 @@ jobs:
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         id: predata
         run: |
+          set -o pipefail
           chmod +x ./apps/app/scripts/e2e-upgrade-create.sh
           ./apps/app/scripts/e2e-upgrade-create.sh "${{ steps.server.outputs.ip }}" "${{ steps.install.outputs.api_key }}" 2>&1 | tee /tmp/e2e-create.log
 
       - name: Upgrade to PR branch
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
+          set -o pipefail
           BRANCH="${{ github.head_ref || github.ref_name }}"
           REPO="${{ github.repository }}"
 
@@ -722,6 +724,7 @@ jobs:
       - name: Reset to release version for rollback and UI tests
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
+          set -o pipefail
           TAG="${{ steps.release.outputs.tag }}"
           echo "Resetting to release $TAG..."
 
@@ -757,6 +760,7 @@ jobs:
       - name: Test rollback on build failure
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
+          set -o pipefail
           chmod +x ./apps/app/scripts/e2e-update-rollback.sh
           ./apps/app/scripts/e2e-update-rollback.sh \
             "${{ steps.server.outputs.ip }}" \
@@ -767,6 +771,7 @@ jobs:
       - name: Test rollback on migration failure
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
+          set -o pipefail
           chmod +x ./apps/app/scripts/e2e-update-rollback.sh
           ./apps/app/scripts/e2e-update-rollback.sh \
             "${{ steps.server.outputs.ip }}" \
@@ -778,6 +783,7 @@ jobs:
       - name: Test UI-triggered update flow
         if: steps.release.outputs.skip != 'true' && steps.server.outputs.skipped != 'true'
         run: |
+          set -o pipefail
           chmod +x ./apps/app/scripts/e2e-update-ui.sh
           ./apps/app/scripts/e2e-update-ui.sh \
             "${{ steps.server.outputs.ip }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
         if: steps.server.outputs.skipped != 'true'
         env:
           E2E_BRANCH: ${{ github.head_ref || github.ref_name }}
-          E2E_BATCH_SIZE: 3
+          E2E_BATCH_SIZE: 2
         run: |
           chmod +x ./apps/app/scripts/e2e-test.sh
           set -o pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Script knobs (standardized):
 - `E2E_GROUPS` - comma-separated explicit groups (e.g. `01-basic,28-oauth`)
 - `E2E_GROUP_GLOB` - shell glob for group files (default: `group-*.sh`)
 - `E2E_START_STAGGER_SEC` - delay between group starts
-- `E2E_BATCH_SIZE` - max concurrent groups (full CI uses 3)
+- `E2E_BATCH_SIZE` - max concurrent groups (full CI uses 2)
 
 Image-pull resiliency knobs:
 - `FROST_IMAGE_PULL_RETRIES` (default `3`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,8 @@ E2E_START_STAGGER_SEC=0 ./apps/app/scripts/e2e-test.sh <ip> <api-key>           
 Script knobs (standardized):
 - `E2E_GROUPS` - comma-separated explicit groups (e.g. `01-basic,28-oauth`)
 - `E2E_GROUP_GLOB` - shell glob for group files (default: `group-*.sh`)
-- `E2E_START_STAGGER_SEC` - delay between group starts in a batch
-- `E2E_BATCH_SIZE` - groups per batch (CI defaults to 4)
+- `E2E_START_STAGGER_SEC` - delay between group starts
+- `E2E_BATCH_SIZE` - max concurrent groups (full CI uses 3)
 
 Image-pull resiliency knobs:
 - `FROST_IMAGE_PULL_RETRIES` (default `3`)

--- a/apps/app/scripts/e2e-local-managed.sh
+++ b/apps/app/scripts/e2e-local-managed.sh
@@ -92,7 +92,7 @@ echo "Managed Local E2E"
 echo "========================================"
 echo "Port: $PORT"
 echo "Data dir: $DATA_DIR"
-echo "Batch size: $BATCH_SIZE"
+echo "Max concurrency: $BATCH_SIZE"
 echo "Retry failed groups: ${E2E_RETRY_FAILED:-0}"
 if [ -n "${E2E_GROUPS:-}" ]; then
   echo "Groups: $E2E_GROUPS"

--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 E2E_DIR="$SCRIPT_DIR/e2e"
+source "$SCRIPT_DIR/e2e-runner.sh"
 
 BATCH_SIZE="${2:-${E2E_BATCH_SIZE:-2}}"
 PORT=${FROST_PORT:-3000}
@@ -206,67 +207,21 @@ if [ "${#ALL_GROUPS[@]}" -eq 0 ]; then
 fi
 
 TOTAL=${#ALL_GROUPS[@]}
-BATCH=0
 FAILED_GROUP_PATHS=()
 FAILED_GROUP_NAMES=()
 
 echo ""
 if [ -n "$GROUP_LIST" ]; then
-  echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, groups: $GROUP_LIST)"
+  echo "Running $TOTAL test groups (max concurrency: $BATCH_SIZE, groups: $GROUP_LIST)"
 else
-  echo "Running $TOTAL test groups (batch size: $BATCH_SIZE, glob: $GROUP_GLOB)"
+  echo "Running $TOTAL test groups (max concurrency: $BATCH_SIZE, glob: $GROUP_GLOB)"
 fi
 echo "Start stagger: ${START_STAGGER_SEC}s"
 echo "Data dir: $FROST_DATA_DIR"
 echo ""
 
-for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
-  BATCH=$((BATCH+1))
-  PIDS=()
-  GROUP_PATHS=()
-  GROUP_NAMES=()
-  START_TIMES=()
-
-  END=$((i + BATCH_SIZE))
-  [ $END -gt $TOTAL ] && END=$TOTAL
-
-  echo "--- Batch $BATCH: groups $((i+1))-$END ---"
-
-  for ((j=i; j<END; j++)); do
-    group="${ALL_GROUPS[$j]}"
-    GROUP_NAME=$(basename "$group" .sh)
-    GROUP_PATHS+=("$group")
-    GROUP_NAMES+=("$GROUP_NAME")
-    START_TIMES+=("$(date +%s)")
-    "$group" &
-    PIDS+=($!)
-    if [ "$START_STAGGER_SEC" -gt 0 ] && [ "$j" -lt $((END - 1)) ]; then
-      sleep "$START_STAGGER_SEC"
-    fi
-  done
-
-  for k in "${!PIDS[@]}"; do
-    PID=${PIDS[$k]}
-    GROUP_PATH=${GROUP_PATHS[$k]}
-    GROUP=${GROUP_NAMES[$k]}
-    START_TS=${START_TIMES[$k]}
-    if wait "$PID"; then
-      END_TS=$(date +%s)
-      DURATION=$((END_TS - START_TS))
-      echo "✓ $GROUP passed"
-      record_result "$GROUP" "passed" "$DURATION" 1
-    else
-      END_TS=$(date +%s)
-      DURATION=$((END_TS - START_TS))
-      echo "✗ $GROUP FAILED"
-      record_result "$GROUP" "failed" "$DURATION" 1
-      FAILED=1
-      FAILED_GROUP_PATHS+=("$GROUP_PATH")
-      FAILED_GROUP_NAMES+=("$GROUP")
-    fi
-  done
-  echo ""
-done
+run_e2e_group_pool
+echo ""
 
 if [ "$FAILED" -ne 0 ] && [ "$RETRY_FAILED" = "1" ] && [ "${#FAILED_GROUP_PATHS[@]}" -gt 0 ]; then
   echo "Retrying failed groups once..."

--- a/apps/app/scripts/e2e-runner.sh
+++ b/apps/app/scripts/e2e-runner.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+run_e2e_group_pool() {
+  if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ ]] || [ "$BATCH_SIZE" -lt 1 ]; then
+    echo "Error: batch size must be a positive integer, got '$BATCH_SIZE'"
+    exit 1
+  fi
+
+  local total=${#ALL_GROUPS[@]}
+  local poll_sec="${E2E_SCHEDULER_POLL_SEC:-0.2}"
+  local next_group=0
+  local pids=()
+  local group_paths=()
+  local group_names=()
+  local start_times=()
+
+  FAILED=0
+  FAILED_GROUP_PATHS=()
+  FAILED_GROUP_NAMES=()
+
+  echo "Scheduling with max concurrency: $BATCH_SIZE"
+  echo ""
+
+  while [ "$next_group" -lt "$total" ] || [ "${#pids[@]}" -gt 0 ]; do
+    while [ "${#pids[@]}" -lt "$BATCH_SIZE" ] && [ "$next_group" -lt "$total" ]; do
+      local group_path="${ALL_GROUPS[$next_group]}"
+      local group_name
+      group_name=$(basename "$group_path" .sh)
+
+      echo "--- Starting $group_name ($((next_group + 1))/$total, running $((${#pids[@]} + 1))/$BATCH_SIZE) ---"
+      group_paths+=("$group_path")
+      group_names+=("$group_name")
+      start_times+=("$(date +%s)")
+      "$group_path" &
+      pids+=($!)
+      next_group=$((next_group + 1))
+
+      if [ "$START_STAGGER_SEC" -gt 0 ] && [ "$next_group" -lt "$total" ] && [ "${#pids[@]}" -lt "$BATCH_SIZE" ]; then
+        sleep "$START_STAGGER_SEC"
+      fi
+    done
+
+    [ "${#pids[@]}" -eq 0 ] && continue
+
+    sleep "$poll_sec"
+
+    local old_pids=("${pids[@]}")
+    local old_group_paths=("${group_paths[@]}")
+    local old_group_names=("${group_names[@]}")
+    local old_start_times=("${start_times[@]}")
+
+    pids=()
+    group_paths=()
+    group_names=()
+    start_times=()
+
+    local index
+    for index in "${!old_pids[@]}"; do
+      local pid="${old_pids[$index]}"
+      local finished_group_path="${old_group_paths[$index]}"
+      local finished_group="${old_group_names[$index]}"
+      local started_at="${old_start_times[$index]}"
+
+      if kill -0 "$pid" 2>/dev/null; then
+        pids+=("$pid")
+        group_paths+=("$finished_group_path")
+        group_names+=("$finished_group")
+        start_times+=("$started_at")
+        continue
+      fi
+
+      local ended_at
+      local duration
+      ended_at=$(date +%s)
+      duration=$((ended_at - started_at))
+
+      if wait "$pid"; then
+        echo "✓ $finished_group passed"
+        if declare -F record_result > /dev/null; then
+          record_result "$finished_group" "passed" "$duration" 1
+        fi
+      else
+        echo "✗ $finished_group FAILED"
+        if declare -F record_result > /dev/null; then
+          record_result "$finished_group" "failed" "$duration" 1
+        fi
+        FAILED=1
+        FAILED_GROUP_PATHS+=("$finished_group_path")
+        FAILED_GROUP_NAMES+=("$finished_group")
+      fi
+    done
+  done
+}

--- a/apps/app/scripts/e2e-test.sh
+++ b/apps/app/scripts/e2e-test.sh
@@ -19,10 +19,11 @@ export API_KEY
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 E2E_DIR="$SCRIPT_DIR/e2e"
+source "$SCRIPT_DIR/e2e-runner.sh"
 
 echo "========================================"
 echo "Running E2E tests against http://$SERVER_IP:3000"
-echo "Batch size: $BATCH_SIZE groups at a time"
+echo "Max concurrency: $BATCH_SIZE groups"
 echo "Start stagger: ${START_STAGGER_SEC}s"
 echo "========================================"
 echo ""
@@ -77,7 +78,6 @@ else
 fi
 
 TOTAL=${#ALL_GROUPS[@]}
-BATCH=0
 
 if [ "$TOTAL" -eq 0 ]; then
   if [ -n "$GROUP_LIST" ]; then
@@ -91,39 +91,8 @@ fi
 echo "Total test groups: $TOTAL"
 echo ""
 
-for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
-  BATCH=$((BATCH+1))
-  PIDS=()
-  GROUP_NAMES=()
-
-  END=$((i + BATCH_SIZE))
-  [ $END -gt $TOTAL ] && END=$TOTAL
-
-  echo "--- Batch $BATCH: groups $((i+1))-$END ---"
-
-  for ((j=i; j<END; j++)); do
-    group="${ALL_GROUPS[$j]}"
-    GROUP_NAME=$(basename "$group" .sh)
-    GROUP_NAMES+=("$GROUP_NAME")
-    "$group" &
-    PIDS+=($!)
-    if [ "$START_STAGGER_SEC" -gt 0 ] && [ "$j" -lt $((END - 1)) ]; then
-      sleep "$START_STAGGER_SEC"
-    fi
-  done
-
-  for k in "${!PIDS[@]}"; do
-    PID=${PIDS[$k]}
-    GROUP=${GROUP_NAMES[$k]}
-    if wait "$PID"; then
-      echo "✓ $GROUP passed"
-    else
-      echo "✗ $GROUP FAILED"
-      FAILED=1
-    fi
-  done
-  echo ""
-done
+run_e2e_group_pool
+echo ""
 
 if [ "$FAILED" -eq 0 ]; then
   echo "========================================"

--- a/apps/app/scripts/e2e-update-rollback.sh
+++ b/apps/app/scripts/e2e-update-rollback.sh
@@ -73,6 +73,30 @@ remote() {
   ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR root@$SERVER_IP "$@"
 }
 
+ensure_remote_sqlite() {
+  ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR root@$SERVER_IP bash -s <<'REMOTE'
+set -e
+
+if command -v sqlite3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service >/dev/null 2>&1 || true
+
+for attempt in 1 2 3 4; do
+  if apt-get update && apt-get install -y sqlite3; then
+    exit 0
+  fi
+
+  sleep_sec=$((attempt * 10))
+  echo "sqlite3 install failed (attempt $attempt/4), retrying in ${sleep_sec}s..."
+  sleep "$sleep_sec"
+done
+
+exit 1
+REMOTE
+}
+
 create_broken_update_target() {
   ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR root@$SERVER_IP \
     "BROKEN_BRANCH='$BROKEN_BRANCH' MODE='$MODE' bash -s" <<'REMOTE'
@@ -151,7 +175,7 @@ remote "sed -i 's|curl -fsSL https://raw.githubusercontent.com/.*/update.sh.*bas
 
 echo ""
 echo "=== Ensuring sqlite3 is installed ==="
-remote "which sqlite3 > /dev/null 2>&1 || (apt-get update && apt-get install -y sqlite3)"
+ensure_remote_sqlite
 
 if [ "$MODE" = "migration" ]; then
   echo ""

--- a/apps/app/scripts/e2e-update-ui.sh
+++ b/apps/app/scripts/e2e-update-ui.sh
@@ -66,10 +66,34 @@ remote() {
   ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR root@$SERVER_IP "$@"
 }
 
+ensure_remote_sqlite() {
+  ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR root@$SERVER_IP bash -s <<'REMOTE'
+set -e
+
+if command -v sqlite3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service >/dev/null 2>&1 || true
+
+for attempt in 1 2 3 4; do
+  if apt-get update && apt-get install -y sqlite3; then
+    exit 0
+  fi
+
+  sleep_sec=$((attempt * 10))
+  echo "sqlite3 install failed (attempt $attempt/4), retrying in ${sleep_sec}s..."
+  sleep "$sleep_sec"
+done
+
+exit 1
+REMOTE
+}
+
 echo ""
 echo "=== Recording current state ==="
 CURRENT_VERSION=$(api "$BASE_URL/api/health" | jq -r '.version')
-CURRENT_COMMIT=$(remote "cd /opt/frost && git rev-parse HEAD")
+CURRENT_COMMIT=$(remote "cd /opt/frost && git rev-parse HEAD 2>/dev/null || echo tarball-install")
 echo "Current version: $CURRENT_VERSION"
 echo "Current commit: $CURRENT_COMMIT"
 
@@ -81,8 +105,20 @@ fi
 echo ""
 echo "=== Preparing repo to pull from target branch ==="
 remote "cd /opt/frost && \
-  git remote set-url origin https://github.com/${REPO}.git && \
+  git config --global --add safe.directory /opt/frost && \
+  if [ ! -d .git ]; then \
+    echo 'Initializing git repo (tarball installation detected)'; \
+    git init && \
+    git remote add origin https://github.com/${REPO}.git; \
+  else \
+    git remote set-url origin https://github.com/${REPO}.git; \
+  fi && \
   git fetch origin ${TARGET_BRANCH}:refs/remotes/origin/main -f"
+
+echo ""
+echo "=== Copying current update.sh to server ==="
+scp -o StrictHostKeyChecking=no -o LogLevel=ERROR "$(dirname "$0")/../../../update.sh" root@$SERVER_IP:/opt/frost/update.sh
+remote "chmod +x /opt/frost/update.sh"
 
 echo ""
 echo "=== Disabling git fetch in update.sh to preserve our fake origin/main ==="
@@ -96,7 +132,7 @@ remote "sed -i 's|curl -fsSL https://raw.githubusercontent.com/.*/update.sh.*bas
 
 echo ""
 echo "=== Ensuring sqlite3 is installed ==="
-remote "which sqlite3 > /dev/null 2>&1 || (apt-get update && apt-get install -y sqlite3)"
+ensure_remote_sqlite
 
 echo ""
 echo "=== Faking available update in settings ==="

--- a/apps/app/scripts/e2e/group-20-setup.sh
+++ b/apps/app/scripts/e2e/group-20-setup.sh
@@ -3,6 +3,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+SETTINGS_LOCK="settings"
+acquire_e2e_lock "$SETTINGS_LOCK" || fail "Could not acquire settings lock"
+trap 'release_e2e_lock "$SETTINGS_LOCK"' EXIT
+
 log "=== Web-based setup flow ==="
 
 log "Checking if setup is already complete (e.g. upgrade scenario)..."

--- a/apps/app/scripts/e2e/group-28-oauth.sh
+++ b/apps/app/scripts/e2e/group-28-oauth.sh
@@ -3,6 +3,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+SETTINGS_LOCK="settings"
+acquire_e2e_lock "$SETTINGS_LOCK" || fail "Could not acquire settings lock"
+trap 'release_e2e_lock "$SETTINGS_LOCK"' EXIT
+
 log "=== OAuth 2.1 flow ==="
 
 log "Step 1: Check well-known metadata..."

--- a/apps/app/scripts/e2e/group-29-mcp.sh
+++ b/apps/app/scripts/e2e/group-29-mcp.sh
@@ -3,6 +3,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+SETTINGS_LOCK="settings"
+acquire_e2e_lock "$SETTINGS_LOCK" || fail "Could not acquire settings lock"
+trap 'release_e2e_lock "$SETTINGS_LOCK"' EXIT
+
 log "=== MCP endpoint auth ==="
 
 log "Step 1: Get Bearer token via OAuth flow..."

--- a/apps/app/src/lib/docker.test.ts
+++ b/apps/app/src/lib/docker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { getDatabaseTargetReservedPorts } from "./docker";
+
+describe("getDatabaseTargetReservedPorts", function describeReservedPorts() {
+  test("returns provider and runtime host ports", function testReservedPorts() {
+    const ports = getDatabaseTargetReservedPorts({
+      providerRefJson: JSON.stringify({
+        containerName: "frost-db-test-main",
+        hostPort: 10001,
+        runtimeHostPort: 10002,
+      }),
+      runtimeHostPort: 10003,
+    });
+
+    expect(ports.sort()).toEqual([10001, 10002, 10003]);
+  });
+
+  test("deduplicates repeated ports", function testDeduplicatePorts() {
+    const ports = getDatabaseTargetReservedPorts({
+      providerRefJson: JSON.stringify({
+        containerName: "frost-db-test-main",
+        hostPort: 10001,
+        runtimeHostPort: 10001,
+      }),
+      runtimeHostPort: 10001,
+    });
+
+    expect(ports).toEqual([10001]);
+  });
+
+  test("ignores malformed provider refs", function testMalformedProviderRef() {
+    const ports = getDatabaseTargetReservedPorts({
+      providerRefJson: "{not-json",
+      runtimeHostPort: 10003,
+    });
+
+    expect(ports).toEqual([10003]);
+  });
+});

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -688,6 +688,49 @@ function isMissingTableError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("no such table");
 }
 
+function getNumericProperty(
+  value: unknown,
+  property: "hostPort" | "runtimeHostPort",
+): number | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const propertyValue = (value as Record<string, unknown>)[property];
+  return typeof propertyValue === "number" ? propertyValue : null;
+}
+
+export function getDatabaseTargetReservedPorts(input: {
+  providerRefJson: string;
+  runtimeHostPort?: number | null;
+}): number[] {
+  let providerRef: unknown;
+  try {
+    providerRef = JSON.parse(input.providerRefJson);
+  } catch {
+    providerRef = null;
+  }
+
+  const ports = new Set<number>();
+  const hostPort = getNumericProperty(providerRef, "hostPort");
+  const providerRuntimeHostPort = getNumericProperty(
+    providerRef,
+    "runtimeHostPort",
+  );
+
+  if (hostPort !== null) {
+    ports.add(hostPort);
+  }
+  if (providerRuntimeHostPort !== null) {
+    ports.add(providerRuntimeHostPort);
+  }
+  if (typeof input.runtimeHostPort === "number") {
+    ports.add(input.runtimeHostPort);
+  }
+
+  return [...ports];
+}
+
 export async function getAvailablePort(
   start: number = 10000,
   end: number = 20000,
@@ -740,6 +783,23 @@ export async function getAvailablePort(
     for (const r of replicas) {
       if (r.hostPort) {
         usedPorts.add(r.hostPort);
+      }
+    }
+  } catch (error) {
+    if (!isMissingTableError(error)) {
+      throw error;
+    }
+  }
+
+  try {
+    const databaseTargets = await db
+      .selectFrom("databaseTargets")
+      .select(["providerRefJson", "runtimeHostPort"])
+      .where("lifecycleStatus", "in", ["active", "stopped"])
+      .execute();
+    for (const target of databaseTargets) {
+      for (const port of getDatabaseTargetReservedPorts(target)) {
+        usedPorts.add(port);
       }
     }
   } catch (error) {

--- a/update.sh
+++ b/update.sh
@@ -570,7 +570,7 @@ if [ "$GIT_MODE" = true ]; then
   done
   if [ "$BUILD_OK" = false ]; then
     error "Build failed after 3 attempts"
-    exit 1
+    cleanup_on_failure
   fi
 
   log "Backing up SQLite database..."

--- a/update.sh
+++ b/update.sh
@@ -332,6 +332,14 @@ ensure_zfs_branching_setup() {
   fi
 }
 
+rebuild_restored_git_version() {
+  log "Restoring dependencies for previous version..."
+  bun install --frozen-lockfile 2>&1 || return 1
+
+  log "Rebuilding previous version..."
+  NEXT_TELEMETRY_DISABLED=1 bun run build 2>&1 || return 1
+}
+
 cleanup_on_failure() {
   error "Update failed!"
   echo "failed" > "$UPDATE_RESULT"
@@ -342,6 +350,9 @@ cleanup_on_failure() {
     PREV_COMMIT=$(cat "$BACKUP_DIR/commit")
     cd "$FROST_DIR"
     git reset --hard "$PREV_COMMIT" 2>/dev/null || true
+    if ! rebuild_restored_git_version; then
+      error "Failed to rebuild previous version after rollback"
+    fi
     rm -rf "$BACKUP_DIR"
   elif [ -d "$BACKUP_DIR" ]; then
     log "Restoring previous version..."


### PR DESCRIPTION
## What changed

- Replace fixed e2e batches with one shared max-concurrency scheduler so a new group starts as soon as a slot frees up.
- Keep the same selected e2e groups and same concurrency limits; this only removes idle time inside each batch.
- Add settings locks to setup/OAuth/MCP groups that mutate shared settings and can now overlap.
- Shorten Hetzner capacity retries for push/PR runs while keeping the longer retry window for manual workflow dispatch.
- Limit upgrade smoke pre-pulls to the images that smoke groups actually need.
- Reserve active/stopped database target host ports when allocating service ports, with unit coverage.

## Why

The e2e-vps job was spending most of its test step waiting for the slowest group in each fixed batch before starting the next batch. CI logs from run 28119260436 modeled the full e2e test step at roughly 10m today; the same group durations under max-concurrency scheduling model to roughly 5m for that step without dropping groups.

The faster local scheduling also exposed a real confidence issue: service deployments could choose a port already held by a database target. The allocator now accounts for database target ports too.

## Local validation

- `bash -n apps/app/scripts/e2e-runner.sh apps/app/scripts/e2e-test.sh apps/app/scripts/e2e-local.sh apps/app/scripts/e2e-local-managed.sh apps/app/scripts/e2e/group-20-setup.sh apps/app/scripts/e2e/group-28-oauth.sh apps/app/scripts/e2e/group-29-mcp.sh`
- fake pooled-runner harness with one intentional failure
- fake `e2e-test.sh` remote harness with two passing groups
- `bun --cwd apps/app test src/lib/docker.test.ts`
- `bun run typecheck`
- `bun run lint` (passes; existing unrelated Biome warnings remain)
- `E2E_REPORT_PATH=/tmp/frost-e2e-smoke-pooled.json E2E_START_STAGGER_SEC=0 E2E_GROUPS='01-basic,04-update,10-race,20-setup,28-oauth,29-mcp' bash ./apps/app/scripts/e2e-local-managed.sh 4`
- `E2E_REPORT_PATH=/tmp/frost-e2e-port-collision-pooled.json E2E_START_STAGGER_SEC=0 E2E_GROUPS='05-ssl,06-webhook,07-database,08-rollback,09-healthcheck' bash ./apps/app/scripts/e2e-local-managed.sh 4`

## Timing to verify in CI

Baseline from run 28119260436:

- `e2e-vps (amd64)`: ~18m total, with `Run E2E tests` ~10m
- `e2e-upgrade (amd64)`: ~12m total
- arm64 no-capacity paths: ~18m before skipping

Expected first-pass target:

- `e2e-vps (amd64)` closer to ~13m if setup time is unchanged
- arm64 no-capacity skip paths closer to ~2-3m on push/PR
- upgrade smoke modestly faster from narrower pre-pull
