### PR TITLE
feat(object-storage): add bucket file browser

### DIFF
--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/bucket-access-keys-tab.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/bucket-access-keys-tab.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ObjectStorageAccessKey } from "./types";
+
+interface BucketAccessKeysTabProps {
+  accessKeys: ObjectStorageAccessKey[];
+  onRevokeKey(accessKeyId: string): void;
+}
+
+export function BucketAccessKeysTab({
+  accessKeys,
+  onRevokeKey,
+}: BucketAccessKeysTabProps) {
+  return (
+    <div className="divide-y divide-neutral-800">
+      {accessKeys.map(function renderAccessKey(accessKey) {
+        return (
+          <div
+            key={accessKey.id}
+            className="flex items-center justify-between gap-3 py-2"
+          >
+            <div className="min-w-0">
+              <p className="truncate text-sm text-neutral-200">
+                {accessKey.name}
+              </p>
+              <p className="truncate font-mono text-xs text-neutral-500">
+                {accessKey.accessKeyId} · {accessKey.permissions}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={function handleRevokeKey() {
+                onRevokeKey(accessKey.id);
+              }}
+              title="Revoke key"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        );
+      })}
+      {accessKeys.length === 0 && (
+        <p className="py-4 text-sm text-neutral-500">
+          No access keys for this bucket.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/bucket-files-tab.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/bucket-files-tab.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { FileIcon, Loader2, Plus, RefreshCw, Search } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useObjectStorageBucketObjects } from "@/hooks/use-object-storages";
+import { CopyButton } from "./copy-field";
+import type { ObjectStorageBucket } from "./types";
+
+interface BucketFilesTabProps {
+  objectStorageId: string;
+  bucket: ObjectStorageBucket;
+}
+
+function formatObjectSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let size = bytes / 1024;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  const unit = units[unitIndex] ?? "TB";
+  return `${size >= 10 ? size.toFixed(0) : size.toFixed(1)} ${unit}`;
+}
+
+function formatObjectDate(timestamp: number | null): string {
+  if (timestamp === null) {
+    return "Unknown";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(timestamp);
+}
+
+function normalizePrefixInput(prefix: string): string {
+  return prefix.trim().replace(/^\/+/, "");
+}
+
+export function BucketFilesTab({
+  objectStorageId,
+  bucket,
+}: BucketFilesTabProps) {
+  const [objectPrefixInput, setObjectPrefixInput] = useState("");
+  const [objectPrefix, setObjectPrefix] = useState("");
+  const bucketObjectsQuery = useObjectStorageBucketObjects({
+    objectStorageId,
+    bucketId: bucket.id,
+    prefix: objectPrefix,
+  });
+  const bucketObjects =
+    bucketObjectsQuery.data?.pages.flatMap(function getPageObjects(page) {
+      return page.objects;
+    }) ?? [];
+
+  function handleObjectPrefixSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setObjectPrefix(normalizePrefixInput(objectPrefixInput));
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={handleObjectPrefixSubmit}
+        className="grid gap-2 md:grid-cols-[minmax(0,1fr)_6rem_2.25rem]"
+      >
+        <Label htmlFor="object_storage_object_prefix" className="sr-only">
+          Prefix
+        </Label>
+        <Input
+          id="object_storage_object_prefix"
+          value={objectPrefixInput}
+          onChange={function handleObjectPrefixInputChange(event) {
+            setObjectPrefixInput(event.target.value);
+          }}
+          placeholder="uploads/"
+          className="border-neutral-700 bg-neutral-800 font-mono text-sm text-neutral-100"
+        />
+        <Button type="submit" variant="secondary" className="w-full">
+          <Search className="h-4 w-4" />
+          Filter
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled={bucketObjectsQuery.isFetching}
+          onClick={function handleRefreshObjects() {
+            void bucketObjectsQuery.refetch();
+          }}
+          title="Refresh files"
+        >
+          {bucketObjectsQuery.isFetching ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+        </Button>
+      </form>
+
+      {bucketObjectsQuery.isError && (
+        <p className="rounded-md border border-red-900/60 bg-red-950/20 p-3 text-sm text-red-200">
+          {bucketObjectsQuery.error instanceof Error
+            ? bucketObjectsQuery.error.message
+            : "Failed to load files"}
+        </p>
+      )}
+
+      {bucketObjectsQuery.isLoading && !bucketObjectsQuery.data && (
+        <div className="flex items-center gap-2 py-4 text-sm text-neutral-500">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading files
+        </div>
+      )}
+
+      {!bucketObjectsQuery.isLoading &&
+        bucketObjects.length === 0 &&
+        !bucketObjectsQuery.isError && (
+          <p className="py-4 text-sm text-neutral-500">No files found.</p>
+        )}
+
+      {bucketObjects.length > 0 && (
+        <div className="overflow-hidden rounded-md border border-neutral-800">
+          <div className="grid grid-cols-[minmax(0,1fr)_5rem_2rem] gap-3 border-b border-neutral-800 bg-neutral-950/60 px-3 py-2 text-xs text-neutral-500 md:grid-cols-[minmax(0,1fr)_7rem_10rem_2rem]">
+            <span>Key</span>
+            <span className="text-right">Size</span>
+            <span className="hidden md:block">Modified</span>
+            <span className="sr-only">Copy</span>
+          </div>
+          <div className="divide-y divide-neutral-800">
+            {bucketObjects.map(function renderObject(object) {
+              return (
+                <div
+                  key={object.key}
+                  className="grid grid-cols-[minmax(0,1fr)_5rem_2rem] items-center gap-3 px-3 py-2 md:grid-cols-[minmax(0,1fr)_7rem_10rem_2rem]"
+                >
+                  <div className="flex min-w-0 items-center gap-2">
+                    <FileIcon className="h-4 w-4 shrink-0 text-neutral-500" />
+                    <code className="truncate text-xs text-neutral-200">
+                      {object.key}
+                    </code>
+                  </div>
+                  <span className="text-right text-xs text-neutral-400">
+                    {formatObjectSize(object.size)}
+                  </span>
+                  <span className="hidden truncate text-xs text-neutral-500 md:block">
+                    {formatObjectDate(object.lastModified)}
+                  </span>
+                  <CopyButton value={object.key} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {bucketObjectsQuery.hasNextPage && (
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full"
+          disabled={bucketObjectsQuery.isFetchingNextPage}
+          onClick={function handleLoadMoreObjects() {
+            void bucketObjectsQuery.fetchNextPage();
+          }}
+        >
+          {bucketObjectsQuery.isFetchingNextPage ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4" />
+          )}
+          Load more
+        </Button>
+      )}
+    </>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/buckets-card.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/buckets-card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { FileIcon, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ObjectStorageBucket } from "./types";
+
+interface BucketsCardProps {
+  buckets: ObjectStorageBucket[];
+  selectedBucketId: string;
+  onSelectBucket(bucketId: string): void;
+  onDeleteBucket(bucketId: string): void;
+  onOpenCreateBucket(): void;
+}
+
+export function BucketsCard({
+  buckets,
+  selectedBucketId,
+  onSelectBucket,
+  onDeleteBucket,
+  onOpenCreateBucket,
+}: BucketsCardProps) {
+  return (
+    <Card className="border-neutral-800 bg-neutral-900">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-sm text-neutral-200">Buckets</CardTitle>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onOpenCreateBucket}
+          >
+            <Plus className="h-4 w-4" />
+            New bucket
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="divide-y divide-neutral-800">
+          {buckets.map(function renderBucket(bucket) {
+            return (
+              <div
+                key={bucket.id}
+                className="flex items-center justify-between gap-3 py-2"
+              >
+                <Button
+                  type="button"
+                  variant={
+                    bucket.id === selectedBucketId ? "secondary" : "ghost"
+                  }
+                  className="min-w-0 flex-1 justify-start px-2"
+                  onClick={function handleSelectBucket() {
+                    onSelectBucket(bucket.id);
+                  }}
+                  title="View files"
+                >
+                  <FileIcon className="h-4 w-4 text-neutral-500" />
+                  <code className="truncate text-sm">{bucket.name}</code>
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={function handleDeleteBucket() {
+                    onDeleteBucket(bucket.id);
+                  }}
+                  title="Delete bucket"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            );
+          })}
+          {buckets.length === 0 && (
+            <p className="py-4 text-sm text-neutral-500">No buckets yet.</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/connection-card.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/connection-card.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SettingRow } from "./copy-field";
+import type { ObjectStorageConnection } from "./types";
+
+export function ObjectStorageConnectionCard({
+  connection,
+}: {
+  connection: ObjectStorageConnection;
+}) {
+  return (
+    <Card className="border-neutral-800 bg-neutral-900">
+      <CardHeader>
+        <CardTitle className="text-sm text-neutral-200">
+          S3 Connection
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        <SettingRow
+          label="External endpoint"
+          value={connection.endpoint ?? "Deploying"}
+        />
+        <SettingRow
+          label="Internal endpoint"
+          value={connection.internalEndpoint}
+        />
+        <SettingRow label="Region" value={connection.region} />
+        <SettingRow
+          label="Force path style"
+          value={String(connection.forcePathStyle)}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/copy-field.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/copy-field.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Copy } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+export function CopyButton({ value }: { value: string }) {
+  async function handleCopy() {
+    await navigator.clipboard.writeText(value);
+    toast.success("Copied");
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="h-7 w-7"
+      onClick={handleCopy}
+      title="Copy"
+    >
+      <Copy className="h-3.5 w-3.5" />
+    </Button>
+  );
+}
+
+export function SettingRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-neutral-800 py-2 last:border-0">
+      <span className="text-xs text-neutral-500">{label}</span>
+      <div className="flex min-w-0 items-center gap-2">
+        <code className="truncate text-xs text-neutral-200">{value}</code>
+        <CopyButton value={value} />
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/created-key-card.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/created-key-card.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CopyButton, SettingRow } from "./copy-field";
+import type { CreatedAccessKey } from "./types";
+
+function buildEnvBlock(snippets: CreatedAccessKey["snippets"]): string {
+  return snippets.env
+    .map(function formatEnv(envVar) {
+      return `${envVar.key}=${envVar.value}`;
+    })
+    .join("\n");
+}
+
+export function CreatedKeyCard({
+  createdKey,
+}: {
+  createdKey: CreatedAccessKey;
+}) {
+  const envBlock = buildEnvBlock(createdKey.snippets);
+
+  return (
+    <Card className="border-emerald-800/70 bg-emerald-950/20">
+      <CardHeader>
+        <CardTitle className="text-sm text-emerald-100">
+          Secret shown once
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <SettingRow
+          label="Access key"
+          value={createdKey.accessKey.accessKeyId}
+        />
+        <SettingRow label="Secret key" value={createdKey.secretAccessKey} />
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-neutral-400">Environment</p>
+            <CopyButton value={envBlock} />
+          </div>
+          <pre className="overflow-auto rounded-md border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-300">
+            {envBlock}
+          </pre>
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-neutral-400">AWS CLI</p>
+            <CopyButton value={createdKey.snippets.awsCli} />
+          </div>
+          <pre className="overflow-auto rounded-md border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-300">
+            {createdKey.snippets.awsCli}
+          </pre>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/object-storage-dialogs.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/object-storage-dialogs.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { KeyRound, Loader2, Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { AccessKeyPermission } from "./types";
+
+interface CreateBucketDialogProps {
+  open: boolean;
+  pending: boolean;
+  onOpenChange(open: boolean): void;
+  onCreateBucket(name: string): Promise<boolean>;
+}
+
+interface CreateAccessKeyDialogProps {
+  open: boolean;
+  pending: boolean;
+  bucketName: string | null;
+  disabled: boolean;
+  onOpenChange(open: boolean): void;
+  onCreateKey(input: {
+    name: string;
+    permissions: AccessKeyPermission;
+  }): Promise<boolean>;
+}
+
+export function CreateBucketDialog({
+  open,
+  pending,
+  onOpenChange,
+  onCreateBucket,
+}: CreateBucketDialogProps) {
+  const [bucketName, setBucketName] = useState("");
+
+  async function handleCreateBucket(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const name = bucketName.trim();
+    if (!name) {
+      return;
+    }
+
+    const created = await onCreateBucket(name);
+    if (created) {
+      setBucketName("");
+      onOpenChange(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-neutral-100">New bucket</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleCreateBucket} className="space-y-4">
+          <div className="grid gap-1.5">
+            <Label
+              htmlFor="object_storage_bucket_name"
+              className="text-xs text-neutral-400"
+            >
+              Name
+            </Label>
+            <Input
+              id="object_storage_bucket_name"
+              value={bucketName}
+              onChange={function handleBucketNameChange(event) {
+                setBucketName(event.target.value);
+              }}
+              placeholder="avatars"
+              className="border-neutral-700 bg-neutral-800 font-mono text-sm text-neutral-100"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={function handleCancel() {
+                onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending || !bucketName.trim()}>
+              {pending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              Create bucket
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function CreateAccessKeyDialog({
+  open,
+  pending,
+  bucketName,
+  disabled,
+  onOpenChange,
+  onCreateKey,
+}: CreateAccessKeyDialogProps) {
+  const [keyName, setKeyName] = useState("app");
+  const [permissions, setPermissions] =
+    useState<AccessKeyPermission>("read-write");
+
+  async function handleCreateKey(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const name = keyName.trim();
+    if (!name || disabled) {
+      return;
+    }
+
+    const created = await onCreateKey({ name, permissions });
+    if (created) {
+      setKeyName("app");
+      onOpenChange(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-neutral-100">
+            {bucketName ? `New key for ${bucketName}` : "New key"}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleCreateKey} className="space-y-4">
+          <div className="grid gap-3">
+            <div className="grid gap-1.5">
+              <Label
+                htmlFor="access_key_name"
+                className="text-xs text-neutral-400"
+              >
+                Name
+              </Label>
+              <Input
+                id="access_key_name"
+                value={keyName}
+                onChange={function handleKeyNameChange(event) {
+                  setKeyName(event.target.value);
+                }}
+                className="border-neutral-700 bg-neutral-800 text-neutral-100"
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <Label className="text-xs text-neutral-400">Permission</Label>
+              <Select
+                value={permissions}
+                onValueChange={function handlePermissionChange(value) {
+                  if (
+                    value === "read-only" ||
+                    value === "read-write" ||
+                    value === "full"
+                  ) {
+                    setPermissions(value);
+                  }
+                }}
+              >
+                <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-neutral-700 bg-neutral-800">
+                  <SelectItem value="read-only">Read only</SelectItem>
+                  <SelectItem value="read-write">Read/write</SelectItem>
+                  <SelectItem value="full">Full</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={function handleCancel() {
+                onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={pending || disabled || !keyName.trim()}
+            >
+              {pending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <KeyRound className="h-4 w-4" />
+              )}
+              Create key
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/selected-bucket-panel.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/selected-bucket-panel.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { KeyRound } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { BucketAccessKeysTab } from "./bucket-access-keys-tab";
+import { BucketFilesTab } from "./bucket-files-tab";
+import type { ObjectStorageAccessKey, ObjectStorageBucket } from "./types";
+
+type BucketPanelTab = "files" | "access-keys";
+
+interface SelectedBucketPanelProps {
+  objectStorageId: string;
+  bucket: ObjectStorageBucket | null;
+  accessKeys: ObjectStorageAccessKey[];
+  onOpenCreateKey(): void;
+  onRevokeKey(accessKeyId: string): void;
+}
+
+export function SelectedBucketPanel({
+  objectStorageId,
+  bucket,
+  accessKeys,
+  onOpenCreateKey,
+  onRevokeKey,
+}: SelectedBucketPanelProps) {
+  const [tab, setTab] = useState<BucketPanelTab>("files");
+
+  function handleTabChange(value: string) {
+    if (value === "files" || value === "access-keys") {
+      setTab(value);
+    }
+  }
+
+  return (
+    <Card className="border-neutral-800 bg-neutral-900">
+      <CardHeader>
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="text-sm text-neutral-200">Bucket</CardTitle>
+            {bucket ? (
+              <code className="block truncate text-xs text-neutral-500">
+                {bucket.name}
+              </code>
+            ) : (
+              <p className="text-xs text-neutral-500">No bucket selected</p>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {!bucket ? (
+          <p className="py-4 text-sm text-neutral-500">
+            Select a bucket to view files and keys.
+          </p>
+        ) : (
+          <Tabs
+            value={tab}
+            onValueChange={handleTabChange}
+            className="space-y-4"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <TabsList className="border border-neutral-800 bg-neutral-950">
+                <TabsTrigger value="files">Files</TabsTrigger>
+                <TabsTrigger value="access-keys">Access keys</TabsTrigger>
+              </TabsList>
+              {tab === "access-keys" && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={onOpenCreateKey}
+                >
+                  <KeyRound className="h-4 w-4" />
+                  New key
+                </Button>
+              )}
+            </div>
+
+            <TabsContent value="files" className="space-y-3">
+              <BucketFilesTab
+                objectStorageId={objectStorageId}
+                bucket={bucket}
+              />
+            </TabsContent>
+
+            <TabsContent value="access-keys" className="space-y-3">
+              <BucketAccessKeysTab
+                accessKeys={accessKeys}
+                onRevokeKey={onRevokeKey}
+              />
+            </TabsContent>
+          </Tabs>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/types.ts
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/_components/types.ts
@@ -1,0 +1,9 @@
+import type { ContractOutputs } from "@/contracts";
+
+export type ObjectStorageDetails = ContractOutputs["objectStorages"]["get"];
+export type ObjectStorageBucket = ObjectStorageDetails["buckets"][number];
+export type ObjectStorageAccessKey = ObjectStorageDetails["accessKeys"][number];
+export type ObjectStorageConnection = ObjectStorageDetails["connection"];
+export type CreatedAccessKey =
+  ContractOutputs["objectStorages"]["createAccessKey"];
+export type AccessKeyPermission = ObjectStorageAccessKey["permissions"];

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/page.tsx
@@ -1,12 +1,28 @@
 "use client";
 
-import { Copy, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
+import {
+  Copy,
+  FileIcon,
+  KeyRound,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+} from "lucide-react";
 import { useParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -16,12 +32,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ContractOutputs } from "@/contracts";
 import {
   useCreateObjectStorageAccessKey,
   useCreateObjectStorageBucket,
   useDeleteObjectStorageBucket,
   useObjectStorage,
+  useObjectStorageBucketObjects,
   useRevokeObjectStorageAccessKey,
 } from "@/hooks/use-object-storages";
 
@@ -67,6 +85,39 @@ function buildEnvBlock(snippets: AccessKeyResult["snippets"]): string {
     .join("\n");
 }
 
+function formatObjectSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let size = bytes / 1024;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  const unit = units[unitIndex] ?? "TB";
+  return `${size >= 10 ? size.toFixed(0) : size.toFixed(1)} ${unit}`;
+}
+
+function formatObjectDate(timestamp: number | null): string {
+  if (timestamp === null) {
+    return "Unknown";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(timestamp);
+}
+
+function normalizePrefixInput(prefix: string): string {
+  return prefix.trim().replace(/^\/+/, "");
+}
+
 export default function ObjectStorageOverviewPage() {
   const params = useParams();
   const objectStorageId = params.objectStorageId as string;
@@ -78,6 +129,11 @@ export default function ObjectStorageOverviewPage() {
   const [bucketName, setBucketName] = useState("");
   const [keyName, setKeyName] = useState("app");
   const [selectedBucketId, setSelectedBucketId] = useState("");
+  const [bucketTab, setBucketTab] = useState<"files" | "access-keys">("files");
+  const [objectPrefixInput, setObjectPrefixInput] = useState("");
+  const [objectPrefix, setObjectPrefix] = useState("");
+  const [createBucketOpen, setCreateBucketOpen] = useState(false);
+  const [createKeyOpen, setCreateKeyOpen] = useState(false);
   const [permissions, setPermissions] = useState<
     "read-only" | "read-write" | "full"
   >("read-write");
@@ -94,9 +150,36 @@ export default function ObjectStorageOverviewPage() {
 
   const defaultBucketId = useMemo(
     function getDefaultBucketId() {
-      return selectedBucketId || activeBuckets[0]?.id || "";
+      const selectedBucket = activeBuckets.find(function findBucket(bucket) {
+        return bucket.id === selectedBucketId;
+      });
+      return selectedBucket?.id ?? activeBuckets[0]?.id ?? "";
     },
     [activeBuckets, selectedBucketId],
+  );
+
+  const selectedBucket = useMemo(
+    function getSelectedBucket() {
+      return activeBuckets.find(function findBucket(bucket) {
+        return bucket.id === defaultBucketId;
+      });
+    },
+    [activeBuckets, defaultBucketId],
+  );
+
+  const bucketObjectsQuery = useObjectStorageBucketObjects({
+    objectStorageId,
+    bucketId: defaultBucketId,
+    prefix: objectPrefix,
+  });
+  const bucketObjects =
+    bucketObjectsQuery.data?.pages.flatMap(function getPageObjects(page) {
+      return page.objects;
+    }) ?? [];
+  const selectedBucketAccessKeys = activeKeys.filter(
+    function getSelectedBucketAccessKeys(accessKey) {
+      return accessKey.bucketId === defaultBucketId;
+    },
   );
 
   async function handleCreateBucket(event: React.FormEvent<HTMLFormElement>) {
@@ -106,8 +189,14 @@ export default function ObjectStorageOverviewPage() {
     }
 
     try {
-      await createBucketMutation.mutateAsync({ name: bucketName.trim() });
+      const bucket = await createBucketMutation.mutateAsync({
+        name: bucketName.trim(),
+      });
       setBucketName("");
+      setSelectedBucketId(bucket.id);
+      setObjectPrefix("");
+      setObjectPrefixInput("");
+      setCreateBucketOpen(false);
       toast.success("Bucket created");
     } catch (error) {
       toast.error(
@@ -123,12 +212,32 @@ export default function ObjectStorageOverviewPage() {
 
     try {
       await deleteBucketMutation.mutateAsync(bucketToDelete);
+      if (bucketToDelete === selectedBucketId) {
+        setSelectedBucketId("");
+      }
       setBucketToDelete(null);
       toast.success("Bucket deleted");
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to delete bucket",
       );
+    }
+  }
+
+  function handleSelectBucket(bucketId: string) {
+    setSelectedBucketId(bucketId);
+    setObjectPrefix("");
+    setObjectPrefixInput("");
+  }
+
+  function handleObjectPrefixSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setObjectPrefix(normalizePrefixInput(objectPrefixInput));
+  }
+
+  function handleBucketTabChange(value: string) {
+    if (value === "files" || value === "access-keys") {
+      setBucketTab(value);
     }
   }
 
@@ -146,6 +255,7 @@ export default function ObjectStorageOverviewPage() {
       });
       setCreatedKey(result);
       setKeyName("app");
+      setCreateKeyOpen(false);
       toast.success("Access key created");
     } catch (error) {
       toast.error(
@@ -239,34 +349,22 @@ export default function ObjectStorageOverviewPage() {
 
       <Card className="border-neutral-800 bg-neutral-900">
         <CardHeader>
-          <CardTitle className="text-sm text-neutral-200">Buckets</CardTitle>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm text-neutral-200">Buckets</CardTitle>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={function onOpenCreateBucket() {
+                setCreateBucketOpen(true);
+              }}
+            >
+              <Plus className="h-4 w-4" />
+              New bucket
+            </Button>
+          </div>
         </CardHeader>
         <CardContent className="space-y-3">
-          <form onSubmit={handleCreateBucket} className="flex gap-2">
-            <Label htmlFor="object_storage_bucket_name" className="sr-only">
-              Bucket name
-            </Label>
-            <Input
-              id="object_storage_bucket_name"
-              value={bucketName}
-              onChange={function onBucketNameChange(event) {
-                setBucketName(event.target.value);
-              }}
-              placeholder="avatars"
-              className="border-neutral-700 bg-neutral-800 font-mono text-sm text-neutral-100"
-            />
-            <Button
-              type="submit"
-              disabled={createBucketMutation.isPending}
-              title="Create bucket"
-            >
-              {createBucketMutation.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Plus className="h-4 w-4" />
-              )}
-            </Button>
-          </form>
           <div className="divide-y divide-neutral-800">
             {activeBuckets.map(function renderBucket(bucket) {
               return (
@@ -274,9 +372,20 @@ export default function ObjectStorageOverviewPage() {
                   key={bucket.id}
                   className="flex items-center justify-between gap-3 py-2"
                 >
-                  <code className="truncate text-sm text-neutral-200">
-                    {bucket.name}
-                  </code>
+                  <Button
+                    type="button"
+                    variant={
+                      bucket.id === defaultBucketId ? "secondary" : "ghost"
+                    }
+                    className="min-w-0 flex-1 justify-start px-2"
+                    onClick={function onSelectBucket() {
+                      handleSelectBucket(bucket.id);
+                    }}
+                    title="View files"
+                  >
+                    <FileIcon className="h-4 w-4 text-neutral-500" />
+                    <code className="truncate text-sm">{bucket.name}</code>
+                  </Button>
                   <Button
                     type="button"
                     variant="ghost"
@@ -292,143 +401,354 @@ export default function ObjectStorageOverviewPage() {
                 </div>
               );
             })}
+            {activeBuckets.length === 0 && (
+              <p className="py-4 text-sm text-neutral-500">No buckets yet.</p>
+            )}
           </div>
         </CardContent>
       </Card>
 
       <Card className="border-neutral-800 bg-neutral-900">
         <CardHeader>
-          <CardTitle className="text-sm text-neutral-200">
-            Access Keys
-          </CardTitle>
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <div className="min-w-0">
+              <CardTitle className="text-sm text-neutral-200">Bucket</CardTitle>
+              {selectedBucket ? (
+                <code className="block truncate text-xs text-neutral-500">
+                  {selectedBucket.name}
+                </code>
+              ) : (
+                <p className="text-xs text-neutral-500">No bucket selected</p>
+              )}
+            </div>
+          </div>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <form
-            onSubmit={handleCreateKey}
-            className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_11rem]"
-          >
+        <CardContent>
+          {!selectedBucket ? (
+            <p className="py-4 text-sm text-neutral-500">
+              Select a bucket to view files and keys.
+            </p>
+          ) : (
+            <Tabs
+              value={bucketTab}
+              onValueChange={handleBucketTabChange}
+              className="space-y-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <TabsList className="border border-neutral-800 bg-neutral-950">
+                  <TabsTrigger value="files">Files</TabsTrigger>
+                  <TabsTrigger value="access-keys">Access keys</TabsTrigger>
+                </TabsList>
+                {bucketTab === "access-keys" && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={function onOpenCreateKey() {
+                      setCreateKeyOpen(true);
+                    }}
+                  >
+                    <KeyRound className="h-4 w-4" />
+                    New key
+                  </Button>
+                )}
+              </div>
+
+              <TabsContent value="files" className="space-y-3">
+                <form
+                  onSubmit={handleObjectPrefixSubmit}
+                  className="grid gap-2 md:grid-cols-[minmax(0,1fr)_6rem_2.25rem]"
+                >
+                  <Label
+                    htmlFor="object_storage_object_prefix"
+                    className="sr-only"
+                  >
+                    Prefix
+                  </Label>
+                  <Input
+                    id="object_storage_object_prefix"
+                    value={objectPrefixInput}
+                    onChange={function onObjectPrefixChange(event) {
+                      setObjectPrefixInput(event.target.value);
+                    }}
+                    placeholder="uploads/"
+                    className="border-neutral-700 bg-neutral-800 font-mono text-sm text-neutral-100"
+                  />
+                  <Button type="submit" variant="secondary" className="w-full">
+                    <Search className="h-4 w-4" />
+                    Filter
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    disabled={bucketObjectsQuery.isFetching}
+                    onClick={function onRefreshObjects() {
+                      void bucketObjectsQuery.refetch();
+                    }}
+                    title="Refresh files"
+                  >
+                    {bucketObjectsQuery.isFetching ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-4 w-4" />
+                    )}
+                  </Button>
+                </form>
+
+                {bucketObjectsQuery.isError && (
+                  <p className="rounded-md border border-red-900/60 bg-red-950/20 p-3 text-sm text-red-200">
+                    {bucketObjectsQuery.error instanceof Error
+                      ? bucketObjectsQuery.error.message
+                      : "Failed to load files"}
+                  </p>
+                )}
+
+                {bucketObjectsQuery.isLoading && !bucketObjectsQuery.data && (
+                  <div className="flex items-center gap-2 py-4 text-sm text-neutral-500">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading files
+                  </div>
+                )}
+
+                {!bucketObjectsQuery.isLoading &&
+                  bucketObjects.length === 0 &&
+                  !bucketObjectsQuery.isError && (
+                    <p className="py-4 text-sm text-neutral-500">
+                      No files found.
+                    </p>
+                  )}
+
+                {bucketObjects.length > 0 && (
+                  <div className="overflow-hidden rounded-md border border-neutral-800">
+                    <div className="grid grid-cols-[minmax(0,1fr)_5rem_2rem] gap-3 border-b border-neutral-800 bg-neutral-950/60 px-3 py-2 text-xs text-neutral-500 md:grid-cols-[minmax(0,1fr)_7rem_10rem_2rem]">
+                      <span>Key</span>
+                      <span className="text-right">Size</span>
+                      <span className="hidden md:block">Modified</span>
+                      <span className="sr-only">Copy</span>
+                    </div>
+                    <div className="divide-y divide-neutral-800">
+                      {bucketObjects.map(function renderObject(object) {
+                        return (
+                          <div
+                            key={object.key}
+                            className="grid grid-cols-[minmax(0,1fr)_5rem_2rem] items-center gap-3 px-3 py-2 md:grid-cols-[minmax(0,1fr)_7rem_10rem_2rem]"
+                          >
+                            <div className="flex min-w-0 items-center gap-2">
+                              <FileIcon className="h-4 w-4 shrink-0 text-neutral-500" />
+                              <code className="truncate text-xs text-neutral-200">
+                                {object.key}
+                              </code>
+                            </div>
+                            <span className="text-right text-xs text-neutral-400">
+                              {formatObjectSize(object.size)}
+                            </span>
+                            <span className="hidden truncate text-xs text-neutral-500 md:block">
+                              {formatObjectDate(object.lastModified)}
+                            </span>
+                            <CopyButton value={object.key} />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {bucketObjectsQuery.hasNextPage && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="w-full"
+                    disabled={bucketObjectsQuery.isFetchingNextPage}
+                    onClick={function onLoadMoreObjects() {
+                      void bucketObjectsQuery.fetchNextPage();
+                    }}
+                  >
+                    {bucketObjectsQuery.isFetchingNextPage ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Plus className="h-4 w-4" />
+                    )}
+                    Load more
+                  </Button>
+                )}
+              </TabsContent>
+
+              <TabsContent value="access-keys" className="space-y-3">
+                <div className="divide-y divide-neutral-800">
+                  {selectedBucketAccessKeys.map(
+                    function renderAccessKey(accessKey) {
+                      return (
+                        <div
+                          key={accessKey.id}
+                          className="flex items-center justify-between gap-3 py-2"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm text-neutral-200">
+                              {accessKey.name}
+                            </p>
+                            <p className="truncate font-mono text-xs text-neutral-500">
+                              {accessKey.accessKeyId} · {accessKey.permissions}
+                            </p>
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={function onRevokeKey() {
+                              setKeyToRevoke(accessKey.id);
+                            }}
+                            title="Revoke key"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      );
+                    },
+                  )}
+                  {selectedBucketAccessKeys.length === 0 && (
+                    <p className="py-4 text-sm text-neutral-500">
+                      No access keys for this bucket.
+                    </p>
+                  )}
+                </div>
+              </TabsContent>
+            </Tabs>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={createBucketOpen} onOpenChange={setCreateBucketOpen}>
+        <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-neutral-100">New bucket</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleCreateBucket} className="space-y-4">
             <div className="grid gap-1.5">
               <Label
-                htmlFor="access_key_name"
+                htmlFor="object_storage_bucket_name"
                 className="text-xs text-neutral-400"
               >
                 Name
               </Label>
               <Input
-                id="access_key_name"
-                value={keyName}
-                onChange={function onKeyNameChange(event) {
-                  setKeyName(event.target.value);
+                id="object_storage_bucket_name"
+                value={bucketName}
+                onChange={function onBucketNameChange(event) {
+                  setBucketName(event.target.value);
                 }}
-                className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                placeholder="avatars"
+                className="border-neutral-700 bg-neutral-800 font-mono text-sm text-neutral-100"
               />
             </div>
-            <div className="grid gap-1.5">
-              <Label className="text-xs text-neutral-400">Bucket</Label>
-              <Select
-                value={defaultBucketId}
-                onValueChange={setSelectedBucketId}
-                disabled={activeBuckets.length === 0}
-              >
-                <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
-                  <SelectValue placeholder="Select bucket" />
-                </SelectTrigger>
-                <SelectContent className="border-neutral-700 bg-neutral-800">
-                  {activeBuckets.map(function renderBucketOption(bucket) {
-                    return (
-                      <SelectItem
-                        key={bucket.id}
-                        value={bucket.id}
-                        className="text-neutral-100 focus:bg-neutral-700"
-                      >
-                        {bucket.name}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="grid gap-1.5">
-              <Label className="text-xs text-neutral-400">Permission</Label>
-              <Select
-                value={permissions}
-                onValueChange={function onPermissionChange(value) {
-                  if (
-                    value === "read-only" ||
-                    value === "read-write" ||
-                    value === "full"
-                  ) {
-                    setPermissions(value);
-                  }
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={function onCancelCreateBucket() {
+                  setCreateBucketOpen(false);
                 }}
               >
-                <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="border-neutral-700 bg-neutral-800">
-                  <SelectItem value="read-only">Read only</SelectItem>
-                  <SelectItem value="read-write">Read/write</SelectItem>
-                  <SelectItem value="full">Full</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="grid gap-1.5">
-              <span aria-hidden="true" className="hidden h-4 md:block" />
+                Cancel
+              </Button>
               <Button
                 type="submit"
-                disabled={createKeyMutation.isPending || !defaultBucketId}
-                className="w-full"
+                disabled={createBucketMutation.isPending || !bucketName.trim()}
+              >
+                {createBucketMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                Create bucket
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={createKeyOpen} onOpenChange={setCreateKeyOpen}>
+        <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="text-neutral-100">
+              {selectedBucket
+                ? `New key for ${selectedBucket.name}`
+                : "New key"}
+            </DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleCreateKey} className="space-y-4">
+            <div className="grid gap-3">
+              <div className="grid gap-1.5">
+                <Label
+                  htmlFor="access_key_name"
+                  className="text-xs text-neutral-400"
+                >
+                  Name
+                </Label>
+                <Input
+                  id="access_key_name"
+                  value={keyName}
+                  onChange={function onKeyNameChange(event) {
+                    setKeyName(event.target.value);
+                  }}
+                  className="border-neutral-700 bg-neutral-800 text-neutral-100"
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label className="text-xs text-neutral-400">Permission</Label>
+                <Select
+                  value={permissions}
+                  onValueChange={function onPermissionChange(value) {
+                    if (
+                      value === "read-only" ||
+                      value === "read-write" ||
+                      value === "full"
+                    ) {
+                      setPermissions(value);
+                    }
+                  }}
+                >
+                  <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="border-neutral-700 bg-neutral-800">
+                    <SelectItem value="read-only">Read only</SelectItem>
+                    <SelectItem value="read-write">Read/write</SelectItem>
+                    <SelectItem value="full">Full</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={function onCancelCreateKey() {
+                  setCreateKeyOpen(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  createKeyMutation.isPending ||
+                  !defaultBucketId ||
+                  !keyName.trim()
+                }
               >
                 {createKeyMutation.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
-                  <>
-                    <KeyRound className="h-4 w-4" />
-                    Create key
-                  </>
+                  <KeyRound className="h-4 w-4" />
                 )}
+                Create key
               </Button>
-            </div>
+            </DialogFooter>
           </form>
-
-          <div className="divide-y divide-neutral-800">
-            {activeKeys.map(function renderAccessKey(accessKey) {
-              return (
-                <div
-                  key={accessKey.id}
-                  className="flex items-center justify-between gap-3 py-2"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm text-neutral-200">
-                      {accessKey.name}
-                    </p>
-                    <p className="truncate font-mono text-xs text-neutral-500">
-                      {accessKey.accessKeyId} · {accessKey.permissions}
-                    </p>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    onClick={function onRevokeKey() {
-                      setKeyToRevoke(accessKey.id);
-                    }}
-                    title="Revoke key"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              );
-            })}
-            {activeKeys.length === 0 && (
-              <p className="py-4 text-sm text-neutral-500">
-                No access keys yet.
-              </p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
 
       <ConfirmDialog
         open={bucketToDelete !== null}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/object-storages/[objectStorageId]/page.tsx
@@ -1,122 +1,29 @@
 "use client";
 
-import {
-  Copy,
-  FileIcon,
-  KeyRound,
-  Loader2,
-  Plus,
-  RefreshCw,
-  Search,
-  Trash2,
-} from "lucide-react";
 import { useParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type { ContractOutputs } from "@/contracts";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   useCreateObjectStorageAccessKey,
   useCreateObjectStorageBucket,
   useDeleteObjectStorageBucket,
   useObjectStorage,
-  useObjectStorageBucketObjects,
   useRevokeObjectStorageAccessKey,
 } from "@/hooks/use-object-storages";
-
-type AccessKeyResult = ContractOutputs["objectStorages"]["createAccessKey"];
-
-function CopyButton({ value }: { value: string }) {
-  async function handleCopy() {
-    await navigator.clipboard.writeText(value);
-    toast.success("Copied");
-  }
-
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      className="h-7 w-7"
-      onClick={handleCopy}
-      title="Copy"
-    >
-      <Copy className="h-3.5 w-3.5" />
-    </Button>
-  );
-}
-
-function SettingRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex items-center justify-between gap-3 border-b border-neutral-800 py-2 last:border-0">
-      <span className="text-xs text-neutral-500">{label}</span>
-      <div className="flex min-w-0 items-center gap-2">
-        <code className="truncate text-xs text-neutral-200">{value}</code>
-        <CopyButton value={value} />
-      </div>
-    </div>
-  );
-}
-
-function buildEnvBlock(snippets: AccessKeyResult["snippets"]): string {
-  return snippets.env
-    .map(function formatEnv(envVar) {
-      return `${envVar.key}=${envVar.value}`;
-    })
-    .join("\n");
-}
-
-function formatObjectSize(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes} B`;
-  }
-
-  const units = ["KB", "MB", "GB", "TB"];
-  let size = bytes / 1024;
-  let unitIndex = 0;
-
-  while (size >= 1024 && unitIndex < units.length - 1) {
-    size /= 1024;
-    unitIndex += 1;
-  }
-
-  const unit = units[unitIndex] ?? "TB";
-  return `${size >= 10 ? size.toFixed(0) : size.toFixed(1)} ${unit}`;
-}
-
-function formatObjectDate(timestamp: number | null): string {
-  if (timestamp === null) {
-    return "Unknown";
-  }
-
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(timestamp);
-}
-
-function normalizePrefixInput(prefix: string): string {
-  return prefix.trim().replace(/^\/+/, "");
-}
+import { BucketsCard } from "./_components/buckets-card";
+import { ObjectStorageConnectionCard } from "./_components/connection-card";
+import { CreatedKeyCard } from "./_components/created-key-card";
+import {
+  CreateAccessKeyDialog,
+  CreateBucketDialog,
+} from "./_components/object-storage-dialogs";
+import { SelectedBucketPanel } from "./_components/selected-bucket-panel";
+import type {
+  AccessKeyPermission,
+  CreatedAccessKey,
+} from "./_components/types";
 
 export default function ObjectStorageOverviewPage() {
   const params = useParams();
@@ -126,82 +33,77 @@ export default function ObjectStorageOverviewPage() {
   const deleteBucketMutation = useDeleteObjectStorageBucket(objectStorageId);
   const createKeyMutation = useCreateObjectStorageAccessKey(objectStorageId);
   const revokeKeyMutation = useRevokeObjectStorageAccessKey(objectStorageId);
-  const [bucketName, setBucketName] = useState("");
-  const [keyName, setKeyName] = useState("app");
   const [selectedBucketId, setSelectedBucketId] = useState("");
-  const [bucketTab, setBucketTab] = useState<"files" | "access-keys">("files");
-  const [objectPrefixInput, setObjectPrefixInput] = useState("");
-  const [objectPrefix, setObjectPrefix] = useState("");
   const [createBucketOpen, setCreateBucketOpen] = useState(false);
   const [createKeyOpen, setCreateKeyOpen] = useState(false);
-  const [permissions, setPermissions] = useState<
-    "read-only" | "read-write" | "full"
-  >("read-write");
-  const [createdKey, setCreatedKey] = useState<AccessKeyResult | null>(null);
+  const [createdKey, setCreatedKey] = useState<CreatedAccessKey | null>(null);
   const [bucketToDelete, setBucketToDelete] = useState<string | null>(null);
   const [keyToRevoke, setKeyToRevoke] = useState<string | null>(null);
 
-  const activeBuckets = data?.buckets ?? [];
-  const activeKeys = (data?.accessKeys ?? []).filter(function activeKey(key) {
-    return key.revokedAt === null;
-  });
+  const activeBuckets = useMemo(
+    function getActiveBuckets() {
+      return data?.buckets ?? [];
+    },
+    [data?.buckets],
+  );
+  const selectedBucket = useMemo(
+    function getSelectedBucket() {
+      return (
+        activeBuckets.find(function findBucket(bucket) {
+          return bucket.id === selectedBucketId;
+        }) ?? null
+      );
+    },
+    [activeBuckets, selectedBucketId],
+  );
+  const selectedBucketAccessKeys = useMemo(
+    function getSelectedBucketAccessKeys() {
+      const accessKeys = data?.accessKeys ?? [];
+      if (!selectedBucket) {
+        return [];
+      }
 
-  const externalEndpoint = data?.connection.endpoint ?? null;
-
-  const defaultBucketId = useMemo(
-    function getDefaultBucketId() {
-      const selectedBucket = activeBuckets.find(function findBucket(bucket) {
-        return bucket.id === selectedBucketId;
+      return accessKeys.filter(function isActiveSelectedBucketKey(accessKey) {
+        return (
+          accessKey.revokedAt === null &&
+          accessKey.bucketId === selectedBucket.id
+        );
       });
-      return selectedBucket?.id ?? activeBuckets[0]?.id ?? "";
+    },
+    [data?.accessKeys, selectedBucket],
+  );
+
+  useEffect(
+    function syncSelectedBucket() {
+      const selectedStillExists = activeBuckets.some(
+        function hasSelectedBucket(bucket) {
+          return bucket.id === selectedBucketId;
+        },
+      );
+
+      if (selectedStillExists) {
+        return;
+      }
+
+      const nextSelectedBucketId = activeBuckets[0]?.id ?? "";
+      if (selectedBucketId !== nextSelectedBucketId) {
+        setSelectedBucketId(nextSelectedBucketId);
+      }
     },
     [activeBuckets, selectedBucketId],
   );
 
-  const selectedBucket = useMemo(
-    function getSelectedBucket() {
-      return activeBuckets.find(function findBucket(bucket) {
-        return bucket.id === defaultBucketId;
-      });
-    },
-    [activeBuckets, defaultBucketId],
-  );
-
-  const bucketObjectsQuery = useObjectStorageBucketObjects({
-    objectStorageId,
-    bucketId: defaultBucketId,
-    prefix: objectPrefix,
-  });
-  const bucketObjects =
-    bucketObjectsQuery.data?.pages.flatMap(function getPageObjects(page) {
-      return page.objects;
-    }) ?? [];
-  const selectedBucketAccessKeys = activeKeys.filter(
-    function getSelectedBucketAccessKeys(accessKey) {
-      return accessKey.bucketId === defaultBucketId;
-    },
-  );
-
-  async function handleCreateBucket(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!bucketName.trim()) {
-      return;
-    }
-
+  async function handleCreateBucket(name: string): Promise<boolean> {
     try {
-      const bucket = await createBucketMutation.mutateAsync({
-        name: bucketName.trim(),
-      });
-      setBucketName("");
+      const bucket = await createBucketMutation.mutateAsync({ name });
       setSelectedBucketId(bucket.id);
-      setObjectPrefix("");
-      setObjectPrefixInput("");
-      setCreateBucketOpen(false);
       toast.success("Bucket created");
+      return true;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to create bucket",
       );
+      return false;
     }
   }
 
@@ -224,43 +126,28 @@ export default function ObjectStorageOverviewPage() {
     }
   }
 
-  function handleSelectBucket(bucketId: string) {
-    setSelectedBucketId(bucketId);
-    setObjectPrefix("");
-    setObjectPrefixInput("");
-  }
-
-  function handleObjectPrefixSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setObjectPrefix(normalizePrefixInput(objectPrefixInput));
-  }
-
-  function handleBucketTabChange(value: string) {
-    if (value === "files" || value === "access-keys") {
-      setBucketTab(value);
-    }
-  }
-
-  async function handleCreateKey(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!defaultBucketId || !keyName.trim()) {
-      return;
+  async function handleCreateKey(input: {
+    name: string;
+    permissions: AccessKeyPermission;
+  }): Promise<boolean> {
+    if (!selectedBucket) {
+      return false;
     }
 
     try {
       const result = await createKeyMutation.mutateAsync({
-        bucketId: defaultBucketId,
-        name: keyName.trim(),
-        permissions,
+        bucketId: selectedBucket.id,
+        name: input.name,
+        permissions: input.permissions,
       });
       setCreatedKey(result);
-      setKeyName("app");
-      setCreateKeyOpen(false);
       toast.success("Access key created");
+      return true;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to create access key",
       );
+      return false;
     }
   }
 
@@ -292,467 +179,50 @@ export default function ObjectStorageOverviewPage() {
 
   return (
     <div className="space-y-4">
-      <Card className="border-neutral-800 bg-neutral-900">
-        <CardHeader>
-          <CardTitle className="text-sm text-neutral-200">
-            S3 Connection
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-1">
-          <SettingRow
-            label="External endpoint"
-            value={externalEndpoint ?? "Deploying"}
-          />
-          <SettingRow
-            label="Internal endpoint"
-            value={data.connection.internalEndpoint}
-          />
-          <SettingRow label="Region" value={data.connection.region} />
-          <SettingRow label="Force path style" value="true" />
-        </CardContent>
-      </Card>
+      <ObjectStorageConnectionCard connection={data.connection} />
 
-      {createdKey && (
-        <Card className="border-emerald-800/70 bg-emerald-950/20">
-          <CardHeader>
-            <CardTitle className="text-sm text-emerald-100">
-              Secret shown once
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <SettingRow
-              label="Access key"
-              value={createdKey.accessKey.accessKeyId}
-            />
-            <SettingRow label="Secret key" value={createdKey.secretAccessKey} />
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <p className="text-xs text-neutral-400">Environment</p>
-                <CopyButton value={buildEnvBlock(createdKey.snippets)} />
-              </div>
-              <pre className="overflow-auto rounded-md border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-300">
-                {buildEnvBlock(createdKey.snippets)}
-              </pre>
-            </div>
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <p className="text-xs text-neutral-400">AWS CLI</p>
-                <CopyButton value={createdKey.snippets.awsCli} />
-              </div>
-              <pre className="overflow-auto rounded-md border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-300">
-                {createdKey.snippets.awsCli}
-              </pre>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      {createdKey && <CreatedKeyCard createdKey={createdKey} />}
 
-      <Card className="border-neutral-800 bg-neutral-900">
-        <CardHeader>
-          <div className="flex items-center justify-between gap-3">
-            <CardTitle className="text-sm text-neutral-200">Buckets</CardTitle>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={function onOpenCreateBucket() {
-                setCreateBucketOpen(true);
-              }}
-            >
-              <Plus className="h-4 w-4" />
-              New bucket
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="divide-y divide-neutral-800">
-            {activeBuckets.map(function renderBucket(bucket) {
-              return (
-                <div
-                  key={bucket.id}
-                  className="flex items-center justify-between gap-3 py-2"
-                >
-                  <Button
-                    type="button"
-                    variant={
-                      bucket.id === defaultBucketId ? "secondary" : "ghost"
-                    }
-                    className="min-w-0 flex-1 justify-start px-2"
-                    onClick={function onSelectBucket() {
-                      handleSelectBucket(bucket.id);
-                    }}
-                    title="View files"
-                  >
-                    <FileIcon className="h-4 w-4 text-neutral-500" />
-                    <code className="truncate text-sm">{bucket.name}</code>
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    onClick={function onDeleteBucket() {
-                      setBucketToDelete(bucket.id);
-                    }}
-                    title="Delete bucket"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              );
-            })}
-            {activeBuckets.length === 0 && (
-              <p className="py-4 text-sm text-neutral-500">No buckets yet.</p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+      <BucketsCard
+        buckets={activeBuckets}
+        selectedBucketId={selectedBucket?.id ?? ""}
+        onSelectBucket={setSelectedBucketId}
+        onDeleteBucket={setBucketToDelete}
+        onOpenCreateBucket={function handleOpenCreateBucket() {
+          setCreateBucketOpen(true);
+        }}
+      />
 
-      <Card className="border-neutral-800 bg-neutral-900">
-        <CardHeader>
-          <div className="flex min-w-0 items-center justify-between gap-3">
-            <div className="min-w-0">
-              <CardTitle className="text-sm text-neutral-200">Bucket</CardTitle>
-              {selectedBucket ? (
-                <code className="block truncate text-xs text-neutral-500">
-                  {selectedBucket.name}
-                </code>
-              ) : (
-                <p className="text-xs text-neutral-500">No bucket selected</p>
-              )}
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {!selectedBucket ? (
-            <p className="py-4 text-sm text-neutral-500">
-              Select a bucket to view files and keys.
-            </p>
-          ) : (
-            <Tabs
-              value={bucketTab}
-              onValueChange={handleBucketTabChange}
-              className="space-y-4"
-            >
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <TabsList className="border border-neutral-800 bg-neutral-950">
-                  <TabsTrigger value="files">Files</TabsTrigger>
-                  <TabsTrigger value="access-keys">Access keys</TabsTrigger>
-                </TabsList>
-                {bucketTab === "access-keys" && (
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    size="sm"
-                    onClick={function onOpenCreateKey() {
-                      setCreateKeyOpen(true);
-                    }}
-                  >
-                    <KeyRound className="h-4 w-4" />
-                    New key
-                  </Button>
-                )}
-              </div>
+      <SelectedBucketPanel
+        key={selectedBucket?.id ?? "no-bucket"}
+        objectStorageId={objectStorageId}
+        bucket={selectedBucket}
+        accessKeys={selectedBucketAccessKeys}
+        onOpenCreateKey={function handleOpenCreateKey() {
+          setCreateKeyOpen(true);
+        }}
+        onRevokeKey={setKeyToRevoke}
+      />
 
-              <TabsContent value="files" className="space-y-3">
-                <form
-                  onSubmit={handleObjectPrefixSubmit}
-                  className="grid gap-2 md:grid-cols-[minmax(0,1fr)_6rem_2.25rem]"
-                >
-                  <Label
-                    htmlFor="object_storage_object_prefix"
-                    className="sr-only"
-                  >
-                    Prefix
-                  </Label>
-                  <Input
-                    id="object_storage_object_prefix"
-                    value={objectPrefixInput}
-                    onChange={function onObjectPrefixChange(event) {
-                      setObjectPrefixInput(event.target.value);
-                    }}
-                    placeholder="uploads/"
-                    className="border-neutral-700 bg-neutral-800 font-mono text-sm text-neutral-100"
-                  />
-                  <Button type="submit" variant="secondary" className="w-full">
-                    <Search className="h-4 w-4" />
-                    Filter
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    disabled={bucketObjectsQuery.isFetching}
-                    onClick={function onRefreshObjects() {
-                      void bucketObjectsQuery.refetch();
-                    }}
-                    title="Refresh files"
-                  >
-                    {bucketObjectsQuery.isFetching ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <RefreshCw className="h-4 w-4" />
-                    )}
-                  </Button>
-                </form>
+      <CreateBucketDialog
+        open={createBucketOpen}
+        pending={createBucketMutation.isPending}
+        onOpenChange={setCreateBucketOpen}
+        onCreateBucket={handleCreateBucket}
+      />
 
-                {bucketObjectsQuery.isError && (
-                  <p className="rounded-md border border-red-900/60 bg-red-950/20 p-3 text-sm text-red-200">
-                    {bucketObjectsQuery.error instanceof Error
-                      ? bucketObjectsQuery.error.message
-                      : "Failed to load files"}
-                  </p>
-                )}
-
-                {bucketObjectsQuery.isLoading && !bucketObjectsQuery.data && (
-                  <div className="flex items-center gap-2 py-4 text-sm text-neutral-500">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Loading files
-                  </div>
-                )}
-
-                {!bucketObjectsQuery.isLoading &&
-                  bucketObjects.length === 0 &&
-                  !bucketObjectsQuery.isError && (
-                    <p className="py-4 text-sm text-neutral-500">
-                      No files found.
-                    </p>
-                  )}
-
-                {bucketObjects.length > 0 && (
-                  <div className="overflow-hidden rounded-md border border-neutral-800">
-                    <div className="grid grid-cols-[minmax(0,1fr)_5rem_2rem] gap-3 border-b border-neutral-800 bg-neutral-950/60 px-3 py-2 text-xs text-neutral-500 md:grid-cols-[minmax(0,1fr)_7rem_10rem_2rem]">
-                      <span>Key</span>
-                      <span className="text-right">Size</span>
-                      <span className="hidden md:block">Modified</span>
-                      <span className="sr-only">Copy</span>
-                    </div>
-                    <div className="divide-y divide-neutral-800">
-                      {bucketObjects.map(function renderObject(object) {
-                        return (
-                          <div
-                            key={object.key}
-                            className="grid grid-cols-[minmax(0,1fr)_5rem_2rem] items-center gap-3 px-3 py-2 md:grid-cols-[minmax(0,1fr)_7rem_10rem_2rem]"
-                          >
-                            <div className="flex min-w-0 items-center gap-2">
-                              <FileIcon className="h-4 w-4 shrink-0 text-neutral-500" />
-                              <code className="truncate text-xs text-neutral-200">
-                                {object.key}
-                              </code>
-                            </div>
-                            <span className="text-right text-xs text-neutral-400">
-                              {formatObjectSize(object.size)}
-                            </span>
-                            <span className="hidden truncate text-xs text-neutral-500 md:block">
-                              {formatObjectDate(object.lastModified)}
-                            </span>
-                            <CopyButton value={object.key} />
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-
-                {bucketObjectsQuery.hasNextPage && (
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    className="w-full"
-                    disabled={bucketObjectsQuery.isFetchingNextPage}
-                    onClick={function onLoadMoreObjects() {
-                      void bucketObjectsQuery.fetchNextPage();
-                    }}
-                  >
-                    {bucketObjectsQuery.isFetchingNextPage ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Plus className="h-4 w-4" />
-                    )}
-                    Load more
-                  </Button>
-                )}
-              </TabsContent>
-
-              <TabsContent value="access-keys" className="space-y-3">
-                <div className="divide-y divide-neutral-800">
-                  {selectedBucketAccessKeys.map(
-                    function renderAccessKey(accessKey) {
-                      return (
-                        <div
-                          key={accessKey.id}
-                          className="flex items-center justify-between gap-3 py-2"
-                        >
-                          <div className="min-w-0">
-                            <p className="truncate text-sm text-neutral-200">
-                              {accessKey.name}
-                            </p>
-                            <p className="truncate font-mono text-xs text-neutral-500">
-                              {accessKey.accessKeyId} · {accessKey.permissions}
-                            </p>
-                          </div>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8"
-                            onClick={function onRevokeKey() {
-                              setKeyToRevoke(accessKey.id);
-                            }}
-                            title="Revoke key"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      );
-                    },
-                  )}
-                  {selectedBucketAccessKeys.length === 0 && (
-                    <p className="py-4 text-sm text-neutral-500">
-                      No access keys for this bucket.
-                    </p>
-                  )}
-                </div>
-              </TabsContent>
-            </Tabs>
-          )}
-        </CardContent>
-      </Card>
-
-      <Dialog open={createBucketOpen} onOpenChange={setCreateBucketOpen}>
-        <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="text-neutral-100">New bucket</DialogTitle>
-          </DialogHeader>
-          <form onSubmit={handleCreateBucket} className="space-y-4">
-            <div className="grid gap-1.5">
-              <Label
-                htmlFor="object_storage_bucket_name"
-                className="text-xs text-neutral-400"
-              >
-                Name
-              </Label>
-              <Input
-                id="object_storage_bucket_name"
-                value={bucketName}
-                onChange={function onBucketNameChange(event) {
-                  setBucketName(event.target.value);
-                }}
-                placeholder="avatars"
-                className="border-neutral-700 bg-neutral-800 font-mono text-sm text-neutral-100"
-              />
-            </div>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={function onCancelCreateBucket() {
-                  setCreateBucketOpen(false);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                disabled={createBucketMutation.isPending || !bucketName.trim()}
-              >
-                {createBucketMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Plus className="h-4 w-4" />
-                )}
-                Create bucket
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={createKeyOpen} onOpenChange={setCreateKeyOpen}>
-        <DialogContent className="border-neutral-800 bg-neutral-900 sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="text-neutral-100">
-              {selectedBucket
-                ? `New key for ${selectedBucket.name}`
-                : "New key"}
-            </DialogTitle>
-          </DialogHeader>
-          <form onSubmit={handleCreateKey} className="space-y-4">
-            <div className="grid gap-3">
-              <div className="grid gap-1.5">
-                <Label
-                  htmlFor="access_key_name"
-                  className="text-xs text-neutral-400"
-                >
-                  Name
-                </Label>
-                <Input
-                  id="access_key_name"
-                  value={keyName}
-                  onChange={function onKeyNameChange(event) {
-                    setKeyName(event.target.value);
-                  }}
-                  className="border-neutral-700 bg-neutral-800 text-neutral-100"
-                />
-              </div>
-              <div className="grid gap-1.5">
-                <Label className="text-xs text-neutral-400">Permission</Label>
-                <Select
-                  value={permissions}
-                  onValueChange={function onPermissionChange(value) {
-                    if (
-                      value === "read-only" ||
-                      value === "read-write" ||
-                      value === "full"
-                    ) {
-                      setPermissions(value);
-                    }
-                  }}
-                >
-                  <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent className="border-neutral-700 bg-neutral-800">
-                    <SelectItem value="read-only">Read only</SelectItem>
-                    <SelectItem value="read-write">Read/write</SelectItem>
-                    <SelectItem value="full">Full</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={function onCancelCreateKey() {
-                  setCreateKeyOpen(false);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                disabled={
-                  createKeyMutation.isPending ||
-                  !defaultBucketId ||
-                  !keyName.trim()
-                }
-              >
-                {createKeyMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <KeyRound className="h-4 w-4" />
-                )}
-                Create key
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <CreateAccessKeyDialog
+        open={createKeyOpen}
+        pending={createKeyMutation.isPending}
+        bucketName={selectedBucket?.name ?? null}
+        disabled={!selectedBucket}
+        onOpenChange={setCreateKeyOpen}
+        onCreateKey={handleCreateKey}
+      />
 
       <ConfirmDialog
         open={bucketToDelete !== null}
-        onOpenChange={function onBucketDialogOpenChange(open) {
+        onOpenChange={function handleBucketDialogOpenChange(open) {
           if (!open) {
             setBucketToDelete(null);
           }
@@ -767,7 +237,7 @@ export default function ObjectStorageOverviewPage() {
 
       <ConfirmDialog
         open={keyToRevoke !== null}
-        onOpenChange={function onKeyDialogOpenChange(open) {
+        onOpenChange={function handleKeyDialogOpenChange(open) {
           if (!open) {
             setKeyToRevoke(null);
           }

--- a/apps/app/src/contracts/object-storages.ts
+++ b/apps/app/src/contracts/object-storages.ts
@@ -50,6 +50,20 @@ const objectStorageDetailsSchema = z.object({
   connection: objectStorageConnectionSchema,
 });
 
+const objectStorageBucketObjectSchema = z.object({
+  key: z.string(),
+  size: z.number(),
+  lastModified: z.number().nullable(),
+  etag: z.string().nullable(),
+});
+
+const objectStorageBucketObjectListSchema = z.object({
+  bucketId: z.string(),
+  prefix: z.string(),
+  nextCursor: z.string().nullable(),
+  objects: z.array(objectStorageBucketObjectSchema),
+});
+
 export const objectStoragesContract = {
   create: oc
     .route({ method: "POST", path: "/projects/{projectId}/object-storages" })
@@ -103,6 +117,21 @@ export const objectStoragesContract = {
       }),
     )
     .output(z.object({ success: z.boolean() })),
+
+  listBucketObjects: oc
+    .route({
+      method: "GET",
+      path: "/object-storages/{objectStorageId}/buckets/{bucketId}/objects",
+    })
+    .input(
+      z.object({
+        objectStorageId: z.string(),
+        bucketId: z.string(),
+        prefix: z.string().optional(),
+        cursor: z.string().optional(),
+      }),
+    )
+    .output(objectStorageBucketObjectListSchema),
 
   createAccessKey: oc
     .route({

--- a/apps/app/src/hooks/use-object-storages.ts
+++ b/apps/app/src/hooks/use-object-storages.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import type { ContractInputs } from "@/contracts";
 import { orpc } from "@/lib/orpc-client";
 
@@ -15,6 +20,34 @@ export function useObjectStorage(objectStorageId: string) {
     ...orpc.objectStorages.get.queryOptions({ input: { objectStorageId } }),
     enabled: !!objectStorageId,
     refetchInterval: 3000,
+  });
+}
+
+export function useObjectStorageBucketObjects(input: {
+  objectStorageId: string;
+  bucketId: string;
+  prefix: string;
+}) {
+  return useInfiniteQuery({
+    queryKey: [
+      "object-storage-bucket-objects",
+      input.objectStorageId,
+      input.bucketId,
+      input.prefix,
+    ],
+    enabled: !!input.objectStorageId && !!input.bucketId,
+    initialPageParam: null as string | null,
+    queryFn: function queryFn({ pageParam }) {
+      return orpc.objectStorages.listBucketObjects.call({
+        objectStorageId: input.objectStorageId,
+        bucketId: input.bucketId,
+        prefix: input.prefix || undefined,
+        cursor: pageParam ?? undefined,
+      });
+    },
+    getNextPageParam: function getNextPageParam(lastPage) {
+      return lastPage.nextCursor ?? undefined;
+    },
   });
 }
 

--- a/apps/app/src/lib/object-storage.test.ts
+++ b/apps/app/src/lib/object-storage.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import type { ListObjectsV2CommandOutput } from "@aws-sdk/client-s3";
 import { nanoid } from "nanoid";
 import { db } from "./db";
 import { runMigrations } from "./migrate";
 import {
   buildObjectStorageConnectionSnippets,
   getGaragePermissions,
+  listObjectStorageS3Objects,
   normalizeBucketName,
   normalizeObjectStorageName,
+  normalizeObjectStorageObjectPrefix,
   waitForObjectStorageDeploymentContainer,
 } from "./object-storage";
 
@@ -223,5 +226,106 @@ describe("buildObjectStorageConnectionSnippets", () => {
       value: "http://s3-assets:3900",
     });
     expect(snippets.javascript).toContain('endpoint: "http://s3-assets:3900"');
+  });
+});
+
+describe("listObjectStorageS3Objects", () => {
+  test("normalizes prefixes for list requests", () => {
+    expect(normalizeObjectStorageObjectPrefix(" /uploads/avatars ")).toBe(
+      "uploads/avatars",
+    );
+    expect(normalizeObjectStorageObjectPrefix(null)).toBe("");
+  });
+
+  test("maps paginated S3 responses into bucket objects", async function testListObjects() {
+    const requests: unknown[] = [];
+    const pages: ListObjectsV2CommandOutput[] = [
+      {
+        $metadata: {},
+        IsTruncated: true,
+        NextContinuationToken: "next-page",
+        Contents: [
+          {
+            Key: "uploads/avatar.png",
+            Size: 2048,
+            LastModified: new Date("2026-01-02T03:04:05Z"),
+            ETag: '"etag-1"',
+          },
+        ],
+      },
+      {
+        $metadata: {},
+        IsTruncated: false,
+        Contents: [
+          {
+            Key: "uploads/profile.json",
+            Size: 64,
+          },
+        ],
+      },
+    ];
+    const client = {
+      send: async function send(command: { input: unknown }) {
+        requests.push(command.input);
+        const page = pages.shift();
+        if (!page) {
+          throw new Error("Unexpected S3 request");
+        }
+        return page;
+      },
+    };
+
+    const firstPage = await listObjectStorageS3Objects({
+      client,
+      bucket: "assets",
+      bucketId: "bucket-assets",
+      prefix: "/uploads/",
+      maxKeys: 2,
+    });
+    const secondPage = await listObjectStorageS3Objects({
+      client,
+      bucket: "assets",
+      bucketId: "bucket-assets",
+      prefix: "/uploads/",
+      cursor: firstPage.nextCursor,
+      maxKeys: 2,
+    });
+
+    expect(requests).toEqual([
+      {
+        Bucket: "assets",
+        Prefix: "uploads/",
+        ContinuationToken: undefined,
+        MaxKeys: 2,
+      },
+      {
+        Bucket: "assets",
+        Prefix: "uploads/",
+        ContinuationToken: "next-page",
+        MaxKeys: 2,
+      },
+    ]);
+    expect(firstPage).toEqual({
+      bucketId: "bucket-assets",
+      prefix: "uploads/",
+      nextCursor: "next-page",
+      objects: [
+        {
+          key: "uploads/avatar.png",
+          size: 2048,
+          lastModified: new Date("2026-01-02T03:04:05Z").getTime(),
+          etag: '"etag-1"',
+        },
+      ],
+    });
+    expect(secondPage.nextCursor).toBe(null);
+    expect(secondPage.objects).toEqual([
+      {
+        key: "uploads/profile.json",
+        size: 64,
+        lastModified: null,
+        etag: null,
+      },
+    ]);
   });
 });

--- a/apps/app/src/lib/object-storage.test.ts
+++ b/apps/app/src/lib/object-storage.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import type { ListObjectsV2CommandOutput } from "@aws-sdk/client-s3";
 import { nanoid } from "nanoid";
+import { encrypt } from "./crypto";
 import { db } from "./db";
 import { runMigrations } from "./migrate";
 import {
   buildObjectStorageConnectionSnippets,
   getGaragePermissions,
+  listObjectStorageBucketObjects,
   listObjectStorageS3Objects,
   normalizeBucketName,
   normalizeObjectStorageName,
   normalizeObjectStorageObjectPrefix,
+  resetObjectStorageRuntimeForTests,
+  setObjectStorageRuntimeForTests,
   waitForObjectStorageDeploymentContainer,
 } from "./object-storage";
 
@@ -19,6 +23,12 @@ interface DeploymentFixture {
   projectId: string;
   environmentId: string;
   serviceId: string;
+}
+
+interface ObjectStorageFixture extends DeploymentFixture {
+  deploymentId: string;
+  objectStorageId: string;
+  bucketId: string;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -91,6 +101,83 @@ async function cleanupDeploymentFixture(
     .where("id", "=", fixture.environmentId)
     .execute();
   await db.deleteFrom("projects").where("id", "=", fixture.projectId).execute();
+}
+
+async function createObjectStorageFixture(input?: {
+  region?: string;
+}): Promise<ObjectStorageFixture> {
+  const fixture = await createDeploymentFixture();
+  const suffix = nanoid(8);
+  const deploymentId = `dep-object-storage-${suffix}`;
+  const objectStorageId = `obj-object-storage-${suffix}`;
+  const bucketId = `objb-object-storage-${suffix}`;
+  const now = Date.now();
+
+  await db
+    .insertInto("deployments")
+    .values({
+      id: deploymentId,
+      serviceId: fixture.serviceId,
+      environmentId: fixture.environmentId,
+      commitSha: "HEAD",
+      status: "running",
+      containerId: "container-object-storage",
+      hostPort: 19001,
+      createdAt: now,
+    })
+    .execute();
+  await db
+    .updateTable("services")
+    .set({ currentDeploymentId: deploymentId })
+    .where("id", "=", fixture.serviceId)
+    .execute();
+  await db
+    .insertInto("objectStorages")
+    .values({
+      id: objectStorageId,
+      projectId: fixture.projectId,
+      environmentId: fixture.environmentId,
+      name: "files",
+      slug: "files",
+      runtimeServiceId: fixture.serviceId,
+      region: input?.region ?? "garage",
+      internalEndpoint: "http://s3-files:3900",
+      externalEndpoint: null,
+      adminTokenEncrypted: encrypt("admin"),
+      metricsTokenEncrypted: encrypt("metrics"),
+      createdAt: now,
+    })
+    .execute();
+  await db
+    .insertInto("objectStorageBuckets")
+    .values({
+      id: bucketId,
+      objectStorageId,
+      garageBucketId: "garage-bucket-files",
+      name: "files",
+      createdAt: now,
+    })
+    .execute();
+
+  return { ...fixture, deploymentId, objectStorageId, bucketId };
+}
+
+async function cleanupObjectStorageFixture(
+  fixture: ObjectStorageFixture,
+): Promise<void> {
+  await db
+    .deleteFrom("objectStorageAccessKeys")
+    .where("objectStorageId", "=", fixture.objectStorageId)
+    .execute();
+  await db
+    .deleteFrom("objectStorageBuckets")
+    .where("objectStorageId", "=", fixture.objectStorageId)
+    .execute();
+  await db
+    .deleteFrom("objectStorages")
+    .where("id", "=", fixture.objectStorageId)
+    .execute();
+  await cleanupDeploymentFixture(fixture);
 }
 
 async function insertDeployment(
@@ -327,5 +414,144 @@ describe("listObjectStorageS3Objects", () => {
         etag: null,
       },
     ]);
+  });
+});
+
+describe("listObjectStorageBucketObjects", () => {
+  test("lists objects through a scoped temporary read key", async function testTemporaryReadKey() {
+    const fixture = await createObjectStorageFixture({ region: "garage" });
+    const garageCalls: {
+      operation: string;
+      payload?: Record<string, unknown>;
+    }[] = [];
+    const clientInputs: unknown[] = [];
+    const listRequests: unknown[] = [];
+
+    setObjectStorageRuntimeForTests({
+      garageJsonApi: async function garageJsonApi(
+        _containerId,
+        operation,
+        payload,
+      ) {
+        garageCalls.push({ operation, payload });
+        if (operation === "CreateKey") {
+          return {
+            accessKeyId: "temporary-list-key",
+            secretAccessKey: "temporary-list-secret",
+          };
+        }
+        return null;
+      },
+      s3ClientFactory: function s3ClientFactory(input) {
+        clientInputs.push(input);
+        return {
+          send: async function send(command: { input: unknown }) {
+            listRequests.push(command.input);
+            return {
+              $metadata: {},
+              Contents: [{ Key: "uploads/avatar.png", Size: 42 }],
+            };
+          },
+        };
+      },
+    });
+
+    try {
+      const result = await listObjectStorageBucketObjects({
+        objectStorageId: fixture.objectStorageId,
+        bucketId: fixture.bucketId,
+        prefix: "/uploads/",
+      });
+
+      expect(result.objects).toEqual([
+        {
+          key: "uploads/avatar.png",
+          size: 42,
+          lastModified: null,
+          etag: null,
+        },
+      ]);
+      expect(clientInputs).toEqual([
+        {
+          endpoint: "http://127.0.0.1:19001",
+          region: "garage",
+          credentials: {
+            accessKeyId: "temporary-list-key",
+            secretAccessKey: "temporary-list-secret",
+          },
+        },
+      ]);
+      expect(listRequests).toEqual([
+        {
+          Bucket: "files",
+          Prefix: "uploads/",
+          ContinuationToken: undefined,
+          MaxKeys: 100,
+        },
+      ]);
+      expect(garageCalls).toEqual([
+        {
+          operation: "CreateKey",
+          payload: { name: "frost-list-files", neverExpires: true },
+        },
+        {
+          operation: "AllowBucketKey",
+          payload: {
+            bucketId: "garage-bucket-files",
+            accessKeyId: "temporary-list-key",
+            permissions: { read: true },
+          },
+        },
+        {
+          operation: "DeleteKey",
+          payload: { id: "temporary-list-key" },
+        },
+      ]);
+    } finally {
+      resetObjectStorageRuntimeForTests();
+      await cleanupObjectStorageFixture(fixture);
+    }
+  });
+
+  test("cleans temporary read keys when S3 listing fails", async function testTemporaryReadKeyCleanupOnError() {
+    const fixture = await createObjectStorageFixture();
+    const garageOperations: string[] = [];
+
+    setObjectStorageRuntimeForTests({
+      garageJsonApi: async function garageJsonApi(_containerId, operation) {
+        garageOperations.push(operation);
+        if (operation === "CreateKey") {
+          return {
+            accessKeyId: "temporary-list-key",
+            secretAccessKey: "temporary-list-secret",
+          };
+        }
+        return null;
+      },
+      s3ClientFactory: function s3ClientFactory() {
+        return {
+          send: async function send() {
+            throw new Error("S3 list failed");
+          },
+        };
+      },
+    });
+
+    try {
+      await expect(
+        listObjectStorageBucketObjects({
+          objectStorageId: fixture.objectStorageId,
+          bucketId: fixture.bucketId,
+        }),
+      ).rejects.toThrow("S3 list failed");
+      expect(garageOperations).toEqual([
+        "CreateKey",
+        "AllowBucketKey",
+        "DeleteKey",
+      ]);
+    } finally {
+      resetObjectStorageRuntimeForTests();
+      await cleanupObjectStorageFixture(fixture);
+    }
   });
 });

--- a/apps/app/src/lib/object-storage.ts
+++ b/apps/app/src/lib/object-storage.ts
@@ -8,6 +8,11 @@ import {
   resetObjectStorageDeployServiceForTests,
   setObjectStorageDeployServiceForTests,
 } from "./object-storage/runtime";
+import {
+  type ObjectStorageS3ClientFactory,
+  resetObjectStorageS3ClientFactoryForTests,
+  setObjectStorageS3ClientFactoryForTests,
+} from "./object-storage/s3";
 
 export {
   ObjectStorageError,
@@ -58,6 +63,7 @@ export type {
 export function setObjectStorageRuntimeForTests(fns: {
   deployService?: typeof deployService;
   garageJsonApi?: GarageJsonApiRunner;
+  s3ClientFactory?: ObjectStorageS3ClientFactory;
 }): void {
   if (fns.deployService) {
     setObjectStorageDeployServiceForTests(fns.deployService);
@@ -65,9 +71,13 @@ export function setObjectStorageRuntimeForTests(fns: {
   if (fns.garageJsonApi) {
     setGarageJsonApiRunnerForTests(fns.garageJsonApi);
   }
+  if (fns.s3ClientFactory) {
+    setObjectStorageS3ClientFactoryForTests(fns.s3ClientFactory);
+  }
 }
 
 export function resetObjectStorageRuntimeForTests(): void {
   resetObjectStorageDeployServiceForTests();
   resetGarageJsonApiRunnerForTests();
+  resetObjectStorageS3ClientFactoryForTests();
 }

--- a/apps/app/src/lib/object-storage.ts
+++ b/apps/app/src/lib/object-storage.ts
@@ -29,17 +29,25 @@ export {
   deleteObjectStorageBucket,
   getObjectStorageDetails,
   getObjectStorageLatestDeployment,
+  listObjectStorageBucketObjects,
   listObjectStoragesByProject,
   revokeObjectStorageAccessKey,
 } from "./object-storage/repository";
 export { waitForObjectStorageDeploymentContainer } from "./object-storage/runtime";
+export {
+  listObjectStorageS3Objects,
+  normalizeObjectStorageObjectPrefix,
+} from "./object-storage/s3";
 export { buildObjectStorageConnectionSnippets } from "./object-storage/snippets";
 export type {
   CreateAccessKeyInput,
   CreateAccessKeyResult,
   CreateBucketInput,
   CreateObjectStorageInput,
+  ListBucketObjectsInput,
   ObjectStorageAccessKeyPermission,
+  ObjectStorageBucketObject,
+  ObjectStorageBucketObjectList,
   ObjectStorageConnectionInfo,
   ObjectStorageConnectionSnippets,
   ObjectStorageDeployment,

--- a/apps/app/src/lib/object-storage/config.ts
+++ b/apps/app/src/lib/object-storage/config.ts
@@ -10,3 +10,7 @@ export function getObjectStorageClientRegion(region: string): string {
   }
   return region;
 }
+
+export function getObjectStorageSigningRegion(region: string): string {
+  return region;
+}

--- a/apps/app/src/lib/object-storage/object-browser.ts
+++ b/apps/app/src/lib/object-storage/object-browser.ts
@@ -1,0 +1,62 @@
+import {
+  allowGarageKey,
+  createGarageKey,
+  deleteGarageKey,
+} from "./garage-admin";
+import type { ObjectStorageS3Credentials } from "./s3";
+
+interface ObjectBrowserReadSessionInput {
+  containerId: string;
+  bucketName: string;
+  garageBucketId: string;
+}
+
+export interface ObjectBrowserReadSession {
+  credentials: ObjectStorageS3Credentials;
+  cleanup(): Promise<void>;
+}
+
+async function cleanupGarageKey(
+  containerId: string,
+  accessKeyId: string,
+): Promise<void> {
+  await deleteGarageKey(containerId, accessKeyId).catch(
+    function ignoreCleanupError() {},
+  );
+}
+
+export async function createObjectBrowserReadSession(
+  input: ObjectBrowserReadSessionInput,
+): Promise<ObjectBrowserReadSession> {
+  const garageKey = await createGarageKey(
+    input.containerId,
+    `frost-list-${input.bucketName}`,
+  );
+
+  if (!garageKey.secretAccessKey) {
+    await cleanupGarageKey(input.containerId, garageKey.accessKeyId);
+    throw new Error("Garage did not return the secret access key");
+  }
+
+  try {
+    await allowGarageKey({
+      containerId: input.containerId,
+      bucketId: input.garageBucketId,
+      accessKeyId: garageKey.accessKeyId,
+      permissions: "read-only",
+    });
+  } catch (error) {
+    await cleanupGarageKey(input.containerId, garageKey.accessKeyId);
+    throw error;
+  }
+
+  return {
+    credentials: {
+      accessKeyId: garageKey.accessKeyId,
+      secretAccessKey: garageKey.secretAccessKey,
+    },
+    cleanup: function cleanup() {
+      return cleanupGarageKey(input.containerId, garageKey.accessKeyId);
+    },
+  };
+}

--- a/apps/app/src/lib/object-storage/repository.ts
+++ b/apps/app/src/lib/object-storage/repository.ts
@@ -1,5 +1,5 @@
 import type { Selectable } from "kysely";
-import { encrypt } from "../crypto";
+import { decrypt, encrypt } from "../crypto";
 import { db } from "../db";
 import type { ObjectStorageBuckets, ObjectStorages } from "../db-types";
 import { syncCaddyConfig } from "../domains";
@@ -33,15 +33,24 @@ import {
   getLatestRuntimeDeployment,
   getObjectStorageConnectionInfo,
   getObjectStorageServerIp,
+  getRunningObjectStorageRuntime,
   getRuntimeContainerId,
+  getRuntimeLocalS3Endpoint,
   waitForObjectStorageDeploymentContainer,
 } from "./runtime";
+import {
+  createObjectStorageS3Client,
+  listObjectStorageS3Objects,
+  type ObjectStorageS3Credentials,
+} from "./s3";
 import { buildObjectStorageConnectionSnippets } from "./snippets";
 import type {
   CreateAccessKeyInput,
   CreateAccessKeyResult,
   CreateBucketInput,
   CreateObjectStorageInput,
+  ListBucketObjectsInput,
+  ObjectStorageBucketObjectList,
   ObjectStorageDeployment,
   ObjectStorageDetails,
   ObjectStorageWithRuntime,
@@ -91,6 +100,32 @@ async function getObjectStorageBucketWithGarageId(input: {
 function getAccessKeyPrefix(accessKeyId: string): string {
   const [prefix] = accessKeyId.split(".");
   return prefix && prefix.length > 0 ? prefix : accessKeyId.slice(0, 16);
+}
+
+async function getStoredReadableCredentials(input: {
+  objectStorageId: string;
+  bucketId: string;
+}): Promise<ObjectStorageS3Credentials | null> {
+  const accessKey = await db
+    .selectFrom("objectStorageAccessKeys")
+    .select(["accessKeyId", "secretAccessKeyEncrypted"])
+    .where("objectStorageId", "=", input.objectStorageId)
+    .where("bucketId", "=", input.bucketId)
+    .where("revokedAt", "is", null)
+    .orderBy("createdAt", "desc")
+    .executeTakeFirst();
+
+  if (!accessKey) {
+    return null;
+  }
+  if (!accessKey.secretAccessKeyEncrypted) {
+    return null;
+  }
+
+  return {
+    accessKeyId: accessKey.accessKeyId,
+    secretAccessKey: decrypt(accessKey.secretAccessKeyEncrypted),
+  };
 }
 
 async function rollbackObjectStorageProvisioning(input: {
@@ -395,6 +430,78 @@ export async function createObjectStorageAccessKey(
       secretAccessKey: garageKey.secretAccessKey,
     }),
   };
+}
+
+export async function listObjectStorageBucketObjects(
+  input: ListBucketObjectsInput,
+): Promise<ObjectStorageBucketObjectList> {
+  const objectStorage = await getObjectStorageRow(input.objectStorageId);
+  const bucket = await getObjectStorageBucketWithGarageId(input);
+  const runtime = await getRunningObjectStorageRuntime(objectStorage);
+
+  const storedCredentials = await getStoredReadableCredentials({
+    objectStorageId: input.objectStorageId,
+    bucketId: input.bucketId,
+  });
+  let credentials = storedCredentials;
+  let temporaryAccessKeyId: string | null = null;
+
+  if (!credentials) {
+    const garageKey = await createGarageKey(
+      runtime.containerId,
+      `frost-list-${bucket.name}`,
+    );
+    if (!garageKey.secretAccessKey) {
+      await deleteGarageKey(runtime.containerId, garageKey.accessKeyId).catch(
+        function ignoreCleanupError() {},
+      );
+      throw new Error("Garage did not return the secret access key");
+    }
+
+    try {
+      await allowGarageKey({
+        containerId: runtime.containerId,
+        bucketId: bucket.garageBucketId,
+        accessKeyId: garageKey.accessKeyId,
+        permissions: "read-only",
+      });
+    } catch (error) {
+      await deleteGarageKey(runtime.containerId, garageKey.accessKeyId).catch(
+        function ignoreCleanupError() {},
+      );
+      throw error;
+    }
+
+    temporaryAccessKeyId = garageKey.accessKeyId;
+    credentials = {
+      accessKeyId: garageKey.accessKeyId,
+      secretAccessKey: garageKey.secretAccessKey,
+    };
+  }
+
+  try {
+    const client = createObjectStorageS3Client({
+      endpoint: getRuntimeLocalS3Endpoint(runtime.hostPort),
+      region: objectStorage.region,
+      credentials,
+    });
+
+    return await listObjectStorageS3Objects({
+      client,
+      bucket: bucket.name,
+      bucketId: bucket.id,
+      prefix: input.prefix ?? "",
+      cursor: input.cursor,
+    });
+  } catch (error) {
+    throw objectStorageValidation(getErrorMessage(error));
+  } finally {
+    if (temporaryAccessKeyId) {
+      await deleteGarageKey(runtime.containerId, temporaryAccessKeyId).catch(
+        function ignoreCleanupError() {},
+      );
+    }
+  }
 }
 
 export async function revokeObjectStorageAccessKey(input: {

--- a/apps/app/src/lib/object-storage/repository.ts
+++ b/apps/app/src/lib/object-storage/repository.ts
@@ -1,5 +1,5 @@
 import type { Selectable } from "kysely";
-import { decrypt, encrypt } from "../crypto";
+import { encrypt } from "../crypto";
 import { db } from "../db";
 import type { ObjectStorageBuckets, ObjectStorages } from "../db-types";
 import { syncCaddyConfig } from "../domains";
@@ -8,7 +8,7 @@ import {
   newObjectStorageBucketId,
   newObjectStorageId,
 } from "../id";
-import { GARAGE_REGION } from "./config";
+import { GARAGE_REGION, getObjectStorageSigningRegion } from "./config";
 import {
   getErrorMessage,
   objectStorageConflict,
@@ -24,6 +24,7 @@ import {
   waitForGarageReady,
 } from "./garage-admin";
 import { normalizeBucketName, normalizeObjectStorageName } from "./naming";
+import { createObjectBrowserReadSession } from "./object-browser";
 import {
   attachObjectStorageRuntime,
   cleanupObjectStorageRuntimeService,
@@ -38,11 +39,7 @@ import {
   getRuntimeLocalS3Endpoint,
   waitForObjectStorageDeploymentContainer,
 } from "./runtime";
-import {
-  createObjectStorageS3Client,
-  listObjectStorageS3Objects,
-  type ObjectStorageS3Credentials,
-} from "./s3";
+import { createObjectStorageS3Client, listObjectStorageS3Objects } from "./s3";
 import { buildObjectStorageConnectionSnippets } from "./snippets";
 import type {
   CreateAccessKeyInput,
@@ -100,32 +97,6 @@ async function getObjectStorageBucketWithGarageId(input: {
 function getAccessKeyPrefix(accessKeyId: string): string {
   const [prefix] = accessKeyId.split(".");
   return prefix && prefix.length > 0 ? prefix : accessKeyId.slice(0, 16);
-}
-
-async function getStoredReadableCredentials(input: {
-  objectStorageId: string;
-  bucketId: string;
-}): Promise<ObjectStorageS3Credentials | null> {
-  const accessKey = await db
-    .selectFrom("objectStorageAccessKeys")
-    .select(["accessKeyId", "secretAccessKeyEncrypted"])
-    .where("objectStorageId", "=", input.objectStorageId)
-    .where("bucketId", "=", input.bucketId)
-    .where("revokedAt", "is", null)
-    .orderBy("createdAt", "desc")
-    .executeTakeFirst();
-
-  if (!accessKey) {
-    return null;
-  }
-  if (!accessKey.secretAccessKeyEncrypted) {
-    return null;
-  }
-
-  return {
-    accessKeyId: accessKey.accessKeyId,
-    secretAccessKey: decrypt(accessKey.secretAccessKeyEncrypted),
-  };
 }
 
 async function rollbackObjectStorageProvisioning(input: {
@@ -438,52 +409,17 @@ export async function listObjectStorageBucketObjects(
   const objectStorage = await getObjectStorageRow(input.objectStorageId);
   const bucket = await getObjectStorageBucketWithGarageId(input);
   const runtime = await getRunningObjectStorageRuntime(objectStorage);
-
-  const storedCredentials = await getStoredReadableCredentials({
-    objectStorageId: input.objectStorageId,
-    bucketId: input.bucketId,
+  const browserSession = await createObjectBrowserReadSession({
+    containerId: runtime.containerId,
+    bucketName: bucket.name,
+    garageBucketId: bucket.garageBucketId,
   });
-  let credentials = storedCredentials;
-  let temporaryAccessKeyId: string | null = null;
-
-  if (!credentials) {
-    const garageKey = await createGarageKey(
-      runtime.containerId,
-      `frost-list-${bucket.name}`,
-    );
-    if (!garageKey.secretAccessKey) {
-      await deleteGarageKey(runtime.containerId, garageKey.accessKeyId).catch(
-        function ignoreCleanupError() {},
-      );
-      throw new Error("Garage did not return the secret access key");
-    }
-
-    try {
-      await allowGarageKey({
-        containerId: runtime.containerId,
-        bucketId: bucket.garageBucketId,
-        accessKeyId: garageKey.accessKeyId,
-        permissions: "read-only",
-      });
-    } catch (error) {
-      await deleteGarageKey(runtime.containerId, garageKey.accessKeyId).catch(
-        function ignoreCleanupError() {},
-      );
-      throw error;
-    }
-
-    temporaryAccessKeyId = garageKey.accessKeyId;
-    credentials = {
-      accessKeyId: garageKey.accessKeyId,
-      secretAccessKey: garageKey.secretAccessKey,
-    };
-  }
 
   try {
     const client = createObjectStorageS3Client({
       endpoint: getRuntimeLocalS3Endpoint(runtime.hostPort),
-      region: objectStorage.region,
-      credentials,
+      region: getObjectStorageSigningRegion(objectStorage.region),
+      credentials: browserSession.credentials,
     });
 
     return await listObjectStorageS3Objects({
@@ -496,11 +432,7 @@ export async function listObjectStorageBucketObjects(
   } catch (error) {
     throw objectStorageValidation(getErrorMessage(error));
   } finally {
-    if (temporaryAccessKeyId) {
-      await deleteGarageKey(runtime.containerId, temporaryAccessKeyId).catch(
-        function ignoreCleanupError() {},
-      );
-    }
+    await browserSession.cleanup();
   }
 }
 

--- a/apps/app/src/lib/object-storage/runtime.ts
+++ b/apps/app/src/lib/object-storage/runtime.ts
@@ -46,6 +46,11 @@ export interface CreatedObjectStorageRuntime {
   externalEndpoint: string | null;
 }
 
+export interface RunningObjectStorageRuntime {
+  containerId: string;
+  hostPort: number;
+}
+
 let deployServiceFn: DeployServiceFn = deployService;
 
 function randomSecret(bytes = 32): string {
@@ -277,9 +282,9 @@ export async function createObjectStorageRuntimeService(
   return { service, internalEndpoint, externalEndpoint };
 }
 
-export async function getRuntimeContainerId(
+export async function getRunningObjectStorageRuntime(
   objectStorage: Selectable<ObjectStorages>,
-): Promise<string> {
+): Promise<RunningObjectStorageRuntime> {
   const service = await db
     .selectFrom("services")
     .select(["id", "currentDeploymentId"])
@@ -292,7 +297,7 @@ export async function getRuntimeContainerId(
 
   const deployment = await db
     .selectFrom("deployments")
-    .select(["containerId", "status"])
+    .select(["containerId", "hostPort", "status"])
     .where("id", "=", service.currentDeploymentId)
     .executeTakeFirst();
 
@@ -300,7 +305,22 @@ export async function getRuntimeContainerId(
     throw objectStorageNotReady("Object storage runtime is not running");
   }
 
-  return deployment.containerId;
+  if (!deployment.hostPort) {
+    throw objectStorageNotReady("Object storage runtime is missing its port");
+  }
+
+  return { containerId: deployment.containerId, hostPort: deployment.hostPort };
+}
+
+export async function getRuntimeContainerId(
+  objectStorage: Selectable<ObjectStorages>,
+): Promise<string> {
+  const runtime = await getRunningObjectStorageRuntime(objectStorage);
+  return runtime.containerId;
+}
+
+export function getRuntimeLocalS3Endpoint(hostPort: number): string {
+  return `http://127.0.0.1:${hostPort}`;
 }
 
 export async function getLatestRuntimeDeployment(

--- a/apps/app/src/lib/object-storage/s3.ts
+++ b/apps/app/src/lib/object-storage/s3.ts
@@ -1,0 +1,78 @@
+import {
+  ListObjectsV2Command,
+  type ListObjectsV2CommandOutput,
+  S3Client,
+  type S3ClientConfig,
+} from "@aws-sdk/client-s3";
+import type { ObjectStorageBucketObjectList } from "./types";
+
+export interface ObjectStorageS3Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+export interface ObjectStorageS3ListClient {
+  send(command: ListObjectsV2Command): Promise<ListObjectsV2CommandOutput>;
+}
+
+export function normalizeObjectStorageObjectPrefix(
+  prefix: string | null | undefined,
+): string {
+  return (prefix ?? "").trim().replace(/^\/+/, "");
+}
+
+export function createObjectStorageS3Client(input: {
+  endpoint: string;
+  region: string;
+  credentials: ObjectStorageS3Credentials;
+}): ObjectStorageS3ListClient {
+  const clientConfig: S3ClientConfig = {
+    endpoint: input.endpoint,
+    region: input.region,
+    credentials: input.credentials,
+    forcePathStyle: true,
+  };
+
+  return new S3Client(clientConfig);
+}
+
+export async function listObjectStorageS3Objects(input: {
+  client: ObjectStorageS3ListClient;
+  bucket: string;
+  bucketId: string;
+  prefix: string;
+  cursor?: string | null;
+  maxKeys?: number;
+}): Promise<ObjectStorageBucketObjectList> {
+  const maxKeys = Math.min(Math.max(input.maxKeys ?? 100, 1), 1000);
+  const prefix = normalizeObjectStorageObjectPrefix(input.prefix);
+  const output = await input.client.send(
+    new ListObjectsV2Command({
+      Bucket: input.bucket,
+      Prefix: prefix,
+      ContinuationToken: input.cursor ?? undefined,
+      MaxKeys: maxKeys,
+    }),
+  );
+
+  return {
+    bucketId: input.bucketId,
+    prefix,
+    nextCursor:
+      output.IsTruncated && output.NextContinuationToken
+        ? output.NextContinuationToken
+        : null,
+    objects: (output.Contents ?? [])
+      .filter(function hasObjectKey(item) {
+        return typeof item.Key === "string" && item.Key.length > 0;
+      })
+      .map(function toObject(item) {
+        return {
+          key: item.Key ?? "",
+          size: item.Size ?? 0,
+          lastModified: item.LastModified ? item.LastModified.getTime() : null,
+          etag: item.ETag ?? null,
+        };
+      }),
+  };
+}

--- a/apps/app/src/lib/object-storage/s3.ts
+++ b/apps/app/src/lib/object-storage/s3.ts
@@ -11,9 +11,22 @@ export interface ObjectStorageS3Credentials {
   secretAccessKey: string;
 }
 
+export interface ObjectStorageS3ClientInput {
+  endpoint: string;
+  region: string;
+  credentials: ObjectStorageS3Credentials;
+}
+
 export interface ObjectStorageS3ListClient {
   send(command: ListObjectsV2Command): Promise<ListObjectsV2CommandOutput>;
 }
+
+export type ObjectStorageS3ClientFactory = (
+  input: ObjectStorageS3ClientInput,
+) => ObjectStorageS3ListClient;
+
+let objectStorageS3ClientFactory: ObjectStorageS3ClientFactory =
+  createAwsObjectStorageS3Client;
 
 export function normalizeObjectStorageObjectPrefix(
   prefix: string | null | undefined,
@@ -21,11 +34,9 @@ export function normalizeObjectStorageObjectPrefix(
   return (prefix ?? "").trim().replace(/^\/+/, "");
 }
 
-export function createObjectStorageS3Client(input: {
-  endpoint: string;
-  region: string;
-  credentials: ObjectStorageS3Credentials;
-}): ObjectStorageS3ListClient {
+function createAwsObjectStorageS3Client(
+  input: ObjectStorageS3ClientInput,
+): ObjectStorageS3ListClient {
   const clientConfig: S3ClientConfig = {
     endpoint: input.endpoint,
     region: input.region,
@@ -34,6 +45,22 @@ export function createObjectStorageS3Client(input: {
   };
 
   return new S3Client(clientConfig);
+}
+
+export function createObjectStorageS3Client(
+  input: ObjectStorageS3ClientInput,
+): ObjectStorageS3ListClient {
+  return objectStorageS3ClientFactory(input);
+}
+
+export function setObjectStorageS3ClientFactoryForTests(
+  factory: ObjectStorageS3ClientFactory,
+): void {
+  objectStorageS3ClientFactory = factory;
+}
+
+export function resetObjectStorageS3ClientFactoryForTests(): void {
+  objectStorageS3ClientFactory = createAwsObjectStorageS3Client;
 }
 
 export async function listObjectStorageS3Objects(input: {

--- a/apps/app/src/lib/object-storage/types.ts
+++ b/apps/app/src/lib/object-storage/types.ts
@@ -65,4 +65,25 @@ export interface CreateAccessKeyResult {
   snippets: ObjectStorageConnectionSnippets;
 }
 
+export interface ObjectStorageBucketObject {
+  key: string;
+  size: number;
+  lastModified: number | null;
+  etag: string | null;
+}
+
+export interface ObjectStorageBucketObjectList {
+  bucketId: string;
+  prefix: string;
+  nextCursor: string | null;
+  objects: ObjectStorageBucketObject[];
+}
+
+export interface ListBucketObjectsInput {
+  objectStorageId: string;
+  bucketId: string;
+  prefix?: string | null;
+  cursor?: string | null;
+}
+
 export type ObjectStorageDeployment = Selectable<Deployments>;

--- a/apps/app/src/server/object-storages.ts
+++ b/apps/app/src/server/object-storages.ts
@@ -6,6 +6,7 @@ import {
   deleteObjectStorage,
   deleteObjectStorageBucket,
   getObjectStorageDetails,
+  listObjectStorageBucketObjects,
   listObjectStoragesByProject,
   ObjectStorageError,
   revokeObjectStorageAccessKey,
@@ -85,6 +86,14 @@ export const objectStorages = {
       return handleObjectStorageAction(async function deleteBucketAction() {
         await deleteObjectStorageBucket(input);
         return { success: true };
+      });
+    },
+  ),
+
+  listBucketObjects: os.objectStorages.listBucketObjects.handler(
+    function listBucketObjectsHandler({ input }) {
+      return handleObjectStorageAction(function listBucketObjectsAction() {
+        return listObjectStorageBucketObjects(input);
       });
     },
   ),


### PR DESCRIPTION
## Summary

- Add object-storage bucket object listing through the S3 API, including prefix filtering, pagination data, and reusable S3 client helpers.
- Rework the object storage overview hierarchy so buckets act as the selector and the selected bucket owns `Files` and `Access keys` tabs.
- Move bucket and access-key creation into scoped modals, with access-key creation tied to the selected bucket.
- Add focused tests for object-list prefix normalization and S3 response mapping.

## Validation

- `bun run typecheck`
- `bun run lint` (exits 0; existing unrelated Biome warnings remain in `apps/app/src/lib/mcp/mcp-tools.test.ts`)
- `bun --cwd apps/app test src/lib/object-storage.test.ts`
- Browser-use verification on `localhost:3000`:
  - seeded a temporary S3 object, verified it appears in the Files tab via prefix filtering, and removed it afterward
  - verified bucket switching clears the prefix and scopes files correctly
  - verified Access keys are shown under the selected bucket
  - verified New key and New bucket modals open, accept input, and cancel cleanly without creating persistent resources
  - verified no browser console errors during the pass
