### PR TITLE
fix(storage): repair garage and minio templates

### DIFF
--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -38,6 +38,7 @@ import {
 } from "./docker";
 import { syncCaddyConfig as syncCaddyConfigDefault } from "./domains";
 import { loadFrostConfig, mergeConfigWithService } from "./frost-config";
+import { prepareGarageRuntime } from "./garage-runtime";
 import {
   createCommitStatus,
   generateInstallationToken,
@@ -47,7 +48,6 @@ import {
 } from "./github";
 import { detectIcon, detectIconFromImage } from "./icon-detector";
 import { newDeploymentClaimId, newDeploymentId, newReplicaId } from "./id";
-import { getDataDir } from "./paths";
 import { runCommand } from "./process-runner";
 import { shellEscape } from "./shell-escape";
 import { slugify } from "./slugify";
@@ -59,29 +59,6 @@ import { updateEnvironmentPRComment } from "./webhook";
 const execAsync = promisify(exec);
 
 const REPOS_PATH = join(process.cwd(), "repos");
-const GARAGE_CONFIG_CONTENT = `metadata_dir = "/var/lib/garage/meta"
-data_dir = "/var/lib/garage/data"
-db_engine = "sqlite"
-replication_factor = 1
-rpc_bind_addr = "[::1]:3901"
-rpc_public_addr = "127.0.0.1:3901"
-rpc_secret = "0000000000000000000000000000000000000000000000000000000000000000"
-
-[s3_api]
-s3_region = "garage"
-api_bind_addr = "[::]:3900"
-root_domain = ".s3.garage.localhost"
-
-[s3_web]
-bind_addr = "[::1]:3902"
-root_domain = ".web.garage.localhost"
-index = "index.html"
-
-[admin]
-api_bind_addr = "[::1]:3903"
-admin_token = "unused-admin-token"
-metrics_token = "unused-metrics-token"
-`;
 
 if (!existsSync(REPOS_PATH)) {
   mkdirSync(REPOS_PATH, { recursive: true });
@@ -653,27 +630,6 @@ function buildFrostEnvVars(
     vars.FROST_GIT_BRANCH = gitInfo.branch;
   }
   return vars;
-}
-
-function isGarageImage(imageUrl: string | null): boolean {
-  if (!imageUrl) {
-    return false;
-  }
-  const normalized = imageUrl.toLowerCase();
-  return (
-    normalized === "dxflrs/garage" ||
-    normalized.startsWith("dxflrs/garage:") ||
-    normalized === "docker.io/dxflrs/garage" ||
-    normalized.startsWith("docker.io/dxflrs/garage:")
-  );
-}
-
-function prepareGarageConfigFile(serviceId: string): string {
-  const dir = join(getDataDir(), "garage", serviceId);
-  mkdirSync(dir, { recursive: true });
-  const configPath = join(dir, "garage.toml");
-  writeFileSync(configPath, GARAGE_CONFIG_CONTENT);
-  return configPath;
 }
 
 async function cancelActiveDeployments(
@@ -1540,16 +1496,11 @@ async function runServiceDeployment(
     let entrypoint = commandOptions.entrypoint;
     let command = commandOptions.command;
 
-    if (isGarageImage(service.imageUrl) && !service.command) {
-      const configPath = prepareGarageConfigFile(service.id);
-      fileMounts = [
-        {
-          hostPath: configPath,
-          containerPath: "/etc/garage.toml",
-        },
-      ];
-      command = ["/garage", "server", "--single-node", "--default-bucket"];
-      await appendLog(deploymentId, "Garage single-node config mounted\n");
+    const garageRuntime = prepareGarageRuntime(service);
+    if (garageRuntime) {
+      fileMounts = garageRuntime.fileMounts;
+      command = garageRuntime.command;
+      await appendLog(deploymentId, garageRuntime.logMessage);
     }
 
     const isPostgres = service.imageUrl?.includes("postgres") ?? false;

--- a/apps/app/src/lib/garage-runtime.test.ts
+++ b/apps/app/src/lib/garage-runtime.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { buildGarageConfigContent, isGarageImage } from "./garage-runtime";
+
+describe("buildGarageConfigContent", function describeGarageConfig() {
+  test("exposes Garage auxiliary listeners on the project network", function testGarageListeners() {
+    const content = buildGarageConfigContent();
+
+    expect(content).toContain('rpc_bind_addr = "[::]:3901"');
+    expect(content).toContain('bind_addr = "[::]:3902"');
+    expect(content).toContain('api_bind_addr = "[::]:3903"');
+  });
+
+  test("uses generated environment tokens instead of hardcoded admin tokens", function testGarageTokens() {
+    const content = buildGarageConfigContent();
+
+    expect(content).not.toContain("unused-admin-token");
+    expect(content).not.toContain("unused-metrics-token");
+    expect(content).not.toContain("admin_token =");
+    expect(content).not.toContain("metrics_token =");
+  });
+});
+
+describe("isGarageImage", function describeGarageImageDetection() {
+  test("matches supported Garage image names", function testGarageImages() {
+    expect(isGarageImage("dxflrs/garage")).toBe(true);
+    expect(isGarageImage("dxflrs/garage:v2.3.0")).toBe(true);
+    expect(isGarageImage("docker.io/dxflrs/garage")).toBe(true);
+    expect(isGarageImage("docker.io/dxflrs/garage:v2.3.0")).toBe(true);
+  });
+
+  test("ignores non-Garage image names", function testNonGarageImages() {
+    expect(isGarageImage(null)).toBe(false);
+    expect(isGarageImage("myorg/garage-dashboard")).toBe(false);
+    expect(isGarageImage("minio/minio")).toBe(false);
+  });
+});

--- a/apps/app/src/lib/garage-runtime.ts
+++ b/apps/app/src/lib/garage-runtime.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { FileMount } from "./docker";
+import { getDataDir } from "./paths";
+
+const GARAGE_CONFIG_CONTAINER_PATH = "/etc/garage.toml";
+const GARAGE_SERVER_COMMAND = [
+  "/garage",
+  "server",
+  "--single-node",
+  "--default-bucket",
+];
+
+interface GarageRuntimeService {
+  id: string;
+  imageUrl: string | null;
+  command?: string | null;
+}
+
+export interface GarageRuntimeConfig {
+  fileMounts: FileMount[];
+  command: string[];
+  logMessage: string;
+}
+
+export function buildGarageConfigContent(): string {
+  return `metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+replication_factor = 1
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".web.garage.localhost"
+index = "index.html"
+
+[admin]
+api_bind_addr = "[::]:3903"
+`;
+}
+
+export function isGarageImage(imageUrl: string | null): boolean {
+  if (!imageUrl) {
+    return false;
+  }
+  const normalized = imageUrl.toLowerCase();
+  return (
+    normalized === "dxflrs/garage" ||
+    normalized.startsWith("dxflrs/garage:") ||
+    normalized === "docker.io/dxflrs/garage" ||
+    normalized.startsWith("docker.io/dxflrs/garage:")
+  );
+}
+
+function prepareGarageConfigFile(serviceId: string): string {
+  const dir = join(getDataDir(), "garage", serviceId);
+  mkdirSync(dir, { recursive: true });
+  const configPath = join(dir, "garage.toml");
+  writeFileSync(configPath, buildGarageConfigContent());
+  return configPath;
+}
+
+export function prepareGarageRuntime(
+  service: GarageRuntimeService,
+): GarageRuntimeConfig | null {
+  if (!isGarageImage(service.imageUrl) || service.command) {
+    return null;
+  }
+
+  const configPath = prepareGarageConfigFile(service.id);
+  return {
+    fileMounts: [
+      {
+        hostPath: configPath,
+        containerPath: GARAGE_CONFIG_CONTAINER_PATH,
+      },
+    ],
+    command: [...GARAGE_SERVER_COMMAND],
+    logMessage: "Garage single-node config mounted\n",
+  };
+}

--- a/apps/app/src/lib/icon-detector.test.ts
+++ b/apps/app/src/lib/icon-detector.test.ts
@@ -27,6 +27,10 @@ describe("detectIconFromImage", () => {
     expect(detectIconFromImage("nginx:alpine")).toBe("nginx");
   });
 
+  test("detects Garage from image url", () => {
+    expect(detectIconFromImage("dxflrs/garage:v2.3.0")).toBe("garage");
+  });
+
   test("detects node from image url", () => {
     expect(detectIconFromImage("node:20-alpine")).toBe("nodedotjs");
   });

--- a/apps/app/src/lib/icon-detector.ts
+++ b/apps/app/src/lib/icon-detector.ts
@@ -1,69 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-
-const IMAGE_PATTERNS: Array<{ pattern: string; icon: string }> = [
-  { pattern: "next", icon: "nextdotjs" },
-  { pattern: "nuxt", icon: "nuxtdotjs" },
-  { pattern: "remix", icon: "remix" },
-  { pattern: "astro", icon: "astro" },
-  { pattern: "svelte", icon: "svelte" },
-  { pattern: "angular", icon: "angular" },
-  { pattern: "vue", icon: "vuedotjs" },
-  { pattern: "react", icon: "react" },
-  { pattern: "express", icon: "express" },
-  { pattern: "fastify", icon: "fastify" },
-  { pattern: "hono", icon: "hono" },
-  { pattern: "django", icon: "django" },
-  { pattern: "flask", icon: "flask" },
-  { pattern: "fastapi", icon: "fastapi" },
-  { pattern: "rails", icon: "rubyonrails" },
-  { pattern: "laravel", icon: "laravel" },
-  { pattern: "spring", icon: "spring" },
-
-  { pattern: "node", icon: "nodedotjs" },
-  { pattern: "bun", icon: "bun" },
-  { pattern: "deno", icon: "deno" },
-  { pattern: "python", icon: "python" },
-  { pattern: "golang", icon: "go" },
-  { pattern: "rust", icon: "rust" },
-  { pattern: "ruby", icon: "ruby" },
-  { pattern: "php", icon: "php" },
-  { pattern: "openjdk", icon: "openjdk" },
-  { pattern: "dotnet", icon: "dotnet" },
-
-  { pattern: "postgres", icon: "postgresql" },
-  { pattern: "mysql", icon: "mysql" },
-  { pattern: "mariadb", icon: "mariadb" },
-  { pattern: "mongo", icon: "mongodb" },
-  { pattern: "redis", icon: "redis" },
-  { pattern: "nginx", icon: "nginx" },
-  { pattern: "caddy", icon: "caddy" },
-  { pattern: "rabbitmq", icon: "rabbitmq" },
-  { pattern: "elasticsearch", icon: "elasticsearch" },
-  { pattern: "minio", icon: "minio" },
-  { pattern: "clickhouse", icon: "clickhouse" },
-
-  { pattern: "meilisearch", icon: "meilisearch" },
-  { pattern: "pocketbase", icon: "pocketbase" },
-  { pattern: "grafana", icon: "grafana" },
-  { pattern: "ghost", icon: "ghost" },
-  { pattern: "strapi", icon: "strapi" },
-  { pattern: "wordpress", icon: "wordpress" },
-  { pattern: "n8n", icon: "n8n" },
-  { pattern: "hasura", icon: "hasura" },
-  { pattern: "umami", icon: "umami" },
-  { pattern: "plausible", icon: "plausibleanalytics" },
-];
+import { detectServiceIconFromImage } from "./service-icons";
 
 function detectFromDockerfile(content: string): string | null {
   const fromMatch = content.toLowerCase().match(/^from\s+([^\s:]+)/m);
   if (!fromMatch) return null;
 
   const baseImage = fromMatch[1];
-  for (const { pattern, icon } of IMAGE_PATTERNS) {
-    if (baseImage.includes(pattern)) return icon;
-  }
-  return null;
+  return detectServiceIconFromImage(baseImage);
 }
 
 function detectFromPackageJson(content: object): string | null {
@@ -123,9 +67,5 @@ export function detectIcon(
 }
 
 export function detectIconFromImage(imageUrl: string): string | null {
-  const lower = imageUrl.toLowerCase();
-  for (const { pattern, icon } of IMAGE_PATTERNS) {
-    if (lower.includes(pattern)) return icon;
-  }
-  return null;
+  return detectServiceIconFromImage(imageUrl);
 }

--- a/apps/app/src/lib/service-icons.ts
+++ b/apps/app/src/lib/service-icons.ts
@@ -1,0 +1,162 @@
+export interface ServiceIconDefinition {
+  icon: string;
+  keywords?: string[];
+  imagePatterns?: string[];
+  dark?: boolean;
+  customUrl?: string;
+}
+
+export const FALLBACK_SERVICE_ICON_URL =
+  "https://cdn.simpleicons.org/docker/666666";
+
+export const SERVICE_ICON_DEFINITIONS: ServiceIconDefinition[] = [
+  { icon: "nextdotjs", imagePatterns: ["next"], dark: true },
+  { icon: "nuxtdotjs", imagePatterns: ["nuxt"] },
+  { icon: "remix", imagePatterns: ["remix"] },
+  { icon: "astro", imagePatterns: ["astro"] },
+  { icon: "svelte", imagePatterns: ["svelte"] },
+  { icon: "angular", imagePatterns: ["angular"] },
+  { icon: "vuedotjs", imagePatterns: ["vue"] },
+  { icon: "react", imagePatterns: ["react"] },
+  { icon: "express", imagePatterns: ["express"] },
+  { icon: "fastify", imagePatterns: ["fastify"] },
+  { icon: "hono", imagePatterns: ["hono"] },
+  { icon: "django", imagePatterns: ["django"] },
+  { icon: "flask", imagePatterns: ["flask"] },
+  { icon: "fastapi", imagePatterns: ["fastapi"] },
+  { icon: "rubyonrails", imagePatterns: ["rails"] },
+  { icon: "laravel", imagePatterns: ["laravel"] },
+  { icon: "spring", imagePatterns: ["spring"] },
+
+  { icon: "nodedotjs", keywords: ["node"], imagePatterns: ["node"] },
+  { icon: "bun", imagePatterns: ["bun"] },
+  { icon: "deno", imagePatterns: ["deno"] },
+  { icon: "python", keywords: ["python"], imagePatterns: ["python"] },
+  { icon: "go", imagePatterns: ["golang"] },
+  { icon: "rust", imagePatterns: ["rust"] },
+  { icon: "ruby", imagePatterns: ["ruby"] },
+  { icon: "php", imagePatterns: ["php"] },
+  { icon: "openjdk", imagePatterns: ["openjdk"] },
+  { icon: "dotnet", imagePatterns: ["dotnet"] },
+
+  {
+    icon: "postgresql",
+    keywords: ["postgres", "pg"],
+    imagePatterns: ["postgres"],
+  },
+  { icon: "mysql", keywords: ["mysql"], imagePatterns: ["mysql"] },
+  { icon: "mariadb", keywords: ["mariadb"], imagePatterns: ["mariadb"] },
+  { icon: "mongodb", keywords: ["mongo"], imagePatterns: ["mongo"] },
+  { icon: "redis", keywords: ["redis"], imagePatterns: ["redis"] },
+  { icon: "nginx", keywords: ["nginx"], imagePatterns: ["nginx"] },
+  { icon: "caddy", imagePatterns: ["caddy"] },
+  { icon: "rabbitmq", keywords: ["rabbitmq"], imagePatterns: ["rabbitmq"] },
+  {
+    icon: "elasticsearch",
+    keywords: ["elasticsearch", "elastic"],
+    imagePatterns: ["elasticsearch"],
+  },
+  { icon: "minio", keywords: ["minio"], imagePatterns: ["minio"] },
+  {
+    icon: "garage",
+    keywords: ["garage", "dxflrs/garage"],
+    imagePatterns: ["garage"],
+    customUrl: "https://garagehq.deuxfleurs.fr/images/garage-logo.svg",
+  },
+  {
+    icon: "clickhouse",
+    keywords: ["clickhouse"],
+    imagePatterns: ["clickhouse"],
+  },
+
+  {
+    icon: "meilisearch",
+    keywords: ["meilisearch", "meili"],
+    imagePatterns: ["meilisearch"],
+  },
+  {
+    icon: "pocketbase",
+    keywords: ["pocketbase"],
+    imagePatterns: ["pocketbase"],
+  },
+  { icon: "grafana", keywords: ["grafana"], imagePatterns: ["grafana"] },
+  { icon: "ghost", keywords: ["ghost"], imagePatterns: ["ghost"], dark: true },
+  { icon: "strapi", keywords: ["strapi"], imagePatterns: ["strapi"] },
+  { icon: "wordpress", keywords: ["wordpress"], imagePatterns: ["wordpress"] },
+  { icon: "n8n", keywords: ["n8n"], imagePatterns: ["n8n"] },
+  { icon: "hasura", keywords: ["hasura"], imagePatterns: ["hasura"] },
+  { icon: "umami", keywords: ["umami"], imagePatterns: ["umami"], dark: true },
+  {
+    icon: "plausibleanalytics",
+    keywords: ["plausible"],
+    imagePatterns: ["plausible"],
+  },
+];
+
+const SERVICE_ICON_BY_ICON = new Map(
+  SERVICE_ICON_DEFINITIONS.map(function toIconEntry(definition) {
+    return [definition.icon, definition];
+  }),
+);
+
+function includesAny(value: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (value.includes(pattern)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function valuesIncludeAny(values: string[], patterns: string[]): boolean {
+  for (const value of values) {
+    if (includesAny(value, patterns)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function getServiceIconUrl(icon: string): string {
+  const definition = SERVICE_ICON_BY_ICON.get(icon);
+  if (definition?.customUrl) {
+    return definition.customUrl;
+  }
+
+  const color = definition?.dark ? "/ffffff" : "";
+  return `https://cdn.simpleicons.org/${icon}${color}`;
+}
+
+export function isRegisteredServiceIcon(icon: string): boolean {
+  return SERVICE_ICON_BY_ICON.has(icon);
+}
+
+export function detectServiceIconFromKeywords(values: string[]): string | null {
+  const normalizedValues = values.map(function normalizeValue(value) {
+    return value.toLowerCase();
+  });
+
+  for (const definition of SERVICE_ICON_DEFINITIONS) {
+    const keywords = definition.keywords ?? [];
+    if (valuesIncludeAny(normalizedValues, keywords)) {
+      return definition.icon;
+    }
+  }
+
+  return null;
+}
+
+export function detectServiceIconFromImage(imageUrl: string): string | null {
+  const lower = imageUrl.toLowerCase();
+
+  for (const definition of SERVICE_ICON_DEFINITIONS) {
+    const imagePatterns = definition.imagePatterns ?? [];
+    if (includesAny(lower, imagePatterns)) {
+      return definition.icon;
+    }
+  }
+
+  return null;
+}

--- a/apps/app/src/lib/service-logo.test.ts
+++ b/apps/app/src/lib/service-logo.test.ts
@@ -33,6 +33,12 @@ describe("getServiceIcon", () => {
     );
   });
 
+  test("returns custom icon url for Garage", () => {
+    expect(getServiceIcon({ name: "garage", icon: "garage" })).toBe(
+      "https://garagehq.deuxfleurs.fr/images/garage-logo.svg",
+    );
+  });
+
   test("falls back to keyword detection when no icon field", () => {
     const service = { name: "postgres-db", imageUrl: "postgres:17" };
     expect(getServiceIcon(service)).toBe(
@@ -47,6 +53,9 @@ describe("getServiceIcon", () => {
     expect(getServiceIcon({ name: "my-postgres" })).toBe(
       "https://cdn.simpleicons.org/postgresql",
     );
+    expect(getServiceIcon({ name: "garage" })).toBe(
+      "https://garagehq.deuxfleurs.fr/images/garage-logo.svg",
+    );
   });
 
   test("keyword detection from image url", () => {
@@ -56,6 +65,9 @@ describe("getServiceIcon", () => {
     expect(getServiceIcon({ name: "store", imageUrl: "mongo:7" })).toBe(
       "https://cdn.simpleicons.org/mongodb",
     );
+    expect(
+      getServiceIcon({ name: "storage", imageUrl: "dxflrs/garage:v2.3.0" }),
+    ).toBe("https://garagehq.deuxfleurs.fr/images/garage-logo.svg");
   });
 
   test("returns null when no match found", () => {

--- a/apps/app/src/lib/service-logo.ts
+++ b/apps/app/src/lib/service-logo.ts
@@ -1,55 +1,28 @@
+import {
+  detectServiceIconFromKeywords,
+  FALLBACK_SERVICE_ICON_URL,
+  getServiceIconUrl,
+} from "./service-icons";
+
 interface ServiceLike {
   name: string;
   icon?: string | null;
   imageUrl?: string | null;
 }
 
-const KEYWORD_ICONS: Array<{ keywords: string[]; icon: string }> = [
-  { keywords: ["postgres", "pg"], icon: "postgresql" },
-  { keywords: ["redis"], icon: "redis" },
-  { keywords: ["mysql"], icon: "mysql" },
-  { keywords: ["mongo"], icon: "mongodb" },
-  { keywords: ["mariadb"], icon: "mariadb" },
-  { keywords: ["nginx"], icon: "nginx" },
-  { keywords: ["node"], icon: "nodedotjs" },
-  { keywords: ["python"], icon: "python" },
-  { keywords: ["rabbitmq"], icon: "rabbitmq" },
-  { keywords: ["elasticsearch", "elastic"], icon: "elasticsearch" },
-  { keywords: ["minio"], icon: "minio" },
-  { keywords: ["meilisearch", "meili"], icon: "meilisearch" },
-  { keywords: ["pocketbase"], icon: "pocketbase" },
-  { keywords: ["grafana"], icon: "grafana" },
-  { keywords: ["ghost"], icon: "ghost" },
-  { keywords: ["strapi"], icon: "strapi" },
-  { keywords: ["wordpress"], icon: "wordpress" },
-  { keywords: ["n8n"], icon: "n8n" },
-  { keywords: ["hasura"], icon: "hasura" },
-  { keywords: ["umami"], icon: "umami" },
-  { keywords: ["plausible"], icon: "plausibleanalytics" },
-  { keywords: ["clickhouse"], icon: "clickhouse" },
-];
-
-const DARK_ICONS = new Set(["ghost", "umami", "nextdotjs"]);
-
-function getIconUrl(icon: string): string {
-  const color = DARK_ICONS.has(icon) ? "/ffffff" : "";
-  return `https://cdn.simpleicons.org/${icon}${color}`;
-}
-
-export const FALLBACK_ICON = "https://cdn.simpleicons.org/docker/666666";
+export const FALLBACK_ICON = FALLBACK_SERVICE_ICON_URL;
 
 export function getServiceIcon(service: ServiceLike): string | null {
   if (service.icon) {
-    return getIconUrl(service.icon);
+    return getServiceIconUrl(service.icon);
   }
 
-  const imageUrl = service.imageUrl?.toLowerCase() ?? "";
-  const name = service.name.toLowerCase();
-
-  for (const { keywords, icon } of KEYWORD_ICONS) {
-    if (keywords.some((kw) => imageUrl.includes(kw) || name.includes(kw))) {
-      return getIconUrl(icon);
-    }
+  const icon = detectServiceIconFromKeywords([
+    service.imageUrl ?? "",
+    service.name,
+  ]);
+  if (icon) {
+    return getServiceIconUrl(icon);
   }
 
   return null;

--- a/apps/app/src/lib/templates.test.ts
+++ b/apps/app/src/lib/templates.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
+import { isRegisteredServiceIcon } from "./service-icons";
 import {
   buildConnectionString,
   clearTemplateCache,
@@ -10,11 +11,20 @@ import {
   getTemplate,
   getTemplates,
   resolveTemplateServices,
+  type Template,
 } from "./templates";
 
 beforeEach(() => {
   clearTemplateCache();
 });
+
+function requireTemplate(id: string): Template {
+  const template = getTemplate(id);
+  if (!template) {
+    throw new Error(`${id} template not found`);
+  }
+  return template;
+}
 
 describe("getTemplates", () => {
   it("loads all templates from yaml files", () => {
@@ -133,9 +143,7 @@ describe("getManagedTemplateDatabases", () => {
 
 describe("resolveTemplateServices", () => {
   it("resolves a single-service template", () => {
-    const template = getTemplate("postgres");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("postgres"));
     expect(resolved.length).toBe(1);
 
     const svc = resolved[0];
@@ -146,9 +154,7 @@ describe("resolveTemplateServices", () => {
   });
 
   it("generates credentials for env vars", () => {
-    const template = getTemplate("postgres");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("postgres"));
     const svc = resolved[0];
 
     const passwordEnv = svc.envVars.find((e) => e.key === "POSTGRES_PASSWORD");
@@ -225,9 +231,7 @@ describe("resolveTemplateServices", () => {
   });
 
   it("sets main service correctly in project templates", () => {
-    const template = getTemplate("plausible");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("plausible"));
 
     const mainServices = resolved.filter((s) => s.isMain);
     expect(mainServices.length).toBe(1);
@@ -235,9 +239,7 @@ describe("resolveTemplateServices", () => {
   });
 
   it("parses volumes correctly", () => {
-    const template = getTemplate("postgres");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("postgres"));
     const svc = resolved[0];
 
     expect(svc.volumes.length).toBe(1);
@@ -246,51 +248,79 @@ describe("resolveTemplateServices", () => {
   });
 
   it("includes icon from postgres template", () => {
-    const template = getTemplate("postgres");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("postgres"));
     expect(resolved[0].icon).toBe("postgresql");
   });
 
   it("includes icon from redis template", () => {
-    const template = getTemplate("redis");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("redis"));
     expect(resolved[0].icon).toBe("redis");
   });
 
   it("includes icon from mysql template", () => {
-    const template = getTemplate("mysql");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("mysql"));
     expect(resolved[0].icon).toBe("mysql");
   });
 
   it("includes icon from mongo template", () => {
-    const template = getTemplate("mongo");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("mongo"));
     expect(resolved[0].icon).toBe("mongodb");
   });
 
   it("includes icon from nginx template", () => {
-    const template = getTemplate("nginx");
-    expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    const resolved = resolveTemplateServices(requireTemplate("nginx"));
     expect(resolved[0].icon).toBe("nginx");
   });
 
-  it("starts minio through the minio binary", () => {
-    const template = getTemplate("minio");
-    expect(template).toBeDefined();
-    if (!template) {
-      throw new Error("minio template not found");
+  it("uses registered service icons for every template", function testTemplateIcons() {
+    const unknownIcons: string[] = [];
+
+    for (const template of getTemplates()) {
+      for (const [serviceName, service] of Object.entries(template.services)) {
+        if (service.icon && !isRegisteredServiceIcon(service.icon)) {
+          unknownIcons.push(`${template.id}/${serviceName}:${service.icon}`);
+        }
+      }
     }
 
-    const resolved = resolveTemplateServices(template);
+    expect(unknownIcons).toEqual([]);
+  });
+
+  it("includes icon from garage template", function testGarageTemplateIcon() {
+    const resolved = resolveTemplateServices(requireTemplate("garage"));
+    expect(resolved[0].icon).toBe("garage");
+  });
+
+  it("starts minio through the minio binary", () => {
+    const resolved = resolveTemplateServices(requireTemplate("minio"));
     expect(resolved[0].command).toBe(
       'minio server /data --console-address ":9001"',
     );
+  });
+
+  it("exposes the minio console as the public template port", () => {
+    const resolved = resolveTemplateServices(requireTemplate("minio"));
+
+    expect(resolved[0].port).toBe(9001);
+    expect(resolved[0].healthCheckPath).toBe("/");
+    expect(
+      resolved[0].envVars.find((envVar) => envVar.key === "S3_ENDPOINT")?.value,
+    ).toBe("http://minio:9000");
+  });
+
+  it("generates garage admin tokens for companion management tools", () => {
+    const resolved = resolveTemplateServices(requireTemplate("garage"));
+    const adminToken = resolved[0].envVars.find(
+      (envVar) => envVar.key === "GARAGE_ADMIN_TOKEN",
+    );
+    const metricsToken = resolved[0].envVars.find(
+      (envVar) => envVar.key === "GARAGE_METRICS_TOKEN",
+    );
+
+    expect(adminToken?.generated).toBe(true);
+    expect(adminToken?.value.length).toBe(32);
+    expect(metricsToken?.generated).toBe(true);
+    expect(metricsToken?.value.length).toBe(32);
   });
 });
 

--- a/apps/app/templates/services/garage.yaml
+++ b/apps/app/templates/services/garage.yaml
@@ -7,8 +7,12 @@ services:
   garage:
     image: dxflrs/garage:v2.3.0
     port: 3900
-    icon: amazons3
+    icon: garage
     environment:
+      GARAGE_ADMIN_TOKEN:
+        generated: password
+      GARAGE_METRICS_TOKEN:
+        generated: password
       GARAGE_DEFAULT_ACCESS_KEY:
         generated: password
       GARAGE_DEFAULT_SECRET_KEY:

--- a/apps/app/templates/services/minio.yaml
+++ b/apps/app/templates/services/minio.yaml
@@ -6,15 +6,24 @@ docs: https://min.io/docs/minio/linux/index.html
 services:
   minio:
     image: minio/minio:RELEASE.2025-01-20T14-49-07Z
-    port: 9000
+    port: 9001
     icon: minio
     command: minio server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: admin
       MINIO_ROOT_PASSWORD:
         generated: password
+      AWS_ACCESS_KEY_ID: admin
+      AWS_SECRET_ACCESS_KEY: ${minio.MINIO_ROOT_PASSWORD}
+      AWS_DEFAULT_REGION: us-east-1
+      S3_ENDPOINT: http://minio:9000
+      S3_BUCKET: default-bucket
+      S3_REGION: us-east-1
+      S3_ACCESS_KEY_ID: admin
+      S3_SECRET_ACCESS_KEY: ${minio.MINIO_ROOT_PASSWORD}
+      S3_FORCE_PATH_STYLE: "true"
     volumes:
       - data:/data
     health_check:
-      path: /minio/health/live
+      path: /
       timeout: 30


### PR DESCRIPTION
## Summary
- expose MinIO Console on the template URL while preserving the internal S3 endpoint helpers
- configure Garage with generated admin/metrics tokens and reachable auxiliary listeners
- add the official Garage logo through a shared service icon registry
- move Garage runtime config wiring out of the deployer and into a focused helper

## Validation
- bun --cwd apps/app test src/lib/service-logo.test.ts src/lib/icon-detector.test.ts src/lib/templates.test.ts src/lib/garage-runtime.test.ts src/lib/deployer-lock.test.ts
- bun run typecheck
- bun run lint

Note: lint exits cleanly and still reports the pre-existing MCP arrow-function warnings.